### PR TITLE
Refactor feature discovery to use fluent assembly providers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,7 @@ using CShells.AspNetCore.Extensions;
 var builder = WebApplication.CreateBuilder(args);
 
 // Register CShells from configuration
-builder.Services.AddCShells();
+builder.AddShells();
 
 var app = builder.Build();
 
@@ -106,12 +106,23 @@ app.Run();
 
 CShells will:
 
-1. Scan the assembly containing your features for all `[ShellFeature]`-decorated types
+1. Scan the host-derived default feature assembly set for all discovered shell features
 2. Load shell settings from the `CShells` configuration section
 3. Build isolated DI containers per shell, registering only the features each shell enables
 4. Map shell-scoped endpoints into ASP.NET Core's routing system
 
-> Note: the public factory method used in the library to register shells is AddCShells on IServiceCollection (e.g. builder.Services.AddCShells()).
+To switch to explicit feature assembly selection, configure it on the fluent builder:
+
+```csharp
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(BlogFeature).Assembly);
+    cshells.FromHostAssemblies();
+});
+```
+
+Any call to `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)` switches CShells into explicit provider mode. In that mode, only the assemblies returned by those appended providers are scanned, and duplicate assemblies are discovered once in first-seen order.
 
 ### Testing the Result
 

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -108,7 +108,11 @@ using CShells.AspNetCore.Extensions;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-builder.Services.AddCShells([typeof(MyFeature)]);
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(MyFeature).Assembly);
+});
 
 var app = builder.Build();
 

--- a/docs/multiple-shell-providers.md
+++ b/docs/multiple-shell-providers.md
@@ -7,9 +7,32 @@ CShells supports loading shells from multiple sources simultaneously. Providers 
 ### Configuration Provider Only (Default)
 
 ```csharp
-builder.Services.AddCShells([typeof(MyFeature)]);
+builder.Services.AddCShells();
 // Shells are loaded from appsettings.json automatically
 ```
+
+### Feature Assembly Selection
+
+Shell settings providers and feature assembly providers are configured independently.
+
+```csharp
+builder.Services.AddCShells(shells =>
+{
+    shells.WithConfigurationProvider(builder.Configuration);
+
+    // Explicit feature assemblies
+    shells.FromAssemblies(typeof(MyFeature).Assembly);
+
+    // Append the built-in host-derived default explicitly when needed
+    shells.FromHostAssemblies();
+
+    // Append custom assembly providers additively
+    shells.WithAssemblyProvider(sp =>
+        new MyFeatureAssemblyProvider(sp.GetRequiredService<IModuleCatalog>()));
+});
+```
+
+If you do not call any assembly-source method, CShells preserves the default host-derived discovery behavior. As soon as you call `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)`, discovery uses only the explicitly configured providers, concatenates their assembly contributions in registration order, and deduplicates assemblies before feature discovery.
 
 ### Code-First Shells
 

--- a/docs/multiple-shell-providers.md
+++ b/docs/multiple-shell-providers.md
@@ -7,8 +7,11 @@ CShells supports loading shells from multiple sources simultaneously. Providers 
 ### Configuration Provider Only (Default)
 
 ```csharp
-builder.Services.AddCShells();
-// Shells are loaded from appsettings.json automatically
+builder.Services.AddCShells(shells =>
+{
+    shells.WithConfigurationProvider(builder.Configuration);
+});
+// Shells are loaded from appsettings.json via the configuration provider
 ```
 
 ### Feature Assembly Selection

--- a/samples/CShells.Workbench/Program.cs
+++ b/samples/CShells.Workbench/Program.cs
@@ -1,12 +1,17 @@
 using CShells.AspNetCore.Extensions;
+using CShells.DependencyInjection;
 using CShells.Workbench.Background;
 using CShells.Workbench.Features.Core;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Load shells from appsettings.json — three tenants with escalating feature tiers.
-// Pass the CoreFeature marker type so CShells scans the features assembly.
-builder.AddShells([typeof(CoreFeature)]);
+// Configure feature discovery fluently so the features assembly is included explicitly.
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(CoreFeature).Assembly);
+});
 
 // Background service that logs a heartbeat for each active shell every 30 s.
 // Demonstrates IShellHost + IShellContextScopeFactory for background work.

--- a/specs/003-fluent-assembly-selection/checklists/requirements.md
+++ b/specs/003-fluent-assembly-selection/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Fluent Assembly Source Selection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/spec.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: All checklist items pass.
+- Explicitly captured breaking-change policy and legacy-removal intent in `FR-014` and assumptions.
+- Included naming-focused work item in `FR-016` per request.
+- Clarifications now require an assembly provider interface, a builder-maintained provider list, and additive provider appends for every fluent assembly-source call.

--- a/specs/003-fluent-assembly-selection/contracts/feature-assembly-provider-contract.md
+++ b/specs/003-fluent-assembly-selection/contracts/feature-assembly-provider-contract.md
@@ -1,0 +1,106 @@
+# Public Contract: Feature Assembly Provider Selection
+
+## Scope
+
+This contract defines the public API and behavioral rules for configuring CShells feature-discovery assemblies through the fluent builder model.
+
+The contract applies to:
+
+- `IServiceCollection.AddCShells(...)`
+- `IServiceCollection.AddCShellsAspNetCore(...)`
+- `WebApplicationBuilder.AddShells(...)`
+- `CShellsBuilder` fluent configuration for feature-discovery sources
+- third-party implementations of the public feature-assembly provider abstraction
+
+## Public Abstraction Contract
+
+The custom extension point is a public interface that lives in `CShells.Abstractions`.
+
+```csharp
+namespace CShells.Features;
+
+public interface IFeatureAssemblyProvider
+{
+    IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider);
+}
+```
+
+### Behavioral Rules
+
+- Implementations may return zero or more assemblies, but they must return a non-null sequence.
+- The `serviceProvider` argument is the root application service provider available to the shell registration pipeline.
+- Implementations must be usable alongside built-in providers in the same discovery flow.
+- Returning an assembly already contributed by another provider is allowed; CShells deduplicates before feature discovery.
+- Returning `null` is invalid and must fail fast with actionable guidance.
+- The contract is part of the supported public extension surface and is not an internal-only seam.
+
+## Fluent Builder Contract
+
+The `CShellsBuilder` public surface exposes fluent assembly-source APIs with additive semantics.
+
+```csharp
+public static class CShellsBuilderExtensions
+{
+    public static CShellsBuilder FromAssemblies(this CShellsBuilder builder, params Assembly[] assemblies);
+    public static CShellsBuilder FromHostAssemblies(this CShellsBuilder builder);
+    public static CShellsBuilder WithAssemblyProvider<TProvider>(this CShellsBuilder builder)
+        where TProvider : class, IFeatureAssemblyProvider;
+    public static CShellsBuilder WithAssemblyProvider(this CShellsBuilder builder, IFeatureAssemblyProvider provider);
+    public static CShellsBuilder WithAssemblyProvider(
+        this CShellsBuilder builder,
+        Func<IServiceProvider, IFeatureAssemblyProvider> factory);
+}
+```
+
+### Behavioral Rules
+
+- Every assembly-source method call appends another provider registration to the builder-managed provider list.
+- Later calls do not replace earlier calls.
+- `FromAssemblies(...)` appends a built-in provider that contributes exactly the configured assemblies for that call.
+- `FromHostAssemblies()` appends a built-in provider that contributes the same host-derived assembly set used by today’s default behavior.
+- `WithAssemblyProvider(...)` appends a custom provider that participates in the same additive flow as built-in providers.
+- `WithAssemblyProvider<TProvider>()` resolves `TProvider` from the root application service provider and fails fast with actionable guidance if that provider cannot be resolved.
+- Null builder arguments, null provider instances, and null provider factories must be rejected with actionable errors.
+- Empty explicit assembly lists are valid and still switch discovery into explicit-provider mode.
+- Custom providers receive the same root application service provider context described by `IFeatureAssemblyProvider.GetAssemblies(...)`.
+
+## Discovery-Mode Contract
+
+### Default Behavior
+
+If no assembly-source method is called, CShells must preserve current default behavior by scanning the host-derived assembly set.
+
+### Explicit Behavior
+
+Once any assembly-source method is called:
+
+- CShells must use only explicitly configured providers.
+- Host-derived assemblies are not included implicitly.
+- Host-derived assemblies are included only if `FromHostAssemblies()` was appended.
+
+## Aggregate Discovery Contract
+
+Before calling `FeatureDiscovery`, CShells must:
+
+1. evaluate the selected provider list in registration order,
+2. concatenate all returned assemblies,
+3. deduplicate the aggregate set, and
+4. scan the resulting distinct set exactly once.
+
+### Behavioral Rules
+
+- Built-in and custom providers compose additively.
+- Duplicate assembly contributions do not change discovery results.
+- Provider-registration order is preserved for aggregation and diagnostics even though final scanning uses a deduplicated union.
+- An explicit-mode configuration may legitimately produce an empty discovery set.
+- A custom provider that returns `null` is treated as invalid input and does not produce a partial discovery result.
+
+## Breaking-Change Contract
+
+The previous non-fluent assembly-argument approach is removed.
+
+### Required Outcomes
+
+- Public examples must use fluent assembly-source configuration only.
+- Legacy `AddCShells` / `AddShells` overloads that accept assemblies as direct method arguments are not retained as supported API.
+- Migration guidance must map legacy assembly-argument examples to the new fluent equivalents.

--- a/specs/003-fluent-assembly-selection/contracts/naming-decision-record.md
+++ b/specs/003-fluent-assembly-selection/contracts/naming-decision-record.md
@@ -1,0 +1,34 @@
+# Naming Decision Record: Fluent Assembly Source Selection
+
+## Approved Naming Set
+
+| Area | Approved Name | Why it was chosen |
+|---|---|---|
+| Public interface | `IFeatureAssemblyProvider` | Clearly states that the contract supplies assemblies specifically for feature discovery. |
+| Explicit assemblies fluent method | `FromAssemblies(...)` | Reads as an additive source-selection operation rather than a replacement-oriented setter. |
+| Host-derived fluent method | `FromHostAssemblies()` | Makes the built-in default-equivalent source explicit and discoverable. |
+| Custom provider fluent method | `WithAssemblyProvider(...)` | Matches existing CShells builder vocabulary for appending provider-like extensibility components. |
+| Built-in host provider type | `HostFeatureAssemblyProvider` | Connects the implementation to host-derived discovery without implying replacement semantics. |
+| Built-in explicit provider type | `ExplicitFeatureAssemblyProvider` | Mirrors the spec’s “explicit assemblies” concept directly. |
+| Internal builder registration field | `_featureAssemblyProviderRegistrations` | Describes stored contents precisely, reflects the registration-based design, and follows the constitution's private-field naming convention. |
+| Internal aggregation helper | `FeatureAssemblyResolver` | Describes a helper that materializes the effective assembly set from the configured providers. |
+
+## Rejected Alternatives
+
+| Rejected Name | Rejection Reason |
+|---|---|
+| `UseAssemblies(...)` | `Use*` commonly suggests replacement semantics, which conflicts with additive composition. |
+| `UseHostAssemblies()` | Same replacement-semantics concern as `UseAssemblies(...)`. |
+| `WithAssemblies(...)` | Too ambiguous between mutation of a single property and appending a new discovery source. |
+| `AddAssemblies(...)` | Reads like direct list mutation rather than provider-backed source configuration. |
+| `IAssemblySourceProvider` | Redundant and less natural than `IFeatureAssemblyProvider`. |
+| `IDiscoveryAssemblyProvider` | Accurate but less user-friendly and less aligned with the existing `CShells.Features` vocabulary. |
+| `DefaultAssemblyProvider` | Too vague; it hides the crucial host-derived behavior. |
+| `ConfiguredAssemblyProvider` | Too generic; it does not distinguish explicit developer-supplied assemblies from other configuration styles. |
+
+## Naming Usage Rules
+
+- Public docs and examples should use the approved fluent method names only.
+- Implementation, tests, and docs should not mix “source” and “provider” terminology inconsistently for the same concept.
+- The host-derived path should be described as “host assemblies” rather than “default assemblies” whenever the behavior must be explicit.
+- The old assembly-argument API names remain only in migration context, not as active recommendations.

