### PR TITLE
Update workflows, locking mechanism, and project configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "10.0.x"

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -13,7 +13,7 @@ namespace CShells.AspNetCore.Routing;
 public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSource>? logger = null) : EndpointDataSource
 {
     private readonly List<Endpoint> _endpoints = [];
-    private readonly Lock _lock = new();
+    private readonly object _lock = new();
     private CancellationTokenSource _cts = new();
     private readonly ILogger<DynamicShellEndpointDataSource> _logger = logger ?? NullLogger<DynamicShellEndpointDataSource>.Instance;
 

--- a/src/CShells/Configuration/ShellSettingsCache.cs
+++ b/src/CShells/Configuration/ShellSettingsCache.cs
@@ -11,7 +11,7 @@ public class ShellSettingsCache : IShellSettingsCache
     private readonly ConcurrentDictionary<ShellId, ShellSettings> _cache = new();
     // Ordered list to preserve insertion order (ConcurrentDictionary.Values doesn't guarantee order)
     private List<ShellSettings> _orderedSettings = [];
-    private readonly Lock _lock = new();
+    private readonly object _lock = new();
 
     /// <inheritdoc />
     public IReadOnlyCollection<ShellSettings> GetAll()

--- a/src/CShells/Hosting/DefaultShellHost.cs
+++ b/src/CShells/Hosting/DefaultShellHost.cs
@@ -42,7 +42,7 @@ public class DefaultShellHost : IShellHost, IDisposable
     private readonly ConcurrentDictionary<ShellId, ShellContext> _shellContexts = new();
     private readonly FeatureDependencyResolver _dependencyResolver = new();
     private readonly ILogger<DefaultShellHost> _logger;
-    private readonly Lock _buildLock = new();
+    private readonly object _buildLock = new();
     private bool _disposed;
 
     // Cached copy of root service descriptors for efficient bulk-copy to shell service collections.

--- a/src/CShells/Management/DefaultShellManager.cs
+++ b/src/CShells/Management/DefaultShellManager.cs
@@ -17,7 +17,7 @@ public class DefaultShellManager : IShellManager
     private readonly IShellSettingsProvider _provider;
     private readonly INotificationPublisher _notificationPublisher;
     private readonly ILogger<DefaultShellManager> _logger;
-    private readonly Lock _lock = new();
+    private readonly object _lock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultShellManager"/> class.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
 
         <!-- Central base version for all packages; preview builds will append a suffix like -preview.{runNumber} -->
         <Version>0.0.5</Version>
@@ -25,4 +26,5 @@
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations"/>
     </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Renamed `.NET` setup step in GitHub Actions workflow for clarity.
- Replaced `Lock` with `object` across multiple files for thread synchronization.
- Updated `Directory.Build.props` to target multiple frameworks (`net8.0`, `net9.0`, `net10.0`) and specify `LangVersion` as `latest`.