--- a/specs/003-fluent-assembly-selection/data-model.md
+++ b/specs/003-fluent-assembly-selection/data-model.md
@@ -1,0 +1,121 @@
+# Data Model: Fluent Assembly Source Selection
+
+## Feature Assembly Provider Interface
+
+Represents one discovery-source contract capable of contributing assemblies for feature scanning.
+
+### Fields
+
+- `ProviderType`: the concrete provider implementation type used at runtime
+- `ResolutionBehavior`: logic that returns zero or more assemblies for feature discovery
+- `ResolutionContext`: the root application service provider passed into provider evaluation
+- `Origin`: whether the provider is built-in host-derived, built-in explicit, or developer-supplied custom
+
+### Validation Rules
+
+- Public implementations must satisfy the `IFeatureAssemblyProvider` contract defined in `CShells.Abstractions`.
+- Provider instances added through the fluent builder must not be `null`.
+- Provider outputs may be empty, but they must not be `null` and they must not re-enable implicit host-derived scanning.
+- Provider evaluation always receives the root application service provider used during shell registration.
+
+## Builder Assembly Provider Registration
+
+Represents one appended provider entry in the `CShellsBuilder`-managed list.
+
+### Fields
+
+- `RegistrationOrder`: the call-order index of the fluent assembly-source invocation
+- `ProviderFactoryOrInstance`: the provider registration payload appended by the builder API
+- `SourceKind`: `Host`, `ExplicitAssemblies`, or `CustomProvider`
+- `ActivatesExplicitMode`: whether the registration counts toward explicit-source mode
+
+### Validation Rules
+
+- Every assembly-source fluent call appends at least one registration entry.
+- Existing registration entries are never replaced by later calls.
+- Empty explicit assembly inputs still append a registration and therefore activate explicit-source mode.
+- Call order is preserved for later aggregation and diagnostics.
+
+## Assembly Discovery Mode
+
+Represents how CShells decides which provider set drives feature discovery for the application.
+
+### States
+
+- `ImplicitHostDefault`: used only when no assembly-source fluent calls were made
+- `ExplicitProviders`: used once any assembly-source fluent call appends a provider registration
+
+### State Transitions
+
+- `ImplicitHostDefault` → `ExplicitProviders`: triggered by `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)`
+- `ImplicitHostDefault` → `ImplicitHostDefault`: maintained when no assembly-source API is called
+- `ExplicitProviders` has no transition back during the same builder configuration session
+
+### Validation Rules
+
+- `ImplicitHostDefault` must use the same host-derived assembly set as `FromHostAssemblies()`.
+- `ExplicitProviders` must scan only assemblies returned by appended providers.
+- Explicit mode must not implicitly add the host-derived provider unless `FromHostAssemblies()` was appended.
+
+## Assembly Discovery Set
+
+Represents the aggregate assembly set passed into `FeatureDiscovery`.
+
+### Fields
+
+- `ProviderContributions`: ordered provider outputs collected from the selected provider list
+- `DeduplicatedAssemblies`: the distinct runtime assemblies that will be scanned
+- `AssemblyIdentity`: the runtime identity used to suppress duplicate scanning
+
+### Validation Rules
+
+- All configured provider contributions are concatenated before deduplication.
+- Duplicate assemblies contributed by multiple providers appear only once in `DeduplicatedAssemblies`.
+- First-seen provider order is preserved when duplicates are removed.
+- The aggregate set may be empty in explicit mode if all appended providers contribute zero assemblies.
+
+## Built-in Host Feature Assembly Provider
+
+Represents the built-in provider that supplies the host-derived scan set.
+
+### Fields
+
+- `ResolutionStrategy`: the extracted helper that mirrors current default host assembly resolution
+- `ConfiguredBy`: implicit default mode or explicit `FromHostAssemblies()` call
+
+### Validation Rules
+
+- The returned assembly set must match today’s default host-derived discovery behavior exactly.
+- Combining this provider with other providers is additive.
+- Repeated registration of the host provider is allowed, but final discovery remains deduplicated.
+
+## Built-in Explicit Feature Assembly Provider
+
+Represents the built-in provider that returns a fixed developer-supplied assembly set.
+
+### Fields
+
+- `ConfiguredAssemblies`: the assemblies supplied to `FromAssemblies(...)`
+- `ConfiguredOrder`: the order those assemblies were supplied in the fluent call
+
+### Validation Rules
+
+- A `null` explicit assembly input must be rejected with a clear developer-facing error.
+- An empty explicit assembly input is valid and contributes zero assemblies.
+- Assemblies contributed across multiple explicit-provider registrations are all included additively before deduplication.
+
+## Naming Decision Record
+
+Represents the approved terminology for the new public API surface.
+
+### Fields
+
+- `ProviderInterfaceName`: approved interface name for the public extension point
+- `BuilderMethodNames`: approved fluent names for built-in and custom provider registration
+- `BuiltInProviderNames`: approved implementation names for the built-in host and explicit providers
+- `RejectedAlternatives`: deprecated or rejected naming candidates with rationale
+
+### Validation Rules
+
+- One approved naming set must be used consistently across contracts, implementation, tests, and docs.
+- Rejected names must not remain in public examples or documentation after the feature ships.

--- a/specs/003-fluent-assembly-selection/plan.md
+++ b/specs/003-fluent-assembly-selection/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Fluent Assembly Source Selection
+
+**Branch**: `003-fluent-assembly-selection` | **Date**: 2026-04-12 | **Spec**: `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/spec.md`
+**Input**: Feature specification from `/specs/003-fluent-assembly-selection/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Refactor CShells feature discovery so assembly selection moves from trailing `AddCShells`/`AddShells` method arguments into fluent `CShellsBuilder` configuration backed by a builder-managed assembly-provider list. The implementation will introduce a public feature-assembly provider abstraction in `CShells.Abstractions`, add built-in host-derived and explicit-assembly providers in `CShells`, preserve current host-derived discovery only when no assembly-source calls are made, support additive composition across built-in and custom providers, remove the legacy non-fluent assembly-argument path, and capture the approved naming set for the new public API surface.
+
+## Technical Context
+
+**Language/Version**: C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`)  
+**Primary Dependencies**: `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.DependencyModel`, `Microsoft.AspNetCore.Builder`, existing `CShells.Features` discovery code, `CShells.DependencyInjection` builder extensions, and ASP.NET Core registration helpers  
+**Storage**: N/A  
+**Testing**: xUnit with `Assert.*`, unit tests in `tests/CShells.Tests/Unit/`, integration tests in `tests/CShells.Tests/Integration/`  
+**Target Platform**: Cross-platform .NET class libraries consumed by ASP.NET Core applications and feature class libraries  
+**Project Type**: Multi-project framework/library with ASP.NET Core integration, samples, and markdown documentation  
+**Performance Goals**: Preserve startup-only feature discovery costs that remain linear in configured provider count plus deduplicated assembly count, while ensuring each expected feature is discovered exactly once  
+**Constraints**: New public extensibility contracts must live in `CShells.Abstractions`; breaking changes are intentional and must remove legacy assembly-argument overloads; no new third-party dependencies; explicit assembly-source mode must suppress implicit host-derived scanning unless `FromHostAssemblies()` is appended; docs/examples must reflect only the new fluent model  
+**Scale/Scope**: Changes span `src/CShells.Abstractions`, `src/CShells`, `src/CShells.AspNetCore`, focused unit/integration tests, and developer-facing guidance in `README.md`, `docs/`, and possibly `wiki/`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Abstraction-First Architecture**: PASS. The new public custom-provider extension point is planned as `IFeatureAssemblyProvider` in `src/CShells.Abstractions`, while built-in providers and registration behavior remain in `src/CShells` and `src/CShells.AspNetCore`.
+- **Feature Modularity**: PASS. The feature changes discovery-source selection only; discovered feature semantics, dependency ordering, and per-shell isolation remain intact.
+- **Modern C# Style**: PASS. The work fits the existing file-scoped namespaces, nullable reference types, explicit access modifiers, collection expressions, and XML-doc-heavy public API conventions.
+- **Explicit Error Handling**: PASS. Null assembly inputs, null provider registrations, and other invalid discovery-source inputs will be planned as fail-fast validation paths with actionable guidance.
+- **Test Coverage**: PASS. The plan includes targeted unit tests for builder/provider behavior, integration tests for default-vs-explicit host discovery semantics, and coverage for custom provider composition.
+- **Simplicity & Minimalism**: PASS. The design reuses the existing fluent builder pattern and current host-assembly resolution logic instead of introducing a parallel discovery subsystem.
+
+**Post-Design Re-check**: PASS. Research and design keep the change centered on one new public abstraction, a builder-managed provider list, reusable host-assembly resolution, focused tests, and documentation updates without speculative extra layers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-fluent-assembly-selection/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── feature-assembly-provider-contract.md
+│   └── naming-decision-record.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells.Abstractions/
+│   └── Features/
+│       └── IFeatureAssemblyProvider.cs                    # new public discovery-source contract
+├── CShells/
+│   ├── DependencyInjection/
+│   │   ├── CShellsBuilder.cs                              # builder-managed assembly-provider registrations
+│   │   ├── CShellsBuilderExtensions.cs                    # FromAssemblies / FromHostAssemblies / WithAssemblyProvider APIs + XML docs
+│   │   └── ServiceCollectionExtensions.cs                 # default-vs-explicit provider selection and host wiring
+│   └── Features/
+│       ├── ExplicitFeatureAssemblyProvider.cs             # built-in explicit-assembly provider
+│       ├── HostFeatureAssemblyProvider.cs                 # built-in host-derived provider
+│       └── FeatureAssemblyResolver.cs                     # extracted host-resolution and aggregation helper
+├── CShells.AspNetCore/
+│   └── Extensions/
+│       ├── ServiceCollectionExtensions.cs                 # fluent-only AddCShellsAspNetCore surface
+│       └── ShellExtensions.cs                             # fluent-only AddShells overload surface
+└── CShells.AspNetCore/README.md                           # ASP.NET Core setup guidance if examples change
+
+tests/
+└── CShells.Tests/
+    ├── Integration/
+    │   └── ShellHost/
+    │       └── FeatureAssemblySelectionIntegrationTests.cs
+    └── Unit/
+        ├── DependencyInjection/
+        │   └── CShellsBuilderAssemblySourceTests.cs
+        └── Features/
+            ├── FeatureAssemblyProviderTests.cs
+            └── HostFeatureAssemblyProviderTests.cs
+
+README.md
+docs/
+├── getting-started.md
+├── integration-patterns.md
+└── multiple-shell-providers.md
+
+wiki/
+└── Getting-Started.md                                     # if public examples are mirrored here
+```
+
+**Structure Decision**: Keep the public extensibility contract in `CShells.Abstractions/Features` because assembly selection is part of feature discovery and must remain available to third-party feature libraries without implementation-project references. Implement built-in providers and aggregation logic in `src/CShells`, thread the builder-managed provider list through the existing registration pipeline, remove legacy assembly-argument overloads from both core and ASP.NET Core entry points, and verify behavior through focused builder/discovery tests plus documentation updates at the main entry points users already follow.
+
+## Complexity Tracking
+
+No constitution violations or justified complexity exceptions were identified during planning.

--- a/specs/003-fluent-assembly-selection/quickstart.md
+++ b/specs/003-fluent-assembly-selection/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Validate Fluent Assembly Source Selection
+
+## Prerequisites
+
+- The feature branch `003-fluent-assembly-selection` is checked out.
+- The existing CShells solution builds and tests successfully before changes begin.
+- You know which assemblies currently provide your shell features so you can express them through the new fluent builder API.
+
+## 1. Introduce the public feature-assembly provider contract
+
+- Add `IFeatureAssemblyProvider` to `src/CShells.Abstractions/Features/`.
+- Keep the interface implementation-agnostic so third parties can provide custom discovery sources.
+- Document the contract with XML comments because it is part of the supported public API.
+
+## 2. Move assembly-source configuration onto `CShellsBuilder`
+
+- Extend the core builder fluent surface with `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- Store appended provider registrations on the builder in call order.
+- Keep this provider list independent from the shell-settings provider pipeline.
+
+## 3. Add built-in providers and aggregate discovery behavior
+
+- Implement the built-in explicit-assemblies provider in `src/CShells/Features/`.
+- Implement the built-in host-derived provider by reusing the existing host assembly resolution algorithm.
+- Aggregate provider outputs additively and deduplicate assemblies before calling `FeatureDiscovery`.
+
+## 4. Preserve default behavior while enabling explicit mode
+
+- When no assembly-source fluent calls are made, continue scanning the current host-derived assembly set.
+- Once any assembly-source call is made, use only explicitly configured providers.
+- Require `FromHostAssemblies()` to opt host-derived assemblies back into explicit mode.
+- Treat empty explicit-assemblies calls as valid zero-contribution providers that still activate explicit mode.
+
+## 5. Remove the legacy assembly-argument API surface
+
+- Remove direct assembly parameters from `AddCShells`, `AddCShellsAspNetCore`, and `AddShells` overloads.
+- Update all in-repo examples to show the fluent builder pattern instead of trailing assembly arguments.
+- Ensure migration examples map cleanly from the removed overloads to the new fluent calls.
+
+## 6. Add tests for builder semantics and discovery outcomes
+
+- Add unit tests proving each assembly-source call appends a provider registration.
+- Add unit tests for null input rejection and empty explicit input acceptance.
+- Add integration tests showing:
+  - default behavior matches `FromHostAssemblies()`,
+  - explicit custom or explicit assembly sources do not implicitly include host assemblies,
+  - built-in and custom providers compose additively, and
+  - duplicate assembly contributions are discovered only once.
+
+## 7. Update developer guidance
+
+- Update `README.md` examples that currently pass assemblies directly to `AddShells` or `AddCShells`.
+- Update relevant docs in `docs/` and mirrored wiki content if it repeats the old pattern.
+- Reflect the approved naming set from the naming decision record consistently.
+
+## 8. Validate behavior
+
+- Run focused unit and integration tests for the new builder and discovery semantics.
+- Run the main CShells test project once focused tests pass.
+
+```bash
+dotnet test tests/CShells.Tests/
+```
+
+## Expected Outcomes
+
+- Developers configure feature-discovery assemblies only through fluent builder calls.
+- Default host-derived discovery remains unchanged when no assembly-source call is made.
+- Any explicit assembly-source call switches CShells into explicit-provider mode.
+- Host-derived, explicit, and custom providers compose additively and discover expected features exactly once.
+- Public examples no longer advertise the removed assembly-argument overloads.

--- a/specs/003-fluent-assembly-selection/research.md
+++ b/specs/003-fluent-assembly-selection/research.md
@@ -1,0 +1,73 @@
+# Phase 0 Research: Fluent Assembly Source Selection
+
+## Decision: Introduce a public `IFeatureAssemblyProvider` contract in `CShells.Abstractions/Features`
+
+**Rationale**: The clarified spec makes custom assembly providers a supported public extension point, so the abstraction must live in an abstractions project per the constitution. Placing it in `CShells.Features` keeps the contract aligned with feature discovery rather than shell-settings loading or ASP.NET Core hosting. Third-party libraries can then implement the interface without referencing `CShells` implementation assemblies.
+
+**Alternatives considered**:
+
+- Keep the provider abstraction internal to `CShells`: rejected because the spec explicitly requires a public custom-provider entry point.
+- Place the interface in `CShells.Configuration`: rejected because the contract supplies feature-discovery assemblies, not shell settings.
+- Add the contract to `CShells.AspNetCore.Abstractions`: rejected because the feature applies to both core and ASP.NET Core registration paths.
+
+## Decision: Use a builder-managed ordered provider list to represent explicit assembly-source mode
+
+**Rationale**: The spec requires every assembly-source call to append another provider and forbids replacement semantics. Using an ordered list on `CShellsBuilder` matches the existing provider-registration pattern already used for shell settings providers. It also gives a simple rule for explicit mode: if the builder has appended any feature-assembly provider registrations, discovery uses only those configured providers; if none were appended, CShells falls back to the built-in host-derived provider.
+
+This approach also resolves the empty-input edge case cleanly. An empty explicit-assemblies call still appends a provider instance, so discovery enters explicit mode without re-enabling implicit host scanning.
+
+**Alternatives considered**:
+
+- Track a separate `bool useExplicitAssemblySources`: rejected because list presence already captures the required mode transition with less state.
+- Store a mutable set instead of a list: rejected because the spec requires provider instances to be retained in call order.
+- Replace the previous source on each fluent call: rejected because the spec explicitly requires additive composition.
+
+## Decision: Reuse the current host-derived assembly resolution algorithm through a dedicated internal helper
+
+**Rationale**: `FromHostAssemblies()` must return exactly the same assembly set that CShells currently scans when no assemblies are specified. The safest way to preserve that equivalence is to extract the existing `ResolveAssembliesToScan()` logic behind an internal helper or built-in provider implementation and have both the implicit default path and the explicit `FromHostAssemblies()` path call the same code.
+
+**Alternatives considered**:
+
+- Reimplement host-derived scanning separately inside a new provider: rejected because the two paths could drift over time.
+- Keep the logic inline only in `ServiceCollectionExtensions`: rejected because `FromHostAssemblies()` must reuse it outside the no-configuration fallback path.
+- Change the default host-derived scan set while introducing the provider abstraction: rejected because the spec requires exact behavioral equivalence.
+
+## Decision: Aggregate provider outputs additively and deduplicate assemblies before feature discovery while preserving first-seen order
+
+**Rationale**: The spec requires additive composition across built-in and custom providers, along with deduplicated discovery results. The provider list should therefore be evaluated in registration order, flattened into one sequence, and deduplicated before passing assemblies into `FeatureDiscovery`. Preserving first-seen order keeps behavior stable for diagnostics and testing while ensuring duplicate providers or duplicate assemblies do not trigger extra discovery work.
+
+**Alternatives considered**:
+
+- Skip deduplication and rely on downstream feature-name deduplication: rejected because it would do unnecessary reflection work and make explicit duplicate-source scenarios noisier.
+- Deduplicate providers instead of assemblies: rejected because different providers may legitimately contribute overlapping assemblies.
+- Sort assemblies alphabetically before discovery: rejected because it obscures registration-order behavior without any product requirement.
+
+## Decision: Finalize the fluent naming set as `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`
+
+**Rationale**: The spec calls out a naming-focused work item and emphasizes mentally consistent terminology. `FromAssemblies(...)` communicates “append an explicit assembly contribution,” `FromHostAssemblies()` communicates “append the built-in host-derived contribution,” and `WithAssemblyProvider(...)` matches existing builder vocabulary for appending extensibility components. The interface name `IFeatureAssemblyProvider` ties the abstraction to feature discovery and avoids confusion with shell-settings providers.
+
+**Alternatives considered**:
+
+- `UseAssemblies(...)` / `UseHostAssemblies()`: rejected because `Use*` often implies replacement semantics, which conflicts with additive composition.
+- `WithAssemblies(...)`: rejected because it reads more like an in-place property setter than a source-selection operation.
+- `IAssemblySourceProvider`: rejected because the double abstraction term is more awkward and less discoverable than `IFeatureAssemblyProvider`.
+
+## Decision: Remove the legacy non-fluent assembly-argument APIs instead of preserving compatibility shims
+
+**Rationale**: The spec explicitly allows breaking changes and prohibits keeping the previous non-fluent assembly-argument approach. Removing those overloads avoids a split mental model and keeps the public surface aligned with the new provider-based design. Migration guidance can show the new fluent equivalents directly in `README.md`, `docs/`, and ASP.NET Core examples.
+
+**Alternatives considered**:
+
+- Keep obsolete assembly-argument overloads temporarily: rejected because the spec forbids legacy overload support.
+- Support both fluent and non-fluent forms indefinitely: rejected because it would preserve ambiguity about the preferred assembly-selection model.
+- Hide the old overloads behind forwarding methods: rejected because the resulting public API would still conflict with the clarified spec.
+
+## Decision: Validate the feature with focused unit, integration, and documentation coverage
+
+**Rationale**: The most important risks are builder composition, default-vs-explicit host semantics, and custom-provider extensibility. These are best covered with unit tests around provider-list behavior plus integration tests that build actual service collections and verify discovery outcomes. Because the old assembly-argument API is being removed, documentation updates are part of the functional change rather than optional cleanup.
+
+**Alternatives considered**:
+
+- Documentation-only validation: rejected because additive composition and explicit-mode behavior are easy to regress without tests.
+- Unit tests only: rejected because the feature spans builder wiring, host registration, and ASP.NET Core entry points.
+- Leave examples unchanged until implementation is complete: rejected because the new public API surface must be unambiguous before the next Speckit step.

--- a/specs/003-fluent-assembly-selection/spec.md
+++ b/specs/003-fluent-assembly-selection/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Fluent Assembly Source Selection
+
+**Feature Branch**: `003-fluent-assembly-selection`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "Refactor AddShells so assembly scanning is configured fluently on the builder, support additive assembly source calls (including explicit host assemblies), keep default host-assembly behavior when no sources are specified, allow breaking changes, and include a naming-focused work item."
+
+## Clarifications
+
+### Session 2026-04-11
+
+- Q: What should `FromHostAssemblies()` include? → A: Exactly the same assembly set that CShells currently scans by default when no assemblies are specified.
+- Q: Once any assembly-source method is called, should implicit default host-derived scanning still apply? → A: No. Once any assembly-source method is called, discovery uses only explicitly configured sources; host-derived assemblies are included only by default when no calls are made or when `FromHostAssemblies()` is called.
+- Q: How should multiple assembly-source calls compose? → A: All assembly-source calls concatenate their contributions. Multiple explicit assembly-list calls contribute all listed assemblies, and host-assembly source calls contribute the host-derived assembly set alongside them.
+- Q: What abstraction should back fluent assembly-source configuration? → A: CShells should expose an assembly provider abstraction that supplies assemblies for discovery. The builder maintains a list of assembly provider registrations, including built-in host-derived and explicit-assembly registrations, and each fluent call appends another registration entry to that list.
+
+### Session 2026-04-12
+
+- Q: Should the new assembly provider abstraction be a supported public extension point for custom implementations? → A: Yes. Developers should be able to supply their own custom assembly provider implementations through a public builder API in addition to the built-in convenience methods.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Feature Discovery Fluently (Priority: P1)
+
+As an application developer, I configure feature discovery using only fluent builder calls so I can keep all shell setup logic in one readable chain while composing multiple assembly providers declaratively.
+
+**Why this priority**: This is the primary behavior change and the main value of the enhancement.
+
+**Independent Test**: Configure shells using fluent assembly source methods only, then verify expected feature types are discovered without passing assemblies as extra method arguments and that each call appends another source contribution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shell setup chain with one explicit assembly source call, **When** startup configuration completes, **Then** feature discovery uses that configured source.
+2. **Given** a shell setup chain with multiple explicit assembly source calls, **When** startup configuration completes, **Then** feature discovery uses the concatenated contributions from all configured calls.
+3. **Given** a shell setup chain with an explicit custom assembly source call and no host-assemblies source call, **When** startup configuration completes, **Then** discovery uses only the explicitly configured assembly set.
+4. **Given** multiple fluent assembly source calls, **When** configuration is built, **Then** each call appends another assembly provider registration to the builder-managed provider list.
+
+---
+
+### User Story 2 - Explicitly Include Host Assemblies (Priority: P2)
+
+As an application developer, I can explicitly include host application assemblies in the fluent chain so default behavior can be declared intentionally and combined with other provider-based sources.
+
+**Why this priority**: It improves clarity and supports additive composition when host assemblies are needed alongside custom sources.
+
+**Independent Test**: Configure one setup with no assembly source calls and another with an explicit host-assemblies call; verify both discover the same host-derived features.
+
+**Acceptance Scenarios**:
+
+1. **Given** no explicit assembly source configuration, **When** shells are initialized, **Then** host-assembly discovery still occurs by default.
+2. **Given** an explicit host-assemblies source call, **When** shells are initialized, **Then** discovery includes the host-derived feature set.
+3. **Given** explicit host-assemblies and custom assembly source calls together, **When** shells are initialized, **Then** discovery includes the union of both sources.
+4. **Given** an explicit custom assembly source call without `FromHostAssemblies()`, **When** shells are initialized, **Then** host-derived assemblies are not included implicitly.
+5. **Given** the out-of-the-box host-derived provider and explicit-assembly provider are both configured, **When** discovery runs, **Then** assemblies from both providers are scanned.
+
+---
+
+### User Story 3 - Extend Discovery with Custom Providers (Priority: P3)
+
+As an application developer, I can append my own assembly provider implementations through the public builder API so I can plug in custom discovery sources without forking CShells.
+
+**Why this priority**: The new provider abstraction is much more valuable if it is a supported extension point rather than an internal-only mechanism.
+
+**Independent Test**: Register a custom assembly provider through the public builder API, then verify its contributed assemblies are included additively alongside built-in providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom assembly provider implementation, **When** it is appended through the public builder API, **Then** its assembly contribution is included in discovery.
+2. **Given** built-in and custom providers are appended together, **When** discovery runs, **Then** CShells scans the deduplicated union of all contributed assemblies.
+3. **Given** multiple custom provider inputs are appended, **When** configuration is built, **Then** each input is retained as a distinct provider registration in the builder-managed provider list.
+
+---
+
+### User Story 4 - Adopt Clear Naming for the New API Surface (Priority: P4)
+
+As a maintainer, I can apply clear and mentally consistent names for this enhancement so developers understand intent without reading implementation details.
+
+**Why this priority**: Naming quality strongly affects API discoverability, onboarding, and long-term maintainability.
+
+**Independent Test**: Review the finalized naming set in a short design pass and verify each name is unambiguous, consistent, and reflected in developer-facing usage examples.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new fluent assembly-source capability, **When** naming review is completed, **Then** one approved naming set is selected and used consistently across the exposed API.
+2. **Given** obsolete naming candidates, **When** the enhancement is finalized, **Then** those candidates are not left in developer-facing API surface or examples.
+
+### Edge Cases
+
+- The same assembly is added multiple times across calls; duplicate processing must not alter discovery results.
+- An explicit assembly source call is made with an empty set; configuration remains valid, contributes no assemblies, and does not re-enable implicit host-derived scanning.
+- A null assembly source input is provided; configuration fails fast with a clear developer-facing error.
+- A null custom provider instance or factory is supplied; configuration fails fast with a clear developer-facing error.
+- A custom provider returns a null assembly sequence; discovery treats that as invalid instead of partially succeeding.
+- `WithAssemblyProvider<TProvider>()` is used for a provider type that cannot be resolved from the root application service provider; discovery fails fast with a clear developer-facing error.
+- Host assembly source is combined with custom sources in different call orders; resulting discovered feature set remains equivalent.
+- The builder receives many assembly source calls; provider registrations are all retained in call order and none are silently replaced.
+- A custom provider returns an assembly already contributed by another provider; discovery remains deduplicated.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The shell setup API MUST allow assembly-source configuration through fluent builder methods within the main configuration chain.
+- **FR-002**: CShells MUST define an assembly provider abstraction, expressed as an interface, whose responsibility is to supply assemblies for feature discovery.
+- **FR-003**: The fluent builder MUST maintain an internal ordered list of assembly provider registrations used to determine which assemblies CShells scans.
+- **FR-004**: Each assembly-source fluent call MUST append one or more assembly provider registrations to that builder-maintained list and MUST NOT replace previously configured registrations.
+- **FR-005**: The shell setup API MUST support multiple assembly-source method calls and concatenate their provider contributions into one aggregate discovery set.
+- **FR-006**: The system MUST provide a built-in assembly provider that returns the same host-derived assembly set that CShells currently scans by default when no assemblies are specified.
+- **FR-007**: The system MUST provide a built-in assembly provider that accepts an explicit set of assemblies through its creation inputs and returns that exact configured set.
+- **FR-008**: The system MUST provide a fluent convenience method for adding explicit developer-supplied assemblies as feature discovery sources, and assemblies supplied across multiple calls MUST all be included.
+- **FR-009**: The system MUST provide a fluent convenience method for explicitly adding host-application assemblies as feature discovery sources, and that host-derived assembly set MUST be included additively alongside other configured sources.
+- **FR-010**: The system MUST provide a public builder API for appending custom assembly provider implementations, and the generic custom-provider entry point MUST resolve the provider from the root application service provider.
+- **FR-011**: Custom assembly provider implementations appended through the public builder API MUST participate additively in the same provider list and discovery flow as the built-in providers, and provider evaluation MUST receive the root application service provider used during shell registration.
+- **FR-012**: `FromHostAssemblies()` MUST include exactly the same assembly set that CShells currently scans by default when no assemblies are specified.
+- **FR-013**: If no assembly-source methods are called, the system MUST preserve current default behavior of scanning that same host-derived assembly set.
+- **FR-014**: Once any assembly-source method is called, discovery MUST use only explicitly configured providers and the assemblies they contribute.
+- **FR-015**: When explicit, host-derived, and custom providers are combined, discovery MUST use the deduplicated union of all contributed assemblies.
+- **FR-016**: The previous non-fluent assembly argument approach MUST be removed; maintaining backward compatibility with legacy overloads is out of scope and prohibited.
+- **FR-017**: Null assembly-source inputs, null custom provider registrations, null custom provider factories, and null custom provider output sequences MUST be rejected with clear guidance; empty explicit inputs MUST be accepted as zero-contribution additions that still participate in explicit-source mode.
+- **FR-018**: The enhancement MUST include a naming decision work item that results in clean, mentally consistent terminology for the provider abstraction, builder members, fluent methods, and custom-provider entry point.
+- **FR-019**: Developer-facing usage guidance and examples for shell setup MUST reflect the new fluent assembly-source pattern, the additive provider model, and the public custom-provider extension point only.
+
+### Key Entities *(include if feature involves data)*
+
+- **Assembly Source Set**: The aggregate set of assemblies configured for feature discovery, built from one or more provider contributions and deduplicated before discovery.
+- **IFeatureAssemblyProvider**: The public abstraction CShells uses to obtain assemblies for discovery from different source types.
+- **Assembly Provider List**: The builder-maintained ordered list of assembly provider registrations accumulated through fluent configuration calls.
+- **HostFeatureAssemblyProvider**: The built-in provider that returns the same host-derived assembly set CShells currently uses by default.
+- **ExplicitFeatureAssemblyProvider**: The built-in provider that returns a specific assembly set supplied during its creation.
+- **Custom `IFeatureAssemblyProvider` Implementation**: Any developer-supplied implementation of the provider interface appended through the public builder API.
+- **Naming Decision Record**: The accepted terminology for this enhancement, including selected method names and rejected alternatives with rationale.
+
+### Assumptions
+
+- Developers may combine source directives in any order and expect equivalent discovery results.
+- Existing default host-derived discovery behavior is considered correct, and `FromHostAssemblies()` is expected to target that exact same assembly set through `HostFeatureAssemblyProvider`.
+- Calling any assembly-source method switches discovery into explicit-source mode, so host-derived assemblies are no longer included unless the host assemblies provider is explicitly appended.
+- Each assembly-source call contributes through one or more provider registrations, and the final discovery set is built by concatenating all provider contributions before deduplication.
+- Custom providers are a supported public extension mechanism and are expected to follow the same additive and deduplicated discovery semantics as built-in providers.
+- Breaking changes are intentionally acceptable for this enhancement; migration support for legacy overloads is not required.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, 100% of documented shell setup examples express assembly discovery through fluent builder calls without trailing assembly arguments.
+- **SC-002**: In validation scenarios, 100% of feature types expected from combined provider contributions are discovered exactly once.
+- **SC-003**: In side-by-side verification, default (no explicit source directives) and explicit host-source configuration produce equivalent host-derived discovery outcomes in all defined test scenarios.
+- **SC-004**: In builder-behavior verification, every assembly-source fluent call results in an added provider entry and no previously configured provider entries are lost.
+- **SC-005**: In extension-point verification, custom providers appended through the public builder API contribute assemblies successfully in 100% of defined test scenarios.
+- **SC-006**: During internal API review, all new assembly-source and provider-related names are approved in one naming decision record with no unresolved naming conflicts.

--- a/specs/003-fluent-assembly-selection/tasks.md
+++ b/specs/003-fluent-assembly-selection/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: Fluent Assembly Source Selection
+
+**Input**: Design documents from `/specs/003-fluent-assembly-selection/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/feature-assembly-provider-contract.md`, `contracts/naming-decision-record.md`
+
+**Tests**: Include focused unit and integration tests because the specification, research, quickstart, and constitution explicitly require coverage for fluent builder composition, explicit/default host behavior, custom provider extensibility, deduplicated discovery, and breaking API changes.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently once the shared discovery infrastructure is in place.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the new public feature-discovery contract that the rest of the implementation will build on.
+
+- [X] T001 Create the public `IFeatureAssemblyProvider` contract with XML documentation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared builder and discovery infrastructure that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 Extend `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs` with an ordered `_featureAssemblyProviderRegistrations` list, explicit-mode detection, and provider-construction helpers
+- [X] T003 [P] Extract host/default assembly resolution into `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs` and add the built-in host provider in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`
+- [X] T004 [P] Add the built-in explicit provider in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs` so explicit assembly contributions can be represented independently of the fluent API surface
+- [X] T005 Wire implicit-host-default versus explicit-provider discovery selection into `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`
+
+**Checkpoint**: The public provider abstraction exists, the builder can retain ordered provider registrations, and core discovery can switch cleanly between implicit host-default and explicit-provider modes.
+
+---
+
+## Phase 3: User Story 1 - Configure Feature Discovery Fluently (Priority: P1) 🎯 MVP
+
+**Goal**: Let application developers configure feature discovery only through fluent builder calls while preserving additive composition across explicit assembly-source calls.
+
+**Independent Test**: Configure shells with `FromAssemblies(...)` calls only, verify expected features are discovered without trailing assembly arguments, and confirm each fluent call appends another provider contribution instead of replacing earlier ones.
+
+### Tests for User Story 1
+
+> **NOTE**: Write these tests first, confirm they fail against the current code, then implement the fluent assembly-source behavior.
+
+- [X] T006 [P] [US1] Add append-order, empty-input, and null-explicit-assembly guard coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`
+- [X] T007 [P] [US1] Add explicit-provider aggregation and duplicate-assembly deduplication coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement fluent `FromAssemblies(params Assembly[] assemblies)` registration in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
+- [X] T009 [US1] Remove legacy assembly-argument support from `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs` so `AddCShells(...)` relies only on builder-managed provider configuration
+- [X] T010 [US1] Finalize explicit assembly aggregation, deduplicated first-seen ordering, and zero-contribution explicit-mode handling in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs`
+
+**Checkpoint**: Fluent explicit-assembly configuration works end to end, additive calls are retained in order, duplicate assemblies are scanned once, and the core API no longer advertises trailing assembly arguments.
+
+---
+
+## Phase 4: User Story 2 - Explicitly Include Host Assemblies (Priority: P2)
+
+**Goal**: Let developers explicitly opt host-derived assemblies back into discovery while preserving the existing implicit default behavior when no assembly-source calls are made.
+
+**Independent Test**: Compare a default configuration with no assembly-source calls against a configuration that explicitly uses `FromHostAssemblies()` and verify the discovered host feature set is equivalent; then confirm explicit custom/explicit sources do not include host assemblies unless `FromHostAssemblies()` is appended.
+
+### Tests for User Story 2
+
+- [X] T011 [P] [US2] Add default-versus-`FromHostAssemblies()` equivalence and explicit-mode host-exclusion coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`
+- [X] T012 [P] [US2] Add repeated-host-provider deduplication and host-resolution equivalence coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Implement fluent `FromHostAssemblies()` by reusing the shared host-resolution algorithm in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`
+- [X] T014 [US2] Remove legacy assembly-argument overloads and preserve fluent-only default-host behavior in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ShellExtensions.cs`
+
+**Checkpoint**: Default host-derived discovery remains unchanged when no source methods are called, `FromHostAssemblies()` explicitly restores the same host-derived set in explicit mode, and ASP.NET Core entry points no longer expose legacy assembly-argument overloads.
+
+---
+
+## Phase 5: User Story 3 - Extend Discovery with Custom Providers (Priority: P3)
+
+**Goal**: Let developers append their own `IFeatureAssemblyProvider` implementations through the public builder API so custom discovery sources participate additively with built-in providers.
+
+**Independent Test**: Register custom providers through the public builder API and verify they contribute assemblies additively, preserve provider-registration order, and still produce a deduplicated discovery set when combined with built-in providers.
+
+### Tests for User Story 3
+
+- [X] T015 [P] [US3] Add generic, instance, and factory `WithAssemblyProvider(...)` coverage with null-guard assertions, root-DI generic resolution behavior, and non-null provider-result validation in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`
+- [X] T016 [P] [US3] Add custom-provider additive composition, root-service-provider context propagation, and deduplicated discovery coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Implement public `WithAssemblyProvider<TProvider>()`, instance, and factory overloads in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`, including root-DI resolution and fail-fast behavior for unresolved generic providers
+- [X] T018 [US3] Ensure custom provider registrations are retained, materialized, and aggregated additively in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`
+
+**Checkpoint**: The public custom-provider extension point is live, built-in and custom providers compose in one ordered list, and discovery stays deduplicated regardless of provider overlap.
+
+---
+
+## Phase 6: User Story 4 - Adopt Clear Naming for the New API Surface (Priority: P4)
+
+**Goal**: Apply the approved naming set consistently across the public API surface, internal implementation seams, and entry-point XML docs.
+
+**Independent Test**: Review the final public API and XML docs to confirm the approved names are used consistently, rejected alternatives are absent from active guidance, and the custom-provider entry point matches the naming decision record.
+
+### Implementation for User Story 4
+
+- [X] T019 [P] [US4] Apply the approved naming set and required XML docs for all new public fluent builder methods and overloads across `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs`
+- [X] T020 [P] [US4] Remove rejected or legacy naming from entry-point XML docs in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ShellExtensions.cs`
+
+**Checkpoint**: The codebase uses one approved naming set for the provider abstraction, fluent methods, built-in provider types, and supporting builder/resolver members.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update public guidance, migrate in-repo examples, and validate the completed feature against the quickstart flow.
+
+- [X] T021 [P] Update fluent assembly-selection and migration guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/README.md` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/README.md`
+- [X] T022 [P] Update additive provider composition and explicit/default host behavior guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/getting-started.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/integration-patterns.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/multiple-shell-providers.md`
+- [X] T023 [P] Update mirrored guidance and runnable examples in `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Getting-Started.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Creating-Features.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs`
+- [X] T024 Run the quickstart validation flow from `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/quickstart.md` and the regression suite rooted at `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/`
+- [X] T025 [US4] Audit the final public API, XML docs, examples, and `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/contracts/naming-decision-record.md` for approved-name consistency and rejected-name removal across the repo
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies; start immediately.
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3: User Story 1 (P1)**: Depends on Foundational completion; delivers the MVP fluent explicit-assembly path.
+- **Phase 4: User Story 2 (P2)**: Depends on Foundational completion; shares builder-extension and ASP.NET Core entry-point files with User Story 1, so coordinate edits if parallel work is attempted.
+- **Phase 5: User Story 3 (P3)**: Depends on Foundational completion; should follow the builder/provider infrastructure established by User Story 1 even though its behavior remains independently testable.
+- **Phase 6: User Story 4 (P4)**: Depends on the new API surface existing; complete after User Stories 1-3 have stabilized the names that must be applied consistently.
+- **Phase 7: Polish**: Depends on the stories you plan to ship; run after the public API and tests are stable.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: First deliverable and MVP; no dependency on later stories.
+- **User Story 2 (P2)**: Independent in behavior after Foundational, but it edits some of the same registration files as User Story 1.
+- **User Story 3 (P3)**: Independent in behavior after Foundational, but it extends the same builder/provider flow introduced in User Story 1.
+- **User Story 4 (P4)**: Depends on the finalized API shape from User Stories 1-3 so naming can be applied consistently without churn.
+
+### Within Each User Story
+
+- Test tasks should be completed first and confirmed failing before implementation is considered done.
+- Builder/provider registration changes precede service-registration entry-point cleanup.
+- Discovery aggregation changes precede documentation and sample updates.
+- Legacy overload removal precedes public documentation migration so examples only show supported APIs.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel after T002.
+- T006 and T007 can run in parallel for User Story 1.
+- T011 and T012 can run in parallel for User Story 2.
+- T015 and T016 can run in parallel for User Story 3.
+- T019 and T020 can run in parallel for User Story 4.
+- T021, T022, and T023 can run in parallel during Polish.
+- T025 should run after T019-T023 so the naming audit verifies the final state.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch User Story 1 test work in parallel:
+Task: "Add append-order, empty-input, and null-explicit-assembly guard coverage in tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs"
+Task: "Add explicit-provider aggregation and duplicate-assembly deduplication coverage in tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch User Story 2 verification work in parallel:
+Task: "Add default-versus-FromHostAssemblies() equivalence and explicit-mode host-exclusion coverage in tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs"
+Task: "Add repeated-host-provider deduplication and host-resolution equivalence coverage in tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch User Story 3 verification work in parallel:
+Task: "Add generic, instance, and factory WithAssemblyProvider(...) coverage with null-guard assertions in tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs"
+Task: "Add custom-provider additive composition and deduplicated discovery coverage in tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs"
+```
+
+## Parallel Example: User Story 4
+
+```bash
+# Launch naming-alignment work in parallel once User Stories 1-3 stabilize the final API shape:
+Task: "Apply the approved naming set across src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs, src/CShells/DependencyInjection/CShellsBuilder.cs, src/CShells/DependencyInjection/CShellsBuilderExtensions.cs, and src/CShells/Features/*.cs"
+Task: "Remove rejected or legacy naming from entry-point XML docs in src/CShells/DependencyInjection/ServiceCollectionExtensions.cs, src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs, and src/CShells.AspNetCore/Extensions/ShellExtensions.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Validate fluent explicit-assembly configuration independently before moving on.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational so the new provider abstraction, ordered builder list, and resolver wiring are stable.
+2. Deliver User Story 1 to move explicit assembly selection onto the fluent builder and remove the core legacy API.
+3. Deliver User Story 2 to reintroduce host assemblies explicitly and remove ASP.NET Core legacy overloads.
+4. Deliver User Story 3 to open the public custom-provider extension point.
+5. Deliver User Story 4 to lock naming consistency across the public surface.
+6. Finish with docs, sample updates, and quickstart/regression validation.
+
+### Parallel Team Strategy
+
+1. One developer completes T002 while another prepares the new resolver/provider files for T003-T004.
+2. After Foundational is complete, split unit and integration test tasks within each story across developers.
+3. Reserve shared-file builder-extension changes for coordinated work because User Stories 1-3 all touch `/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`.
+4. Once the API is stable, documentation and sample updates can proceed in parallel with final validation.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and can be run in parallel safely.
+- `[US1]`, `[US2]`, `[US3]`, and `[US4]` map directly to the prioritized stories in the feature spec.
+- The task order intentionally reflects the finalized design: public `IFeatureAssemblyProvider`, builder-managed ordered provider list, built-in host and explicit providers, public custom-provider entry point, additive composition semantics, explicit-mode/default-host behavior, legacy API removal, tests, docs, and naming consistency.
+- Keep the implementation focused on the listed files; avoid introducing alternative assembly-selection models or compatibility shims for removed overloads.

--- a/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs
+++ b/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+
+namespace CShells.Features;
+
+/// <summary>
+/// Provides assemblies that CShells should scan for shell features.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations participate in CShells feature discovery alongside the built-in host and explicit assembly providers.
+/// </para>
+/// <para>
+/// The supplied <c>serviceProvider</c> argument is the root application service provider used during shell registration.
+/// Implementations may return an empty sequence, but they must not return <see langword="null"/>.
+/// </para>
+/// </remarks>
+public interface IFeatureAssemblyProvider
+{
+    /// <summary>
+    /// Gets the assemblies that should be scanned for shell features.
+    /// </summary>
+    /// <param name="serviceProvider">The root application service provider.</param>
+    /// <returns>A non-null sequence of assemblies to scan.</returns>
+    IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider);
+}

--- a/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -28,10 +28,10 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional configuration action to customize the CShells builder.</param>
     /// <returns>The CShells builder for further configuration.</returns>
-      /// <remarks>
-      /// Configure feature discovery assemblies through the returned <see cref="CShellsBuilder"/> using
-      /// <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>, or <c>WithAssemblyProvider(...)</c>.
-      /// </remarks>
+    /// <remarks>
+    /// Configure feature discovery assemblies through the returned <see cref="CShellsBuilder"/> using
+    /// <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>, or <c>WithAssemblyProvider(...)</c>.
+    /// </remarks>
     /// <example>
     /// <code>
     /// // Use defaults (web routing + endpoint routing)

--- a/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using CShells.AspNetCore.Configuration;
 using CShells.AspNetCore.Middleware;
 using CShells.DependencyInjection;
@@ -28,8 +27,11 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional configuration action to customize the CShells builder.</param>
-    /// <param name="assemblies">Optional assemblies to scan for CShells features. If <c>null</c>, all loaded assemblies are scanned.</param>
     /// <returns>The CShells builder for further configuration.</returns>
+      /// <remarks>
+      /// Configure feature discovery assemblies through the returned <see cref="CShellsBuilder"/> using
+      /// <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>, or <c>WithAssemblyProvider(...)</c>.
+      /// </remarks>
     /// <example>
     /// <code>
     /// // Use defaults (web routing + endpoint routing)
@@ -63,14 +65,12 @@ public static class ServiceCollectionExtensions
     /// </example>
     public static CShellsBuilder AddCShellsAspNetCore(
         this IServiceCollection services,
-        Action<CShellsBuilder>? configure = null,
-        IEnumerable<Assembly>? assemblies = null)
+        Action<CShellsBuilder>? configure = null)
     {
         Guard.Against.Null(services);
 
         // Allow user customization first so they can configure the pipeline
-        var builder = services.AddCShells(null, assemblies);
-        configure?.Invoke(builder);
+        var builder = services.AddCShells(configure);
 
         // Register shell resolver options for strategy ordering
         services.TryAddSingleton<ShellResolverOptions>();

--- a/src/CShells.AspNetCore/Extensions/ShellExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ShellExtensions.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using CShells.Configuration;
 using CShells.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
@@ -20,62 +19,41 @@ public static class ShellExtensions
         /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
         public WebApplicationBuilder AddShells()
         {
-            return builder.AddShells(sectionName: CShellsOptions.SectionName, assemblies: null);
+            return builder.AddShells(sectionName: CShellsOptions.SectionName);
         }
 
         /// <summary>
         /// Adds CShells core services and ASP.NET Core integration using the default
         /// configuration section "CShells" and the default shell resolver.
         /// </summary>
-        /// <param name="featureAssemblyMarkerTypes"> The types used to locate feature assemblies to scan for CShells features.</param>
-        /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
-        public WebApplicationBuilder AddShells(IEnumerable<Type> featureAssemblyMarkerTypes)
-        {
-            var assemblyMarkerTypes = featureAssemblyMarkerTypes as Type[] ?? featureAssemblyMarkerTypes.ToArray();
-            Guard.Against.Null(assemblyMarkerTypes);
-            return builder.AddShells(assemblyMarkerTypes.Select(t => t.Assembly));
-        }
-
-        /// <summary>
-        /// Adds CShells core services and ASP.NET Core integration using the default
-        /// configuration section "CShells" and the specified feature assemblies.
-        /// </summary>
-        /// <param name="assemblies">The assemblies to scan for CShells features. If <c>null</c>, all loaded assemblies are scanned.</param>
-        /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
-        public WebApplicationBuilder AddShells(IEnumerable<Assembly> assemblies)
-        {
-            return builder.AddShells(sectionName: CShellsOptions.SectionName, assemblies: assemblies);
-        }
-
-        /// <summary>
-        /// Adds CShells core services and ASP.NET Core integration using the specified
-        /// configuration section and optional feature assemblies.
-        /// </summary>
         /// <param name="sectionName">The configuration section name to bind CShells options from.</param>
-        /// <param name="assemblies">The assemblies to scan for CShells features. If <c>null</c>, all loaded assemblies are scanned.</param>
         /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
-        public WebApplicationBuilder AddShells(string sectionName, IEnumerable<Assembly>? assemblies = null)
+        /// <remarks>
+        /// Configure feature discovery assemblies through the fluent <see cref="CShellsBuilder"/> APIs when needed.
+        /// </remarks>
+        public WebApplicationBuilder AddShells(string sectionName)
         {
             Guard.Against.NullOrEmpty(sectionName);
 
-            return builder.AddShells(shells => shells.WithConfigurationProvider(builder.Configuration, sectionName), assemblies);
+            return builder.AddShells(shells => shells.WithConfigurationProvider(builder.Configuration, sectionName));
         }
 
         /// <summary>
         /// Adds CShells core services and ASP.NET Core integration, allowing customization
-        /// of the shell settings provider and shell resolver.
+        /// of the shell settings provider, feature assembly sources, and shell resolver.
         /// </summary>
-        /// <param name="configureCShells">Callback used to configure the CShells builder (e.g., shell settings provider).</param>
-        /// <param name="assemblies">The assemblies to scan for CShells features. If <c>null</c>, all loaded assemblies are scanned.</param>
+        /// <param name="configureCShells">Callback used to configure the CShells builder.</param>
         /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
-        public WebApplicationBuilder AddShells(
-            Action<CShellsBuilder> configureCShells,
-            IEnumerable<Assembly>? assemblies = null)
+        /// <remarks>
+        /// Configure feature discovery assemblies through <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>,
+        /// or <c>WithAssemblyProvider(...)</c> inside <paramref name="configureCShells"/>.
+        /// </remarks>
+        public WebApplicationBuilder AddShells(Action<CShellsBuilder> configureCShells)
         {
             Guard.Against.Null(configureCShells);
 
             // Register ASP.NET Core integration for CShells
-            builder.Services.AddCShellsAspNetCore(configureCShells, assemblies);
+            builder.Services.AddCShellsAspNetCore(configureCShells);
 
             return builder;
         }

--- a/src/CShells.AspNetCore/README.md
+++ b/src/CShells.AspNetCore/README.md
@@ -97,6 +97,25 @@ app.MapShells();
 app.Run();
 ```
 
+**Explicit feature assembly selection:**
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(Program).Assembly);
+    cshells.FromHostAssemblies();
+});
+
+var app = builder.Build();
+app.MapShells();
+app.Run();
+```
+
+If you do not call an assembly-source method, CShells uses the same host-derived feature assembly set as the default discovery behavior. Once you call `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)`, discovery switches to explicit provider mode and uses only the assemblies contributed by those appended providers.
+
 **Advanced setup with custom resolvers:**
 
 ```csharp

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using CShells.Configuration;
+using CShells.Features;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CShells.DependencyInjection;
@@ -11,6 +13,7 @@ public class CShellsBuilder
 {
     private readonly List<ShellSettings> _codeFirstShells = new();
     private readonly List<Action<IServiceProvider, List<IShellSettingsProvider>>> _providerRegistrations = new();
+    private readonly List<Func<IServiceProvider, IFeatureAssemblyProvider>> _featureAssemblyProviderRegistrations = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CShellsBuilder"/> class.
@@ -30,6 +33,11 @@ public class CShellsBuilder
     /// Gets all code-first shell settings configured via AddShell.
     /// </summary>
     internal IReadOnlyList<ShellSettings> CodeFirstShells => _codeFirstShells.AsReadOnly();
+
+    /// <summary>
+    /// Gets a value indicating whether explicit feature assembly providers were configured.
+    /// </summary>
+    internal bool UsesExplicitFeatureAssemblyProviders => _featureAssemblyProviderRegistrations.Count > 0;
 
     /// <summary>
     /// Registers a provider registration action.
@@ -55,14 +63,54 @@ public class CShellsBuilder
     }
 
     /// <summary>
+    /// Registers a feature assembly provider factory.
+    /// </summary>
+    internal void RegisterFeatureAssemblyProvider(Func<IServiceProvider, IFeatureAssemblyProvider> registration)
+    {
+        _featureAssemblyProviderRegistrations.Add(Guard.Against.Null(registration));
+    }
+
+    /// <summary>
+    /// Builds all registered feature assembly providers and returns them in registration order.
+    /// </summary>
+    internal IReadOnlyList<IFeatureAssemblyProvider> BuildFeatureAssemblyProviders(IServiceProvider serviceProvider)
+    {
+        Guard.Against.Null(serviceProvider);
+
+        var providers = new List<IFeatureAssemblyProvider>(_featureAssemblyProviderRegistrations.Count);
+
+        foreach (var registration in _featureAssemblyProviderRegistrations)
+        {
+            var provider = registration(serviceProvider)
+                ?? throw new InvalidOperationException("Feature assembly provider registrations must return a non-null provider instance.");
+
+            providers.Add(provider);
+        }
+
+        return providers.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Resolves the assemblies that should be scanned for shell feature discovery.
+    /// </summary>
+    internal IReadOnlyCollection<Assembly> BuildFeatureAssemblies(IServiceProvider serviceProvider)
+    {
+        Guard.Against.Null(serviceProvider);
+
+        return UsesExplicitFeatureAssemblyProviders
+            ? CShells.Features.FeatureAssemblyResolver.ResolveAssemblies(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider)
+            : CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies();
+    }
+
+    /// <summary>
     /// Adds a shell using a fluent builder.
     /// </summary>
     /// <param name="configure">Configuration action for the shell builder.</param>
     /// <returns>This builder for method chaining.</returns>
-    public CShellsBuilder AddShell(Action<Configuration.ShellBuilder> configure)
+    public CShellsBuilder AddShell(Action<ShellBuilder> configure)
     {
         Guard.Against.Null(configure);
-        var shellBuilder = new Configuration.ShellBuilder(new ShellId(Guid.NewGuid().ToString()));
+        var shellBuilder = new ShellBuilder(new ShellId(Guid.NewGuid().ToString()));
         configure(shellBuilder);
         _codeFirstShells.Add(shellBuilder.Build());
         return this;
@@ -74,11 +122,11 @@ public class CShellsBuilder
     /// <param name="id">The shell identifier.</param>
     /// <param name="configure">Configuration action for the shell builder.</param>
     /// <returns>This builder for method chaining.</returns>
-    public CShellsBuilder AddShell(string id, Action<Configuration.ShellBuilder> configure)
+    public CShellsBuilder AddShell(string id, Action<ShellBuilder> configure)
     {
         Guard.Against.Null(id);
         Guard.Against.Null(configure);
-        var shellBuilder = new Configuration.ShellBuilder(new ShellId(id));
+        var shellBuilder = new ShellBuilder(new ShellId(id));
         configure(shellBuilder);
         _codeFirstShells.Add(shellBuilder.Build());
         return this;

--- a/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using CShells.Configuration;
+using CShells.Features;
 using CShells.Resolution;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,138 +12,237 @@ namespace CShells.DependencyInjection;
 /// </summary>
 public static class CShellsBuilderExtensions
 {
+    /// <summary>
+    /// Adds a shell settings provider to the provider pipeline.
+    /// Multiple providers can be registered and will be queried in registration order.
+    /// </summary>
+    /// <typeparam name="TProvider">The type of the shell settings provider.</typeparam>
     /// <param name="builder">The CShells builder.</param>
-    extension(CShellsBuilder builder)
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithProvider<TProvider>(this CShellsBuilder builder)
+        where TProvider : class, IShellSettingsProvider
     {
-        /// <summary>
-        /// Adds a shell settings provider to the provider pipeline.
-        /// Multiple providers can be registered and will be queried in registration order.
-        /// </summary>
-        /// <typeparam name="TProvider">The type of the shell settings provider.</typeparam>
-        /// <returns>The updated CShells builder.</returns>
-        public CShellsBuilder WithProvider<TProvider>()
-            where TProvider : class, IShellSettingsProvider
+        Guard.Against.Null(builder);
+
+        builder.RegisterProvider((sp, providers) =>
         {
-            Guard.Against.Null(builder);
-            
-            builder.RegisterProvider((sp, providers) =>
-            {
-                var provider = ActivatorUtilities.CreateInstance<TProvider>(sp);
-                providers.Add(provider);
-            });
-            
-            return builder;
-        }
+            var provider = ActivatorUtilities.CreateInstance<TProvider>(sp);
+            providers.Add(provider);
+        });
 
-        /// <summary>
-        /// Adds a shell settings provider instance to the provider pipeline.
-        /// Multiple providers can be registered and will be queried in registration order.
-        /// </summary>
-        /// <param name="provider">The shell settings provider instance.</param>
-        /// <returns>The updated CShells builder.</returns>
-        public CShellsBuilder WithProvider(IShellSettingsProvider provider)
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a shell settings provider instance to the provider pipeline.
+    /// Multiple providers can be registered and will be queried in registration order.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="provider">The shell settings provider instance.</param>
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithProvider(this CShellsBuilder builder, IShellSettingsProvider provider)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(provider);
+
+        builder.RegisterProvider((_, providers) =>
         {
-            Guard.Against.Null(builder);
-            Guard.Against.Null(provider);
-            
-            builder.RegisterProvider((_, providers) =>
-            {
-                providers.Add(provider);
-            });
-            
-            return builder;
-        }
+            providers.Add(provider);
+        });
 
-        /// <summary>
-        /// Adds a shell settings provider using a factory function to the provider pipeline.
-        /// Multiple providers can be registered and will be queried in registration order.
-        /// </summary>
-        /// <param name="factory">The factory function to create the shell settings provider.</param>
-        /// <returns>The updated CShells builder.</returns>
-        public CShellsBuilder WithProvider(Func<IServiceProvider, IShellSettingsProvider> factory)
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a shell settings provider using a factory function to the provider pipeline.
+    /// Multiple providers can be registered and will be queried in registration order.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="factory">The factory function to create the shell settings provider.</param>
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithProvider(this CShellsBuilder builder, Func<IServiceProvider, IShellSettingsProvider> factory)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(factory);
+
+        builder.RegisterProvider((sp, providers) =>
         {
-            Guard.Against.Null(builder);
-            Guard.Against.Null(factory);
-            
-            builder.RegisterProvider((sp, providers) =>
-            {
-                var provider = factory(sp);
-                providers.Add(provider);
-            });
-            
-            return builder;
-        }
+            var provider = factory(sp);
+            providers.Add(provider);
+        });
 
-        /// <summary>
-        /// Adds the configuration-based shell settings provider to the provider pipeline.
-        /// Multiple providers can be registered and will be queried in registration order.
-        /// </summary>
-        /// <param name="configuration">The application configuration.</param>
-        /// <param name="sectionName">The configuration section name (default: "CShells").</param>
-        /// <returns>The updated CShells builder.</returns>
-        public CShellsBuilder WithConfigurationProvider(IConfiguration configuration,
-            string sectionName = CShellsOptions.SectionName)
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the configuration-based shell settings provider to the provider pipeline.
+    /// Multiple providers can be registered and will be queried in registration order.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="sectionName">The configuration section name (default: "CShells").</param>
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithConfigurationProvider(this CShellsBuilder builder, IConfiguration configuration,
+        string sectionName = CShellsOptions.SectionName)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(configuration);
+
+        builder.RegisterProvider((_, providers) =>
         {
-            Guard.Against.Null(builder);
-            Guard.Against.Null(configuration);
+            providers.Add(new ConfigurationShellSettingsProvider(configuration, sectionName));
+        });
 
-            builder.RegisterProvider((_, providers) =>
-            {
-                providers.Add(new ConfigurationShellSettingsProvider(configuration, sectionName));
-            });
+        return builder;
+    }
 
-            return builder;
-        }
+    /// <summary>
+    /// Appends an explicit assembly contribution for shell feature discovery.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="assemblies">The assemblies to scan for shell features.</param>
+    /// <returns>The updated CShells builder.</returns>
+    /// <remarks>
+    /// <para>
+    /// Every call appends another provider registration. Later calls do not replace earlier ones.
+    /// </para>
+    /// <para>
+    /// Passing an empty array is valid and still switches CShells into explicit feature-assembly provider mode.
+    /// </para>
+    /// </remarks>
+    public static CShellsBuilder FromAssemblies(this CShellsBuilder builder, params Assembly[] assemblies)
+    {
+        Guard.Against.Null(builder);
 
-        /// <summary>
-        /// Configures the shell resolver strategy pipeline with explicit control over which strategies
-        /// are registered and their execution order.
-        /// </summary>
-        /// <param name="configure">Configuration action for the resolver pipeline.</param>
-        /// <returns>The updated CShells builder.</returns>
-        /// <remarks>
-        /// When this method is called, it replaces the default resolver strategy registration behavior.
-        /// Use this for advanced scenarios where you need full control over the resolver pipeline.
-        /// For common scenarios, consider using convenience methods like <c>WithWebRouting</c> or <c>WithDefaultResolver</c>.
-        /// </remarks>
-        /// <example>
-        /// <code>
-        /// builder.AddCShells(shells => shells
-        ///     .ConfigureResolverPipeline(pipeline => pipeline
-        ///         .Use&lt;WebRoutingShellResolver&gt;(order: 0)
-        ///         .Use&lt;ClaimsBasedResolver&gt;(order: 50)
-        ///         .UseFallback&lt;DefaultShellResolverStrategy&gt;()
-        ///     )
-        /// );
-        /// </code>
-        /// </example>
-        public CShellsBuilder ConfigureResolverPipeline(Action<ResolverPipelineBuilder> configure)
-        {
-            Guard.Against.Null(builder);
-            Guard.Against.Null(configure);
+        var configuredAssemblies = Guard.Against.Null(assemblies)
+            .Select((assembly, index) => assembly ?? throw new ArgumentException($"Explicit feature assembly at index {index} cannot be null.", nameof(assemblies)))
+            .ToArray();
 
-            var pipelineBuilder = new ResolverPipelineBuilder(builder.Services);
-            configure(pipelineBuilder);
-            pipelineBuilder.Build();
+        builder.RegisterFeatureAssemblyProvider(_ => new ExplicitFeatureAssemblyProvider(configuredAssemblies));
 
-            return builder;
-        }
+        return builder;
+    }
 
-        /// <summary>
-        /// Configures the shell resolver to use the default fallback strategy.
-        /// This strategy always resolves to a shell with Id "Default".
-        /// </summary>
-        /// <returns>The updated CShells builder.</returns>
-        /// <remarks>
-        /// This is a convenience method that configures the resolver pipeline with just the <see cref="DefaultShellResolverStrategy"/>.
-        /// It's typically used in non-web scenarios where simple default shell resolution is sufficient.
-        /// </remarks>
-        public CShellsBuilder WithDefaultResolver()
-        {
-            Guard.Against.Null(builder);
+    /// <summary>
+    /// Appends the built-in host-derived assembly contribution for shell feature discovery.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <returns>The updated CShells builder.</returns>
+    /// <remarks>
+    /// The host-derived assembly set matches the default feature discovery behavior used when no assembly-source methods are called.
+    /// </remarks>
+    public static CShellsBuilder FromHostAssemblies(this CShellsBuilder builder)
+    {
+        Guard.Against.Null(builder);
 
-            return builder.ConfigureResolverPipeline(pipeline => pipeline
-                .Use<DefaultShellResolverStrategy>());
-        }
+        builder.RegisterFeatureAssemblyProvider(_ => new HostFeatureAssemblyProvider());
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Appends a custom feature assembly provider that will be resolved from the root application service provider.
+    /// </summary>
+    /// <typeparam name="TProvider">The custom provider type.</typeparam>
+    /// <param name="builder">The CShells builder.</param>
+    /// <returns>The updated CShells builder.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <typeparamref name="TProvider"/> cannot be resolved from the root application service provider.
+    /// </exception>
+    public static CShellsBuilder WithAssemblyProvider<TProvider>(this CShellsBuilder builder)
+        where TProvider : class, IFeatureAssemblyProvider
+    {
+        Guard.Against.Null(builder);
+
+        builder.RegisterFeatureAssemblyProvider(sp => sp.GetService<TProvider>()
+            ?? throw new InvalidOperationException($"The feature assembly provider '{typeof(TProvider).FullName}' could not be resolved from the root application service provider. Register it before calling WithAssemblyProvider<TProvider>()."));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Appends a custom feature assembly provider instance.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="provider">The custom provider instance.</param>
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithAssemblyProvider(this CShellsBuilder builder, IFeatureAssemblyProvider provider)
+    {
+        Guard.Against.Null(builder);
+
+        var featureAssemblyProvider = Guard.Against.Null(provider);
+        builder.RegisterFeatureAssemblyProvider(_ => featureAssemblyProvider);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Appends a custom feature assembly provider using a factory evaluated against the root application service provider.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="factory">The factory used to create the custom provider.</param>
+    /// <returns>The updated CShells builder.</returns>
+    public static CShellsBuilder WithAssemblyProvider(this CShellsBuilder builder, Func<IServiceProvider, IFeatureAssemblyProvider> factory)
+    {
+        Guard.Against.Null(builder);
+
+        var providerFactory = Guard.Against.Null(factory);
+        builder.RegisterFeatureAssemblyProvider(sp => providerFactory(sp)
+            ?? throw new InvalidOperationException("The feature assembly provider factory returned null. Return a non-null provider instance."));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the shell resolver strategy pipeline with explicit control over which strategies
+    /// are registered and their execution order.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="configure">Configuration action for the resolver pipeline.</param>
+    /// <returns>The updated CShells builder.</returns>
+    /// <remarks>
+    /// When this method is called, it replaces the default resolver strategy registration behavior.
+    /// Use this for advanced scenarios where you need full control over the resolver pipeline.
+    /// For common scenarios, consider using convenience methods like <c>WithWebRouting</c> or <c>WithDefaultResolver</c>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// builder.AddCShells(shells => shells
+    ///     .ConfigureResolverPipeline(pipeline => pipeline
+    ///         .Use&lt;WebRoutingShellResolver&gt;(order: 0)
+    ///         .Use&lt;ClaimsBasedResolver&gt;(order: 50)
+    ///         .UseFallback&lt;DefaultShellResolverStrategy&gt;()
+    ///     )
+    /// );
+    /// </code>
+    /// </example>
+    public static CShellsBuilder ConfigureResolverPipeline(this CShellsBuilder builder, Action<ResolverPipelineBuilder> configure)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(configure);
+
+        var pipelineBuilder = new ResolverPipelineBuilder(builder.Services);
+        configure(pipelineBuilder);
+        pipelineBuilder.Build();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the shell resolver to use the default fallback strategy.
+    /// This strategy always resolves to a shell with Id "Default".
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <returns>The updated CShells builder.</returns>
+    /// <remarks>
+    /// This is a convenience method that configures the resolver pipeline with just the <see cref="DefaultShellResolverStrategy"/>.
+    /// It's typically used in non-web scenarios where simple default shell resolution is sufficient.
+    /// </remarks>
+    public static CShellsBuilder WithDefaultResolver(this CShellsBuilder builder)
+    {
+        Guard.Against.Null(builder);
+
+        return builder.ConfigureResolverPipeline(pipeline => pipeline
+            .Use<DefaultShellResolverStrategy>());
     }
 }

--- a/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
@@ -67,7 +67,8 @@ public static class CShellsBuilderExtensions
 
         builder.RegisterProvider((sp, providers) =>
         {
-            var provider = factory(sp);
+            var provider = factory(sp)
+                ?? throw new InvalidOperationException("The shell settings provider factory returned null.");
             providers.Add(provider);
         });
 

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,11 +1,9 @@
-using System.Reflection;
 using CShells.Configuration;
 using CShells.Features;
 using CShells.Hosting;
 using CShells.Management;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
 
 namespace CShells.DependencyInjection;
@@ -20,12 +18,10 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional configuration action to customize the CShells builder.</param>
-    /// <param name="assemblies">Optional assemblies to scan for features. If null, scans all loaded assemblies.</param>
     /// <returns>A CShells builder for further configuration.</returns>
     public static CShellsBuilder AddCShells(
         this IServiceCollection services,
-        Action<CShellsBuilder>? configure,
-        IEnumerable<Assembly>? assemblies = null)
+        Action<CShellsBuilder>? configure = null)
     {
         Guard.Against.Null(services);
 
@@ -65,6 +61,8 @@ public static class ServiceCollectionExtensions
         // Register hosted service for shell lifecycle coordination with app lifecycle
         services.AddHostedService<ShellStartupHostedService>();
 
+        var builder = new CShellsBuilder(services);
+
         // Register IShellHost using the DefaultShellHost.
         // The root IServiceProvider is passed to allow IShellFeature constructors to resolve root-level services.
         // The root IServiceCollection is passed via the accessor to enable service inheritance in shells.
@@ -79,7 +77,7 @@ public static class ServiceCollectionExtensions
             var rootServicesAccessor = sp.GetRequiredService<IRootServiceCollectionAccessor>();
             var featureFactory = sp.GetRequiredService<IShellFeatureFactory>();
             var exclusionRegistry = sp.GetRequiredService<Hosting.IShellServiceExclusionRegistry>();
-            var assembliesToScan = assemblies ?? ResolveAssembliesToScan();
+            var assembliesToScan = builder.BuildFeatureAssemblies(sp);
 
             return new DefaultShellHost(shellCache, assembliesToScan, rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, logger);
         });
@@ -89,8 +87,6 @@ public static class ServiceCollectionExtensions
 
         // Register the shell manager for runtime shell lifecycle management
         services.TryAddSingleton<IShellManager, DefaultShellManager>();
-            
-        var builder = new CShellsBuilder(services);
         
         // Register the composite shell settings provider factory immediately
         // This must be done BEFORE configure is called so that DefaultShellManager can be constructed
@@ -129,60 +125,4 @@ public static class ServiceCollectionExtensions
         return builder;
     }
     
-    static IReadOnlyCollection<Assembly> ResolveAssembliesToScan(Func<AssemblyName, bool>? filter = null)
-    {
-        var entry = Assembly.GetEntryAssembly();
-        var names = new HashSet<AssemblyName>(new AssemblyNameComparer());
-
-        if (entry is not null)
-            names.Add(entry.GetName());
-
-        var dc = DependencyContext.Default;
-        if (dc is not null)
-        {
-            foreach (var lib in dc.RuntimeLibraries)
-            {
-                foreach (var an in lib.GetDefaultAssemblyNames(dc))
-                    names.Add(an);
-            }
-        }
-
-        if (filter is not null)
-            names.RemoveWhere(n => !filter(n));
-
-        var loaded = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
-        foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
-            loaded[a.GetName().Name!] = a;
-
-        var result = new List<Assembly>();
-        foreach (var name in names)
-        {
-            if (name.Name is null)
-                continue;
-
-            if (loaded.TryGetValue(name.Name, out var alreadyLoaded))
-            {
-                result.Add(alreadyLoaded);
-                continue;
-            }
-
-            try
-            {
-                result.Add(Assembly.Load(name));
-            }
-            catch
-            {
-                // Ignore assemblies that cannot be loaded in this process (optional deps, analyzers, etc.)
-            }
-        }
-
-        return result;
-    }
-
-    sealed class AssemblyNameComparer : IEqualityComparer<AssemblyName>
-    {
-        public bool Equals(AssemblyName? x, AssemblyName? y) => StringComparer.OrdinalIgnoreCase.Equals(x?.Name, y?.Name);
-        public int GetHashCode(AssemblyName obj) => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name ?? string.Empty);
-    }
 }
-

--- a/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs
+++ b/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace CShells.Features;
+
+internal sealed class ExplicitFeatureAssemblyProvider : IFeatureAssemblyProvider
+{
+    private readonly IReadOnlyList<Assembly> _assemblies;
+
+    public ExplicitFeatureAssemblyProvider(IEnumerable<Assembly> assemblies)
+    {
+        var configuredAssemblies = Guard.Against.Null(assemblies).ToArray();
+
+        _assemblies = configuredAssemblies.Select((assembly, index) => assembly ?? throw new ArgumentException($"Explicit feature assembly at index {index} cannot be null.", nameof(assemblies)))
+            .ToArray();
+    }
+
+    public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+    {
+        Guard.Against.Null(serviceProvider);
+        return _assemblies;
+    }
+}

--- a/src/CShells/Features/FeatureAssemblyResolver.cs
+++ b/src/CShells/Features/FeatureAssemblyResolver.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+
+namespace CShells.Features;
+
+internal static class FeatureAssemblyResolver
+{
+    public static IReadOnlyCollection<Assembly> ResolveAssemblies(IEnumerable<IFeatureAssemblyProvider> providers, IServiceProvider serviceProvider)
+    {
+        var assemblyProviders = Guard.Against.Null(providers).ToArray();
+        Guard.Against.Null(serviceProvider);
+
+        var resolvedAssemblies = new List<Assembly>();
+        var seenAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var provider in assemblyProviders)
+        {
+            var assemblyProvider = Guard.Against.Null(provider);
+            var contributedAssemblies = assemblyProvider.GetAssemblies(serviceProvider)
+                ?? throw new InvalidOperationException($"The feature assembly provider '{assemblyProvider.GetType().FullName}' returned null. Providers must return a non-null sequence.");
+
+            foreach (var assembly in contributedAssemblies)
+            {
+                if (assembly is null)
+                    throw new InvalidOperationException($"The feature assembly provider '{assemblyProvider.GetType().FullName}' returned a null assembly entry. Providers must return only non-null assemblies.");
+
+                if (seenAssemblies.Add(GetAssemblyIdentity(assembly)))
+                    resolvedAssemblies.Add(assembly);
+            }
+        }
+
+        return resolvedAssemblies.AsReadOnly();
+    }
+
+    public static IReadOnlyCollection<Assembly> ResolveHostAssemblies(Func<AssemblyName, bool>? filter = null)
+    {
+        var entry = Assembly.GetEntryAssembly();
+        var names = new HashSet<AssemblyName>(new AssemblyNameComparer());
+
+        if (entry is not null)
+            names.Add(entry.GetName());
+
+        var dependencyContext = DependencyContext.Default;
+        if (dependencyContext is not null)
+        {
+            foreach (var runtimeLibrary in dependencyContext.RuntimeLibraries)
+            {
+                foreach (var assemblyName in runtimeLibrary.GetDefaultAssemblyNames(dependencyContext))
+                    names.Add(assemblyName);
+            }
+        }
+
+        if (filter is not null)
+            names.RemoveWhere(name => !filter(name));
+
+        var loadedAssemblies = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var assemblyName = assembly.GetName().Name;
+            if (!string.IsNullOrWhiteSpace(assemblyName))
+                loadedAssemblies[assemblyName] = assembly;
+        }
+
+        var result = new List<Assembly>();
+        foreach (var name in names)
+        {
+            if (name.Name is null)
+                continue;
+
+            if (loadedAssemblies.TryGetValue(name.Name, out var alreadyLoaded))
+            {
+                result.Add(alreadyLoaded);
+                continue;
+            }
+
+            try
+            {
+                result.Add(Assembly.Load(name));
+            }
+            catch
+            {
+                // Ignore assemblies that cannot be loaded in this process (optional deps, analyzers, etc.)
+            }
+        }
+
+        return result.AsReadOnly();
+    }
+
+    private static string GetAssemblyIdentity(Assembly assembly) => assembly.FullName ?? assembly.GetName().Name ?? assembly.ManifestModule.ModuleVersionId.ToString();
+
+    private sealed class AssemblyNameComparer : IEqualityComparer<AssemblyName>
+    {
+        public bool Equals(AssemblyName? x, AssemblyName? y) => StringComparer.OrdinalIgnoreCase.Equals(x?.Name, y?.Name);
+
+        public int GetHashCode(AssemblyName obj) => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name ?? string.Empty);
+    }
+}

--- a/src/CShells/Features/HostFeatureAssemblyProvider.cs
+++ b/src/CShells/Features/HostFeatureAssemblyProvider.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+
+namespace CShells.Features;
+
+internal sealed class HostFeatureAssemblyProvider : IFeatureAssemblyProvider
+{
+    public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+    {
+        Guard.Against.Null(serviceProvider);
+        return FeatureAssemblyResolver.ResolveHostAssemblies();
+    }
+}

--- a/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+using CShells.DependencyInjection;
+using CShells.Features;
+using CShells.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Integration.ShellHost;
+
+public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
+{
+    private readonly List<IAsyncDisposable> _disposables = [];
+
+    [Fact]
+    public void DefaultHostDiscovery_MatchesFromHostAssemblies()
+    {
+        var defaultProvider = BuildRootProvider(builder =>
+        {
+            builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
+        });
+        var explicitHostProvider = BuildRootProvider(builder =>
+        {
+            builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
+            CShellsBuilderExtensions.FromHostAssemblies(builder);
+        });
+
+        var defaultShell = GetShell(defaultProvider, new("Default"));
+        var explicitHostShell = GetShell(explicitHostProvider, new("Default"));
+        var defaultFeatures = defaultShell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
+        var explicitHostFeatures = explicitHostShell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
+
+        Assert.Equal(defaultFeatures.Select(feature => feature.Id), explicitHostFeatures.Select(feature => feature.Id));
+        Assert.Contains(defaultFeatures, feature => feature.Id == "Core");
+        Assert.Contains(defaultFeatures, feature => feature.Id == "Weather");
+    }
+
+    [Fact]
+    public void ExplicitAssemblyMode_DoesNotImplicitlyIncludeHostAssemblies()
+    {
+        var serviceProvider = BuildRootProvider(builder =>
+        {
+            builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
+            CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
+        });
+
+        var shellHost = serviceProvider.GetRequiredService<IShellHost>();
+        var exception = Assert.Throws<InvalidOperationException>(() => shellHost.GetShell(new("Default")));
+
+        Assert.Contains("Weather", exception.Message);
+    }
+
+    [Fact]
+    public void CustomAssemblyProvider_ComposesAdditivelyAndReceivesRootServiceProviderContext()
+    {
+        TrackingFeatureAssemblyProvider.CreatedProviders.Clear();
+        var marker = new RootMarkerService();
+        var serviceProvider = BuildRootProvider(
+            builder =>
+            {
+                builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
+                CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
+                CShellsBuilderExtensions.WithAssemblyProvider(builder, sp =>
+                {
+                    var resolvedMarker = sp.GetRequiredService<RootMarkerService>();
+                    return new TrackingFeatureAssemblyProvider([typeof(TestFixtures).Assembly], resolvedMarker);
+                });
+            },
+            services => services.AddSingleton(marker));
+
+        var shell = GetShell(serviceProvider, new("Default"));
+        var features = shell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
+
+        Assert.Contains(TrackingFeatureAssemblyProvider.CreatedProviders, provider => ReferenceEquals(provider.ResolvedMarker, marker));
+        Assert.Contains(features, feature => feature.Id == "Weather");
+        Assert.Contains(features, feature => feature.Id == "Core");
+    }
+
+    [Fact]
+    public void CustomAssemblyProvider_ComposesWithBuiltInProvidersUsingDeduplicatedDiscovery()
+    {
+        TrackingFeatureAssemblyProvider.CreatedProviders.Clear();
+        var serviceProvider = BuildRootProvider(builder =>
+        {
+            builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
+            CShellsBuilderExtensions.FromAssemblies(builder, typeof(TestFixtures).Assembly);
+            CShellsBuilderExtensions.WithAssemblyProvider(builder, new TrackingFeatureAssemblyProvider([typeof(TestFixtures).Assembly]));
+        });
+
+        var shell = GetShell(serviceProvider, new("Default"));
+        var features = shell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
+
+        Assert.Contains(features, feature => feature.Id == "Core");
+        Assert.Contains(features, feature => feature.Id == "Weather");
+        Assert.Single(features, feature => feature.Id == "Core");
+        Assert.Single(features, feature => feature.Id == "Weather");
+    }
+
+    private ServiceProvider BuildRootProvider(Action<CShellsBuilder> configure, Action<IServiceCollection>? configureServices = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        configureServices?.Invoke(services);
+        services.AddCShells(configure);
+        var serviceProvider = services.BuildServiceProvider();
+        var shellSettingsProvider = serviceProvider.GetRequiredService<CShells.Configuration.IShellSettingsProvider>();
+        var shellSettingsCache = serviceProvider.GetRequiredService<CShells.Configuration.ShellSettingsCache>();
+        shellSettingsCache.Load(shellSettingsProvider.GetShellSettingsAsync().GetAwaiter().GetResult().ToList());
+        _disposables.Add(serviceProvider);
+        return serviceProvider;
+    }
+
+    private static ShellContext GetShell(IServiceProvider serviceProvider, ShellId shellId)
+    {
+        var shellHost = serviceProvider.GetRequiredService<IShellHost>();
+        return shellHost.GetShell(shellId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        TrackingFeatureAssemblyProvider.CreatedProviders.Clear();
+
+        foreach (var disposable in _disposables)
+            await disposable.DisposeAsync();
+
+        _disposables.Clear();
+    }
+
+    private sealed class RootMarkerService;
+
+    private sealed class TrackingFeatureAssemblyProvider(IEnumerable<Assembly> assemblies, RootMarkerService? resolvedMarker = null) : IFeatureAssemblyProvider
+    {
+        public static List<TrackingFeatureAssemblyProvider> CreatedProviders { get; } = [];
+
+        public RootMarkerService? ResolvedMarker { get; } = resolvedMarker;
+
+        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+        {
+            CreatedProviders.Add(this);
+            return assemblies;
+        }
+    }
+}

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+using CShells.DependencyInjection;
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.DependencyInjection;
+
+public class CShellsBuilderAssemblySourceTests
+{
+    [Fact]
+    public void FromAssemblies_AppendsExplicitProvidersInCallOrder()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        var firstAssembly = typeof(CShellsBuilderAssemblySourceTests).Assembly;
+        var secondAssembly = typeof(CShellsBuilder).Assembly;
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.FromAssemblies(builder, firstAssembly);
+        CShellsBuilderExtensions.FromAssemblies(builder, secondAssembly);
+
+        var providers = builder.BuildFeatureAssemblyProviders(serviceProvider);
+
+        Assert.Collection(
+            providers,
+            provider => Assert.Equal(typeof(ExplicitFeatureAssemblyProvider), provider.GetType()),
+            provider => Assert.Equal(typeof(ExplicitFeatureAssemblyProvider), provider.GetType()));
+    }
+
+    [Fact]
+    public void FromAssemblies_WithEmptyInput_ActivatesExplicitModeWithoutAssemblies()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.FromAssemblies(builder);
+
+        Assert.True(builder.UsesExplicitFeatureAssemblyProviders);
+        Assert.Empty(FeatureAssemblyResolver.ResolveAssemblies(builder.BuildFeatureAssemblyProviders(serviceProvider), serviceProvider));
+    }
+
+    [Fact]
+    public void FromAssemblies_WithNullAssembly_ThrowsArgumentException()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        Assembly[] assemblies = [typeof(CShellsBuilderAssemblySourceTests).Assembly, null!];
+
+        var exception = Assert.Throws<ArgumentException>(() => CShellsBuilderExtensions.FromAssemblies(builder, assemblies));
+
+        Assert.Equal("assemblies", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_GenericOverloadResolvesProviderFromRootServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestFeatureAssemblyProvider>();
+        var builder = new CShellsBuilder(services);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider<TestFeatureAssemblyProvider>(builder);
+
+        var providers = builder.BuildFeatureAssemblyProviders(serviceProvider);
+
+        Assert.Same(serviceProvider.GetRequiredService<TestFeatureAssemblyProvider>(), Assert.Single(providers));
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_GenericOverloadThrowsWhenProviderIsMissingFromRootServiceProvider()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider<MissingFeatureAssemblyProvider>(builder);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.BuildFeatureAssemblyProviders(serviceProvider));
+
+        Assert.Contains(typeof(MissingFeatureAssemblyProvider).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_InstanceOverloadAppendsProvider()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        var provider = new DelegateFeatureAssemblyProvider(_ => [typeof(CShellsBuilderAssemblySourceTests).Assembly]);
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider(builder, provider);
+
+        Assert.Same(provider, Assert.Single(builder.BuildFeatureAssemblyProviders(serviceProvider)));
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_FactoryOverloadAppendsProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<MarkerService>();
+        var builder = new CShellsBuilder(services);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider(builder, _ => new DelegateFeatureAssemblyProvider(_ => [typeof(MarkerService).Assembly]));
+
+        var provider = Assert.IsType<DelegateFeatureAssemblyProvider>(Assert.Single(builder.BuildFeatureAssemblyProviders(serviceProvider)));
+        Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(provider.GetAssemblies(serviceProvider)));
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_InstanceOverloadGuardsNullProvider()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        var exception = Assert.Throws<ArgumentNullException>(() => CShellsBuilderExtensions.WithAssemblyProvider(builder, provider: null!));
+
+        Assert.Equal("provider", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_FactoryOverloadGuardsNullFactory()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        var exception = Assert.Throws<ArgumentNullException>(() => CShellsBuilderExtensions.WithAssemblyProvider(builder, factory: null!));
+
+        Assert.Equal("factory", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_FactoryOverloadRejectsNullProviderResults()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider(builder, _ => null!);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.BuildFeatureAssemblyProviders(serviceProvider));
+
+        Assert.Contains("returned null", exception.Message);
+    }
+
+    private sealed class MarkerService;
+
+    private sealed class MissingFeatureAssemblyProvider : IFeatureAssemblyProvider
+    {
+        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => [];
+    }
+
+    private sealed class TestFeatureAssemblyProvider : IFeatureAssemblyProvider
+    {
+        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => [typeof(CShellsBuilderAssemblySourceTests).Assembly];
+    }
+
+    private sealed class DelegateFeatureAssemblyProvider(Func<IServiceProvider, IEnumerable<Assembly>> getAssemblies) : IFeatureAssemblyProvider
+    {
+        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => getAssemblies(serviceProvider);
+    }
+}

--- a/tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs
@@ -1,0 +1,41 @@
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Features;
+
+public class FeatureAssemblyProviderTests
+{
+    [Fact]
+    public void ResolveAssemblies_AggregatesExplicitProviderContributionsInOrder()
+    {
+        var firstAssembly = typeof(FeatureAssemblyProviderTests).Assembly;
+        var secondAssembly = typeof(CShells.DependencyInjection.CShellsBuilder).Assembly;
+        IFeatureAssemblyProvider[] providers =
+        [
+            new ExplicitFeatureAssemblyProvider([firstAssembly]),
+            new ExplicitFeatureAssemblyProvider([secondAssembly])
+        ];
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var assemblies = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider);
+
+        Assert.Equal([firstAssembly, secondAssembly], assemblies);
+    }
+
+    [Fact]
+    public void ResolveAssemblies_DeduplicatesDuplicateAssemblyContributionsUsingFirstSeenOrder()
+    {
+        var firstAssembly = typeof(FeatureAssemblyProviderTests).Assembly;
+        var secondAssembly = typeof(CShells.DependencyInjection.CShellsBuilder).Assembly;
+        IFeatureAssemblyProvider[] providers =
+        [
+            new ExplicitFeatureAssemblyProvider([firstAssembly, secondAssembly]),
+            new ExplicitFeatureAssemblyProvider([secondAssembly, firstAssembly])
+        ];
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var assemblies = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider);
+
+        Assert.Equal([firstAssembly, secondAssembly], assemblies);
+    }
+}

--- a/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
@@ -1,0 +1,31 @@
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Features;
+
+public class HostFeatureAssemblyProviderTests
+{
+    [Fact]
+    public void GetAssemblies_MatchesSharedHostResolutionAlgorithm()
+    {
+        var provider = new HostFeatureAssemblyProvider();
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var expected = FeatureAssemblyResolver.ResolveHostAssemblies().Select(assembly => assembly.FullName).ToArray();
+        var actual = provider.GetAssemblies(serviceProvider).Select(assembly => assembly.FullName).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ResolveAssemblies_DeduplicatesRepeatedHostProviderContributions()
+    {
+        IFeatureAssemblyProvider[] providers = [new HostFeatureAssemblyProvider(), new HostFeatureAssemblyProvider()];
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var expected = new HostFeatureAssemblyProvider().GetAssemblies(serviceProvider).Select(assembly => assembly.FullName).Distinct().ToArray();
+        var actual = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider).Select(assembly => assembly.FullName).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/wiki/Creating-Features.md
+++ b/wiki/Creating-Features.md
@@ -272,8 +272,15 @@ public class ConditionalFeature(ShellFeatureContext context) : IShellFeature
 
 CShells scans assemblies at startup for any type that implements `IShellFeature` (or one of its sub-interfaces). No explicit registration is required.
 
-By default all loaded assemblies are scanned. Limit the scan by passing specific assemblies:
+If you do not configure an assembly-source method, CShells uses the host-derived default feature assembly set. To switch to explicit feature assembly selection, append providers fluently on `CShellsBuilder`:
 
 ```csharp
-builder.AddShells([typeof(CoreFeature).Assembly, typeof(WeatherFeature).Assembly]);
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(CoreFeature).Assembly, typeof(WeatherFeature).Assembly);
+    cshells.FromHostAssemblies();
+});
 ```
+
+You can also append custom discovery sources with `WithAssemblyProvider(...)`. All configured feature assembly providers compose additively, and duplicate assemblies are scanned only once.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -124,11 +124,17 @@ app.MapShells();
 app.Run();
 ```
 
-`AddShells()` scans all loaded assemblies for features by default. To limit the scan:
+`AddShells()` preserves the default host-derived feature assembly discovery behavior. To switch to explicit feature assembly selection:
 
 ```csharp
-builder.AddShells([typeof(CoreFeature).Assembly]);
+builder.AddShells(cshells =>
+{
+    cshells.WithConfigurationProvider(builder.Configuration);
+    cshells.FromAssemblies(typeof(CoreFeature).Assembly);
+});
 ```
+
+You can append `FromHostAssemblies()` to opt the built-in host-derived assembly set back into explicit mode, or `WithAssemblyProvider(...)` to contribute assemblies from a custom `IFeatureAssemblyProvider` implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR moves CShells feature assembly selection from trailing `AddCShells` / `AddShells` assembly arguments into a fluent, provider-based builder model.

It introduces a public `IFeatureAssemblyProvider` abstraction, a builder-managed ordered registration list, built-in host/explicit providers, a public custom-provider extension point, additive provider composition, and removal of the legacy assembly-argument API path.

## Reviewer changelog

### 1. Public API changes

- Added public `IFeatureAssemblyProvider` in `src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`
- Added fluent feature-assembly APIs on `CShellsBuilder` in `src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
  - `FromAssemblies(...)`
  - `FromHostAssemblies()`
  - `WithAssemblyProvider(...)`
  - generic root-DI overload for `WithAssemblyProvider<TProvider>()`
- Added XML docs for the new public surface

### 2. Core runtime changes

- Added builder-managed ordered feature assembly provider registrations in `src/CShells/DependencyInjection/CShellsBuilder.cs`
- Added shared aggregation/resolution helper in `src/CShells/Features/FeatureAssemblyResolver.cs`
- Added built-in providers:
  - `src/CShells/Features/HostFeatureAssemblyProvider.cs`
  - `src/CShells/Features/ExplicitFeatureAssemblyProvider.cs`
- Updated core registration flow in `src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`
  - default host-derived discovery when no assembly-source calls are made
  - explicit-provider mode once any assembly-source call is made
  - additive provider composition with deduplicated first-seen assembly ordering

### 3. ASP.NET Core surface changes

- Removed legacy assembly-argument overloads / guidance from:
  - `src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`
  - `src/CShells.AspNetCore/Extensions/ShellExtensions.cs`
- Updated ASP.NET Core guidance in `src/CShells.AspNetCore/README.md`

### 4. Breaking changes

- Removed the old trailing assembly-argument configuration path from the active API surface
- Feature-discovery assembly selection is now configured only through the fluent builder model
- Once any assembly-source method is called, discovery switches to explicit provider mode

### 5. Tests added/updated

- `tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`
- `tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs`
- `tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs`
- `tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`

Coverage includes:

- append-order semantics
- empty explicit input behavior
- null guard behavior
- default-vs-explicit host behavior
- additive built-in/custom provider composition
- root service-provider context propagation
- deduplicated discovery
- unresolved generic custom-provider resolution failures

### 6. Docs / sample updates

Updated guidance and examples to use the fluent provider model:

- `src/CShells.AspNetCore/README.md`
- `docs/getting-started.md`
- `docs/integration-patterns.md`
- `docs/multiple-shell-providers.md`
- `wiki/Getting-Started.md`
- `wiki/Creating-Features.md`
- `samples/CShells.Workbench/Program.cs`

### 7. Feature artifacts

Included the Speckit feature artifacts for this branch under:

- `specs/003-fluent-assembly-selection/`

## Validation

Implemented and validated through the feature workflow.

Reported validation results:

- `dotnet build CShells.sln --no-restore`
- `dotnet test tests/CShells.Tests/CShells.Tests.csproj --no-restore`
- Result: build succeeded, `386/386` tests passed

## Notes for reviewers

The highest-value review areas are:

1. the new explicit-vs-default discovery mode semantics
2. public API naming and XML docs
3. additive provider composition / deduplication behavior
4. legacy API removal across both core and ASP.NET Core entry points