### PR TITLE
Implement fluent builder naming matrix guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ app.Run();
 
 To switch to explicit feature assembly selection, configure it fluently on `CShellsBuilder`:
 
+Use `From*` members to select which assemblies feature discovery should scan, and `WithAssemblyProvider(...)` when you want to attach a provider that contributes assemblies.
+
 ```csharp
 builder.AddShells(cshells =>
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,6 +113,8 @@ CShells will:
 
 To switch to explicit feature assembly selection, configure it on the fluent builder:
 
+Use `From*` members to select feature-discovery sources, and `WithAssemblyProvider(...)` when attaching a provider that contributes assemblies.
+
 ```csharp
 builder.AddShells(cshells =>
 {

--- a/docs/multiple-shell-providers.md
+++ b/docs/multiple-shell-providers.md
@@ -17,6 +17,7 @@ builder.Services.AddCShells(shells =>
 ### Feature Assembly Selection
 
 Shell settings providers and feature assembly providers are configured independently.
+Use `From*` members to select assembly sources directly, and `WithAssemblyProvider(...)` to attach provider-based sources.
 
 ```csharp
 builder.Services.AddCShells(shells =>

--- a/samples/CShells.Workbench/Program.cs
+++ b/samples/CShells.Workbench/Program.cs
@@ -6,12 +6,12 @@ using CShells.Workbench.Features.Core;
 var builder = WebApplication.CreateBuilder(args);
 
 // Load shells from appsettings.json — three tenants with escalating feature tiers.
-// Configure feature discovery fluently so the features assembly is included explicitly.
+// Use From* members to select discovery sources explicitly; WithAssemblyProvider(...) is only needed when attaching a custom provider.
 builder.AddShells(cshells =>
 {
     cshells.WithConfigurationProvider(builder.Configuration);
-    cshells.FromHostAssemblies(); // Host assembly is included by default, but we call this to demonstrate fluent configuration.
-    cshells.FromAssemblies(typeof(CoreFeature).Assembly);
+    cshells.FromHostAssemblies(); // Re-include the built-in host-derived source explicitly for this sample.
+    cshells.FromAssemblies(typeof(CoreFeature).Assembly); // Add the separate features assembly as an explicit source.
 });
 
 // Background service that logs a heartbeat for each active shell every 30 s.

--- a/specs/003-fluent-assembly-selection/checklists/requirements.md
+++ b/specs/003-fluent-assembly-selection/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
 **Created**: 2026-04-11  
-**Feature**: [/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/spec.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/003-fluent-assembly-selection/spec.md)
+**Feature**: [`../spec.md`](../spec.md)
 
 ## Content Quality
 
@@ -35,7 +35,4 @@
 - Explicitly captured breaking-change policy and legacy-removal intent in `FR-014` and assumptions.
 - Included naming-focused work item in `FR-016` per request.
 - Clarifications now require an assembly provider interface, a builder-maintained provider list, and additive provider appends for every fluent assembly-source call.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection
+- Validation iteration 2: Added the fluent builder verb matrix, explicit candidate evaluations, and preservation guidance for the approved assembly-discovery names; checklist still passes.

--- a/specs/003-fluent-assembly-selection/contracts/feature-assembly-provider-contract.md
+++ b/specs/003-fluent-assembly-selection/contracts/feature-assembly-provider-contract.md
@@ -104,7 +104,3 @@ The previous non-fluent assembly-argument approach is removed.
 - Public examples must use fluent assembly-source configuration only.
 - Legacy `AddCShells` / `AddShells` overloads that accept assemblies as direct method arguments are not retained as supported API.
 - Migration guidance must map legacy assembly-argument examples to the new fluent equivalents.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection

--- a/specs/003-fluent-assembly-selection/contracts/naming-decision-record.md
+++ b/specs/003-fluent-assembly-selection/contracts/naming-decision-record.md
@@ -1,5 +1,12 @@
 # Naming Decision Record: Fluent Assembly Source Selection
 
+## Fluent Builder Naming Matrix
+
+| Builder action | Verb family | Use when | Approved examples | Why |
+|---|---|---|---|---|
+| Source selection | `From*` | The method describes where feature discovery gets assemblies from. | `FromAssemblies(...)`, `FromHostAssemblies()` | `From*` reads as a discovery-source selector and keeps additive source configuration mentally separate from provider attachment. |
+| Provider attachment | `With*` | The method attaches a provider object, factory, or type to extend discovery behavior. | `WithAssemblyProvider(...)` | `With*` matches existing CShells builder vocabulary for attaching extensibility components. |
+
 ## Approved Naming Set
 
 | Area | Approved Name | Why it was chosen |
@@ -13,6 +20,18 @@
 | Internal builder registration field | `_featureAssemblyProviderRegistrations` | Describes stored contents precisely, reflects the registration-based design, and follows the constitution's private-field naming convention. |
 | Internal aggregation helper | `FeatureAssemblyResolver` | Describes a helper that materializes the effective assembly set from the configured providers. |
 
+## Candidate Evaluation
+
+| Candidate | Outcome | Verb family fit | Rationale |
+|---|---|---|---|
+| `FromAssemblies(...)` | Approved | Correct | Selects an explicit assembly discovery source, so it belongs in the `From*` family. |
+| `FromHostAssemblies()` | Approved | Correct | Selects the host-derived discovery source explicitly while matching default-behavior semantics. |
+| `WithAssemblies(...)` | Rejected | Incorrect | Uses the provider-attachment family for a source-selection action, which blurs the naming matrix. |
+| `WithHostAssemblies()` | Rejected | Incorrect | Has the same verb-family mismatch as `WithAssemblies(...)` and obscures that host assemblies are a discovery source. |
+| `AddAssemblies(...)` | Rejected | Weak | Communicates raw list mutation more than discovery-source selection, so it is less precise than `FromAssemblies(...)`. |
+| `AddHostAssemblies()` | Rejected | Weak | Suggests direct collection mutation rather than choosing the built-in host-derived discovery source. |
+| `WithAssemblyProvider(...)` | Approved | Correct | Attaches a provider abstraction, so it naturally belongs in the `With*` family. |
+
 ## Rejected Alternatives
 
 | Rejected Name | Rejection Reason |
@@ -20,7 +39,9 @@
 | `UseAssemblies(...)` | `Use*` commonly suggests replacement semantics, which conflicts with additive composition. |
 | `UseHostAssemblies()` | Same replacement-semantics concern as `UseAssemblies(...)`. |
 | `WithAssemblies(...)` | Too ambiguous between mutation of a single property and appending a new discovery source. |
+| `WithHostAssemblies()` | Uses the provider-attachment family for a source-selection action and hides the source-selection intent. |
 | `AddAssemblies(...)` | Reads like direct list mutation rather than provider-backed source configuration. |
+| `AddHostAssemblies()` | Reads like direct list mutation rather than explicit selection of the built-in host-derived source. |
 | `IAssemblySourceProvider` | Redundant and less natural than `IFeatureAssemblyProvider`. |
 | `IDiscoveryAssemblyProvider` | Accurate but less user-friendly and less aligned with the existing `CShells.Features` vocabulary. |
 | `DefaultAssemblyProvider` | Too vague; it hides the crucial host-derived behavior. |
@@ -29,10 +50,8 @@
 ## Naming Usage Rules
 
 - Public docs and examples should use the approved fluent method names only.
+- Public docs and examples should apply the `From*` versus `With*` matrix consistently when describing future builder verbs around assembly discovery.
 - Implementation, tests, and docs should not mix “source” and “provider” terminology inconsistently for the same concept.
 - The host-derived path should be described as “host assemblies” rather than “default assemblies” whenever the behavior must be explicit.
 - The old assembly-argument API names remain only in migration context, not as active recommendations.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection
+- Already approved names should be preserved unless a stronger documented alternative clearly improves both clarity and matrix consistency.

--- a/specs/003-fluent-assembly-selection/data-model.md
+++ b/specs/003-fluent-assembly-selection/data-model.md
@@ -110,16 +110,17 @@ Represents the approved terminology for the new public API surface.
 
 ### Fields
 
+- `VerbFamilyRules`: the approved mapping between source-selection actions and `From*`, and provider-attachment actions and `With*`
 - `ProviderInterfaceName`: approved interface name for the public extension point
 - `BuilderMethodNames`: approved fluent names for built-in and custom provider registration
 - `BuiltInProviderNames`: approved implementation names for the built-in host and explicit providers
+- `CandidateEvaluations`: the approved or rejected outcome for each reviewed method-name candidate
 - `RejectedAlternatives`: deprecated or rejected naming candidates with rationale
 
 ### Validation Rules
 
+- Source-selection methods must use the `From*` family unless a stronger documented alternative is explicitly approved.
+- Provider-attachment methods must use the `With*` family unless a stronger documented alternative is explicitly approved.
+- The candidate evaluation set must include `FromAssemblies`, `FromHostAssemblies`, `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, `AddHostAssemblies`, and `WithAssemblyProvider`.
 - One approved naming set must be used consistently across contracts, implementation, tests, and docs.
 - Rejected names must not remain in public examples or documentation after the feature ships.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection

--- a/specs/003-fluent-assembly-selection/quickstart.md
+++ b/specs/003-fluent-assembly-selection/quickstart.md
@@ -15,6 +15,7 @@
 ## 2. Move assembly-source configuration onto `CShellsBuilder`
 
 - Extend the core builder fluent surface with `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- Apply the naming matrix consistently: use `From*` for discovery-source selection and `With*` for provider attachment.
 - Store appended provider registrations on the builder in call order.
 - Keep this provider list independent from the shell-settings provider pipeline.
 
@@ -51,7 +52,7 @@
 
 - Update `README.md` examples that currently pass assemblies directly to `AddShells` or `AddCShells`.
 - Update relevant docs in `docs/` and mirrored wiki content if it repeats the old pattern.
-- Reflect the approved naming set from the naming decision record consistently.
+- Reflect the approved naming set and verb-family matrix from the naming decision record consistently.
 
 ## 8. Validate behavior
 
@@ -69,7 +70,4 @@ dotnet test tests/CShells.Tests/
 - Any explicit assembly-source call switches CShells into explicit-provider mode.
 - Host-derived, explicit, and custom providers compose additively and discover expected features exactly once.
 - Public examples no longer advertise the removed assembly-argument overloads.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection
+- Naming guidance clearly distinguishes `From*` source-selection methods from `With*` provider-attachment methods.

--- a/specs/003-fluent-assembly-selection/research.md
+++ b/specs/003-fluent-assembly-selection/research.md
@@ -42,14 +42,26 @@ This approach also resolves the empty-input edge case cleanly. An empty explicit
 - Deduplicate providers instead of assemblies: rejected because different providers may legitimately contribute overlapping assemblies.
 - Sort assemblies alphabetically before discovery: rejected because it obscures registration-order behavior without any product requirement.
 
-## Decision: Finalize the fluent naming set as `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`
+## Decision: Encode fluent builder naming as a verb-family matrix
 
-**Rationale**: The spec calls out a naming-focused work item and emphasizes mentally consistent terminology. `FromAssemblies(...)` communicates “append an explicit assembly contribution,” `FromHostAssemblies()` communicates “append the built-in host-derived contribution,” and `WithAssemblyProvider(...)` matches existing builder vocabulary for appending extensibility components. The interface name `IFeatureAssemblyProvider` ties the abstraction to feature discovery and avoids confusion with shell-settings providers.
+**Rationale**: The updated spec needs more than a one-off method-name choice; it needs a reusable naming rule for the builder surface around assembly discovery. `From*` best communicates source selection because it answers “where do discovered assemblies come from?” `With*` best communicates provider attachment because it answers “what provider component is being attached to the builder?” Encoding that split as a naming matrix keeps the assembly discovery API aligned with existing CShells builder vocabulary and gives future reviews a stable rule to apply.
 
 **Alternatives considered**:
 
+- Use `With*` for both source selection and provider attachment: rejected because it blurs the difference between selecting inputs and attaching extensibility components.
+- Use `Add*` for additive source selection: rejected because it sounds like raw list mutation rather than a semantic source-selection step.
+- Keep naming as an informal preference instead of a matrix: rejected because future builder additions would lack an explicit rule for consistency.
+
+## Decision: Preserve `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` as the approved naming set
+
+**Rationale**: When the naming matrix is applied to the candidate set, the current approved names remain the clearest fit. `FromAssemblies(...)` and `FromHostAssemblies()` are source-selection calls, so they belong in the `From*` family. `WithAssemblyProvider(...)` attaches a provider abstraction, so it belongs in the `With*` family. Preserving these names avoids churn while still documenting why nearby alternatives such as `WithAssemblies(...)` and `AddAssemblies(...)` are less precise.
+
+**Alternatives considered**:
+
+- `WithAssemblies(...)`: rejected because it uses the provider-attachment family for a source-selection action.
+- `WithHostAssemblies()`: rejected for the same reason as `WithAssemblies(...)`; it obscures the fact that the method selects a discovery source.
+- `AddAssemblies(...)` / `AddHostAssemblies()`: rejected because `Add*` emphasizes collection mutation instead of the source-selection concept.
 - `UseAssemblies(...)` / `UseHostAssemblies()`: rejected because `Use*` often implies replacement semantics, which conflicts with additive composition.
-- `WithAssemblies(...)`: rejected because it reads more like an in-place property setter than a source-selection operation.
 - `IAssemblySourceProvider`: rejected because the double abstraction term is more awkward and less discoverable than `IFeatureAssemblyProvider`.
 
 ## Decision: Remove the legacy non-fluent assembly-argument APIs instead of preserving compatibility shims
@@ -71,7 +83,3 @@ This approach also resolves the empty-input edge case cleanly. An empty explicit
 - Documentation-only validation: rejected because additive composition and explicit-mode behavior are easy to regress without tests.
 - Unit tests only: rejected because the feature spans builder wiring, host registration, and ASP.NET Core entry points.
 - Leave examples unchanged until implementation is complete: rejected because the new public API surface must be unambiguous before the next Speckit step.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection

--- a/specs/003-fluent-assembly-selection/spec.md
+++ b/specs/003-fluent-assembly-selection/spec.md
@@ -17,6 +17,8 @@
 ### Session 2026-04-12
 
 - Q: Should the new assembly provider abstraction be a supported public extension point for custom implementations? → A: Yes. Developers should be able to supply their own custom assembly provider implementations through a public builder API in addition to the built-in convenience methods.
+- Q: How should the fluent builder verb system distinguish assembly source selection from provider attachment? → A: Methods that describe where discovery gets assemblies from stay in the `From*` family, while methods that attach provider instances, factories, or types stay in the `With*` family.
+- Q: Should the already approved assembly discovery names change as part of the naming review? → A: No. Preserve `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` unless a stronger alternative is documented and justified through the naming matrix.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -73,16 +75,19 @@ As an application developer, I can append my own assembly provider implementatio
 
 ### User Story 4 - Adopt Clear Naming for the New API Surface (Priority: P4)
 
-As a maintainer, I can apply clear and mentally consistent names for this enhancement so developers understand intent without reading implementation details.
+As a maintainer, I can apply a clear naming matrix for the fluent builder surface so developers can distinguish source-selection calls from provider-attachment calls without reading implementation details.
 
 **Why this priority**: Naming quality strongly affects API discoverability, onboarding, and long-term maintainability.
 
-**Independent Test**: Review the finalized naming set in a short design pass and verify each name is unambiguous, consistent, and reflected in developer-facing usage examples.
+**Independent Test**: Review the finalized naming matrix and candidate evaluation record, then verify each approved name matches the correct verb family and is reflected consistently in developer-facing usage examples.
 
 **Acceptance Scenarios**:
 
 1. **Given** the new fluent assembly-source capability, **When** naming review is completed, **Then** one approved naming set is selected and used consistently across the exposed API.
 2. **Given** obsolete naming candidates, **When** the enhancement is finalized, **Then** those candidates are not left in developer-facing API surface or examples.
+3. **Given** a method that describes where discovery gets assemblies from, **When** the naming matrix is applied, **Then** the method remains in the `From*` family.
+4. **Given** a method that attaches a provider object, factory, or type, **When** the naming matrix is applied, **Then** the method remains in the `With*` family.
+5. **Given** the candidates `FromAssemblies`, `FromHostAssemblies`, `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, `AddHostAssemblies`, and `WithAssemblyProvider`, **When** the naming review is recorded, **Then** each candidate has an approval or rejection rationale tied to the verb-family matrix.
 
 ### Edge Cases
 
@@ -95,6 +100,7 @@ As a maintainer, I can apply clear and mentally consistent names for this enhanc
 - Host assembly source is combined with custom sources in different call orders; resulting discovered feature set remains equivalent.
 - The builder receives many assembly source calls; provider registrations are all retained in call order and none are silently replaced.
 - A custom provider returns an assembly already contributed by another provider; discovery remains deduplicated.
+- A naming candidate uses `With*` for a source-selection action or `From*` for provider attachment; the naming matrix must reject the candidate unless a stronger rationale is documented.
 
 ## Requirements *(mandatory)*
 
@@ -117,8 +123,11 @@ As a maintainer, I can apply clear and mentally consistent names for this enhanc
 - **FR-015**: When explicit, host-derived, and custom providers are combined, discovery MUST use the deduplicated union of all contributed assemblies.
 - **FR-016**: The previous non-fluent assembly argument approach MUST be removed; maintaining backward compatibility with legacy overloads is out of scope and prohibited.
 - **FR-017**: Null assembly-source inputs, null custom provider registrations, null custom provider factories, and null custom provider output sequences MUST be rejected with clear guidance; empty explicit inputs MUST be accepted as zero-contribution additions that still participate in explicit-source mode.
-- **FR-018**: The enhancement MUST include a naming decision work item that results in clean, mentally consistent terminology for the provider abstraction, builder members, fluent methods, and custom-provider entry point.
-- **FR-019**: Developer-facing usage guidance and examples for shell setup MUST reflect the new fluent assembly-source pattern, the additive provider model, and the public custom-provider extension point only.
+- **FR-018**: The enhancement MUST include a naming decision work item that defines a fluent builder naming matrix for source-selection verbs versus provider-attachment verbs.
+- **FR-019**: The naming matrix MUST state that methods describing where discovery gets assemblies from use the `From*` family, while methods attaching provider instances, factories, or types use the `With*` family.
+- **FR-020**: The naming decision record MUST explicitly evaluate `FromAssemblies`, `FromHostAssemblies`, `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, `AddHostAssemblies`, and `WithAssemblyProvider`, and MUST record approval or rejection rationale for each candidate.
+- **FR-021**: Unless the naming matrix documents a stronger justified alternative, the approved assembly-discovery terminology MUST remain `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- **FR-022**: Developer-facing usage guidance and examples for shell setup MUST reflect the new fluent assembly-source pattern, the additive provider model, the public custom-provider extension point, and the approved verb-family matrix only.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -129,6 +138,7 @@ As a maintainer, I can apply clear and mentally consistent names for this enhanc
 - **ExplicitFeatureAssemblyProvider**: The built-in provider that returns a specific assembly set supplied during its creation.
 - **Custom `IFeatureAssemblyProvider` Implementation**: Any developer-supplied implementation of the provider interface appended through the public builder API.
 - **Naming Decision Record**: The accepted terminology for this enhancement, including selected method names and rejected alternatives with rationale.
+- **Fluent Builder Naming Matrix**: The approved mapping between builder action types and verb families, used to keep source-selection terminology separate from provider-attachment terminology.
 
 ### Assumptions
 
@@ -138,6 +148,7 @@ As a maintainer, I can apply clear and mentally consistent names for this enhanc
 - Each assembly-source call contributes through one or more provider registrations, and the final discovery set is built by concatenating all provider contributions before deduplication.
 - Custom providers are a supported public extension mechanism and are expected to follow the same additive and deduplicated discovery semantics as built-in providers.
 - Breaking changes are intentionally acceptable for this enhancement; migration support for legacy overloads is not required.
+- The fluent builder naming review should preserve already approved assembly-discovery names unless a more compelling alternative clearly improves clarity and consistency.
 
 ## Success Criteria *(mandatory)*
 
@@ -148,4 +159,4 @@ As a maintainer, I can apply clear and mentally consistent names for this enhanc
 - **SC-003**: In side-by-side verification, default (no explicit source directives) and explicit host-source configuration produce equivalent host-derived discovery outcomes in all defined test scenarios.
 - **SC-004**: In builder-behavior verification, every assembly-source fluent call results in an added provider entry and no previously configured provider entries are lost.
 - **SC-005**: In extension-point verification, custom providers appended through the public builder API contribute assemblies successfully in 100% of defined test scenarios.
-- **SC-006**: During internal API review, all new assembly-source and provider-related names are approved in one naming decision record with no unresolved naming conflicts.
+- **SC-006**: During internal API review, all seven evaluated naming candidates are classified in one naming decision record with no unresolved naming conflicts.

--- a/specs/003-fluent-assembly-selection/tasks.md
+++ b/specs/003-fluent-assembly-selection/tasks.md
@@ -225,7 +225,4 @@ Task: "Remove rejected or legacy naming from entry-point XML docs in src/CShells
 - `[US1]`, `[US2]`, `[US3]`, and `[US4]` map directly to the prioritized stories in the feature spec.
 - The task order intentionally reflects the finalized design: public `IFeatureAssemblyProvider`, builder-managed ordered provider list, built-in host and explicit providers, public custom-provider entry point, additive composition semantics, explicit-mode/default-host behavior, legacy API removal, tests, docs, and naming consistency.
 - Keep the implementation focused on the listed files; avoid introducing alternative assembly-selection models or compatibility shims for removed overloads.
-<<<<<<< HEAD
-=======
-
->>>>>>> 003-fluent-assembly-selection
+- User Story 4 now depends on the fluent builder naming matrix, so any naming-related implementation or documentation task should preserve the `From*` versus `With*` distinction.

--- a/specs/004-builder-verb-naming/checklists/requirements.md
+++ b/specs/004-builder-verb-naming/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Fluent Builder Naming Matrix
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-12  
+**Feature**: [`../spec.md`](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: All checklist items pass after updating the spec from design-only to implementation-backed scope.
+- The spec now includes both the approved naming matrix and an explicit candidate evaluation record for `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` plus rejected alternatives.
+- References to the approved public method names are intentional because the feature scope is to preserve and protect that public naming surface; the spec avoids low-level implementation mechanics or framework-specific instructions.
+- The implementation scope is intentionally minimal and grounded in current repository reality: keep the approved names, add guardrails against naming drift, and align samples, documentation, and comments where needed.
+- The update remains aligned to the prior-art decision in `specs/003-fluent-assembly-selection` while enabling real repository changes in code, tests, samples, and documentation during downstream planning.
+

--- a/specs/004-builder-verb-naming/contracts/builder-naming-matrix.md
+++ b/specs/004-builder-verb-naming/contracts/builder-naming-matrix.md
@@ -1,0 +1,71 @@
+# Contract: Fluent Builder Naming Matrix
+
+## Scope
+
+This contract defines the implementation-backed naming obligations for the CShells assembly-discovery builder surface.
+
+It governs:
+
+- the shipped public method groups on `CShellsBuilderExtensions`,
+- the regression checks that protect those method groups,
+- the in-scope docs, samples, and comments that describe assembly-discovery configuration, and
+- future review of changes that could introduce competing public names for the same responsibilities.
+
+`specs/003-fluent-assembly-selection` remains the prior-art baseline. Feature `004-builder-verb-naming` preserves and protects that approved outcome in the repository.
+
+## Naming Matrix
+
+| Builder responsibility | Approved verb family | Use when | Approved examples | Rejection rule |
+|---|---|---|---|---|
+| Source selection | `From*` | The method tells CShells where feature discovery gets assemblies from. | `FromAssemblies(...)`, `FromHostAssemblies()` | Reject names that imply provider attachment, raw collection mutation, or weaker source-selection intent. |
+| Provider attachment | `With*` | The method attaches a provider instance, factory, or provider type that contributes assemblies. | `WithAssemblyProvider(...)` | Reject names that misrepresent provider attachment as direct source selection or introduce alternative verbs for the same attachment role. |
+
+## Approved Public Naming Surface
+
+| Area | Approved name | Allowed shape | Why |
+|---|---|---|---|
+| Explicit assembly source | `FromAssemblies(...)` | Public method group on `CShellsBuilderExtensions` | Selects developer-supplied discovery sources and belongs to the `From*` family. |
+| Host-derived assembly source | `FromHostAssemblies()` | Public method group on `CShellsBuilderExtensions` | Selects the built-in host-derived discovery source and belongs to the `From*` family. |
+| Custom provider attachment | `WithAssemblyProvider(...)` | Public method family that may expose generic, instance, and factory overloads | Attaches provider-based extensibility and belongs to the `With*` family. |
+
+## Required Candidate Evaluation
+
+| Candidate | Outcome | Matrix fit | Repository implication |
+|---|---|---|---|
+| `FromAssemblies(...)` | Approved | Correct | Must remain publicly available. |
+| `FromHostAssemblies()` | Approved | Correct | Must remain publicly available. |
+| `WithAssemblies(...)` | Rejected | Incorrect | Must not be introduced as a public alias or replacement for source selection. |
+| `WithHostAssemblies()` | Rejected | Incorrect | Must not be introduced as a public alias or replacement for host-derived source selection. |
+| `AddAssemblies(...)` | Rejected | Weak | Must not be introduced as a public alias or replacement for explicit source selection. |
+| `AddHostAssemblies()` | Rejected | Weak | Must not be introduced as a public alias or replacement for host-derived source selection. |
+| `WithAssemblyProvider(...)` | Approved | Correct | Must remain the public provider-attachment family, including valid overload variations. |
+
+## Verification Contract
+
+1. The repository must contain automated or equivalently enforceable verification that the approved method groups remain present.
+2. That verification must fail if an approved method name is removed, renamed, or replaced by a rejected competing public name for the same assembly-discovery responsibility.
+3. Verification must treat `WithAssemblyProvider(...)` as one approved naming family and allow legitimate overload variations under that exact name.
+4. Verification should live in the existing repository testing workflow rather than introducing heavyweight tooling unless a later feature explicitly approves that complexity.
+
+## Guidance Alignment Contract
+
+The following asset categories are in scope when they describe assembly discovery:
+
+- root or package `README.md` files,
+- `docs/` and `wiki/` guidance,
+- sample application setup code,
+- XML documentation or explanatory comments near public entry points.
+
+When those assets mention assembly-discovery builder configuration, they must:
+
+- use `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` consistently,
+- reflect `From*` for source selection and `With*` for provider attachment, and
+- avoid teaching rejected alternatives such as `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, or `AddHostAssemblies` as valid public names.
+
+## Review Rules
+
+- Preserve `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` as the fixed approved terminology for feature `004-builder-verb-naming`.
+- Do not approve a change that adds competing public aliases for the same assembly-discovery responsibilities, even if the approved names remain available.
+- Keep implementation scope minimal: protect the current public surface, add regression guardrails, and align only already relevant guidance assets.
+- Any effort to reconsider the approved names or expand the matrix to unrelated builder domains requires a separate approved feature.
+

--- a/specs/004-builder-verb-naming/data-model.md
+++ b/specs/004-builder-verb-naming/data-model.md
@@ -1,0 +1,130 @@
+# Data Model: Fluent Builder Naming Matrix
+
+## Fluent Builder Naming Matrix
+
+Represents the decision table that maps an assembly-discovery builder responsibility to the approved verb family that must remain in the repository.
+
+### Fields
+
+- `Responsibility`: the builder responsibility being named, such as source selection or provider attachment
+- `ApprovedVerbFamily`: the required leading verb family, such as `From*` or `With*`
+- `IntentStatement`: the plain-language rule that explains why the family applies
+- `ApprovedExamples`: the shipped examples that currently satisfy the rule
+- `RejectedPatterns`: the competing verb families or aliases that violate the rule
+
+### Validation Rules
+
+- Source-selection responsibilities must use the `From*` family for this feature.
+- Provider-attachment responsibilities must use the `With*` family for this feature.
+- The matrix must remain stable for the approved assembly-discovery surface throughout feature 004 implementation.
+- New exceptions or alternate verb families are out of scope and require a separate approved feature.
+
+## Approved Naming Surface
+
+Represents the public assembly-discovery method groups that must stay shipped and protected.
+
+### Fields
+
+- `ContainingType`: the public type that exposes the methods, currently `CShellsBuilderExtensions`
+- `ApprovedSourceSelectionMethods`: `FromAssemblies(...)` and `FromHostAssemblies()`
+- `ApprovedProviderAttachmentMethodFamily`: `WithAssemblyProvider(...)`
+- `AllowedOverloadShapes`: the supported overload variations that may share the approved name
+- `PublicVisibility`: whether the surface is publicly reachable from the supported package entry points
+
+### Validation Rules
+
+- The approved source-selection names must remain `FromAssemblies(...)` and `FromHostAssemblies()`.
+- The approved provider-attachment family must remain `WithAssemblyProvider(...)` for all supported overloads.
+- The surface must not gain competing public replacement names such as `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, or `AddHostAssemblies` for the same responsibilities.
+- Overload count may change only if the approved `WithAssemblyProvider(...)` family name is preserved.
+
+## Candidate Name Evaluation
+
+Represents the recorded review outcome for one candidate fluent builder name.
+
+### Fields
+
+- `CandidateName`: the proposed or observed public name under review
+- `Responsibility`: the assembly-discovery responsibility the candidate attempts to represent
+- `ObservedVerbFamily`: the family implied by the candidate name
+- `Outcome`: `Approved` or `Rejected`
+- `Rationale`: why the candidate preserves or violates the matrix
+- `RegressionRisk`: whether the candidate would be a harmless observation, a conflicting alias, or a breaking replacement
+
+### State Transitions
+
+- `Observed` → `Approved`: the candidate matches the approved matrix and the fixed repository baseline
+- `Observed` → `Rejected`: the candidate conflicts with the matrix, introduces drift, or weakens terminology
+
+### Validation Rules
+
+- The required evaluation set must include `FromAssemblies`, `FromHostAssemblies`, `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, `AddHostAssemblies`, and `WithAssemblyProvider`.
+- Every evaluation must record both an outcome and a rationale.
+- Rejected candidates must explain whether the problem is wrong verb family, weaker intent, or competing public aliasing.
+
+## Naming Guardrail
+
+Represents the repository-level verification that protects the approved naming surface.
+
+### Fields
+
+- `GuardrailType`: the verification approach, expected to be a focused xUnit public-surface test or equivalent repository-native check
+- `InspectionTarget`: the API surface or files being validated
+- `ApprovedMethodFamilies`: the method groups that must be present
+- `RejectedMethodNames`: the method names that must not appear as competing public entry points
+- `AllowedVariations`: the overload or signature differences that are acceptable while retaining the approved family
+- `FailureMessageExpectation`: the review signal produced when drift is detected
+
+### State Transitions
+
+- `Planned` → `Implemented`: the guardrail is added to the repository
+- `Implemented` → `Passing`: the approved naming surface is intact
+- `Implemented` → `Failing`: a required name is missing or a rejected competing name is introduced
+
+### Validation Rules
+
+- The guardrail must pass when `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` remain present.
+- The guardrail must fail if the approved names are removed, renamed, or replaced by rejected competing names for the same responsibilities.
+- The guardrail must not fail merely because `WithAssemblyProvider(...)` has multiple valid overloads.
+
+## Developer-Facing Guidance Asset
+
+Represents one in-scope doc, sample, or comment source that teaches the assembly-discovery builder vocabulary.
+
+### Fields
+
+- `AssetPath`: the file path of the doc, sample, or code comment host
+- `AssetType`: `README`, `Doc`, `Wiki`, `Sample`, or `XMLComment`
+- `ExpectedApprovedNames`: the names that should appear when the asset describes assembly discovery
+- `ExpectedMatrixExplanation`: whether the asset should mention source selection versus provider attachment
+- `ReviewStatus`: `Unreviewed`, `Aligned`, or `NeedsUpdate`
+
+### State Transitions
+
+- `Unreviewed` → `Aligned`: the asset already uses the approved names and rationale
+- `Unreviewed` → `NeedsUpdate`: the asset contains stale or conflicting terminology
+- `NeedsUpdate` → `Aligned`: the terminology is corrected without unrelated rewriting
+
+### Validation Rules
+
+- Assets that describe assembly discovery must use `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` consistently.
+- Assets must not teach rejected competing names for in-scope responsibilities.
+- Only assets already describing assembly discovery are in scope for this feature.
+
+## Prior-Art Feature Context
+
+Represents the earlier feature set that established the approved naming direction now being protected.
+
+### Fields
+
+- `ReferenceFeature`: `003-fluent-assembly-selection`
+- `ReferenceArtifacts`: the 003 plan, research, quickstart, and contracts that established the baseline
+- `ApprovedBaseline`: the approved names inherited by 004
+- `AlignmentOutcome`: whether 004 preserves, refines, or overturns the prior-art baseline
+
+### Validation Rules
+
+- Feature 004 must treat 003 as prior art, not a competing design path.
+- The approved baseline inherited from 003 must remain preserved for 004.
+- Any attempt to overturn the 003-approved names is out of scope for this feature.
+

--- a/specs/004-builder-verb-naming/plan.md
+++ b/specs/004-builder-verb-naming/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Fluent Builder Naming Matrix
+
+**Branch**: `004-builder-verb-naming` | **Date**: 2026-04-12 | **Spec**: `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/004-builder-verb-naming/spec.md`
+**Input**: Feature specification from `/specs/004-builder-verb-naming/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Keep feature `004-builder-verb-naming` as the decision record for the fluent builder naming matrix, but update its execution scope so it also protects the already shipped assembly-discovery API in the repository. The implementation should preserve `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` as the fixed public naming surface in `CShellsBuilderExtensions`, add minimal regression guardrails that fail if those names drift or if rejected replacement verbs are introduced, and audit the small set of in-scope docs, samples, and comments that explain assembly discovery so they continue to reinforce the same `From*` versus `With*` distinction.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 for implementation and xUnit tests, plus Markdown planning and documentation artifacts  
+**Primary Dependencies**: Existing public builder surface in `src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`, current assembly-source coverage in `tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs` and `tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`, prior-art feature `specs/003-fluent-assembly-selection/`, and developer guidance in `README.md`, `docs/`, `wiki/`, `samples/`, and `src/CShells.AspNetCore/`  
+**Storage**: N/A  
+**Testing**: xUnit regression guardrails for public method names and approved overload families, plus targeted review of in-scope guidance assets and reuse of existing assembly-discovery behavior tests as supporting evidence  
+**Target Platform**: Cross-platform .NET class libraries and ASP.NET Core integration guidance consumed from the main package, ASP.NET Core package, docs, wiki, and sample app  
+**Project Type**: Multi-project framework/library with tests, samples, and public markdown documentation  
+**Performance Goals**: No runtime behavior change; added verification should stay limited to startup-time test reflection and documentation review  
+**Constraints**: Preserve the approved naming matrix (`From*` for source selection, `With*` for provider attachment); keep the approved public names fixed as `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`; allow multiple valid `WithAssemblyProvider(...)` overloads without treating them as drift; avoid unrelated renames or new aliases; add no new third-party dependencies; keep scope minimal and grounded in existing repository reality  
+**Scale/Scope**: Planning artifacts in `specs/004-builder-verb-naming/`, likely implementation touch points in `src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`, a focused unit test in `tests/CShells.Tests/Unit/DependencyInjection/`, and only the guidance assets that already describe assembly discovery (`README.md`, `docs/getting-started.md`, `docs/multiple-shell-providers.md`, `src/CShells.AspNetCore/README.md`, `src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`, `src/CShells.AspNetCore/Extensions/ShellExtensions.cs`, `wiki/Getting-Started.md`, and `samples/CShells.Workbench/Program.cs` if naming guidance there needs cleanup)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Abstraction-First Architecture**: PASS. The approved public API already exists and no new public extensibility contract is required; the work is limited to preserving names, testing them, and aligning guidance.
+- **Feature Modularity**: PASS. The change scope stays inside assembly-discovery builder vocabulary and does not alter feature composition, shell isolation, or dependency semantics.
+- **Modern C# Style**: PASS. Any implementation work is expected to be limited to existing extension methods and xUnit tests inside established projects and conventions.
+- **Explicit Error Handling**: PASS. Regression guardrails strengthen early failure for naming drift without changing runtime exception paths.
+- **Test Coverage**: PASS. The feature now explicitly requires automated guardrails, so the plan includes focused xUnit coverage for the approved naming surface and preserves existing behavior tests as regression support.
+- **Simplicity & Minimalism**: PASS. A reflection-based or equivalent public-surface test in the existing test project is the smallest repository-native guardrail that protects the naming decision without adding analyzers, packages, or broad refactors.
+
+**Post-Design Re-check**: PASS. The design keeps the feature implementation-backed but narrow: preserve the current API surface, add targeted verification, align only already relevant guidance assets, and avoid introducing new abstractions or unrelated public renames.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-builder-verb-naming/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── builder-naming-matrix.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells/
+│   └── DependencyInjection/
+│       └── CShellsBuilderExtensions.cs
+├── CShells.AspNetCore/
+│   ├── README.md
+│   └── Extensions/
+│       ├── ServiceCollectionExtensions.cs
+│       └── ShellExtensions.cs
+├── README.md
+├── docs/
+│   ├── getting-started.md
+│   └── multiple-shell-providers.md
+├── wiki/
+│   └── Getting-Started.md
+└── samples/
+    └── CShells.Workbench/
+        └── Program.cs
+
+tests/
+└── CShells.Tests/
+    ├── Unit/
+    │   └── DependencyInjection/
+    │       ├── CShellsBuilderAssemblySourceTests.cs
+    │       └── CShellsBuilderNamingGuardrailTests.cs        # likely new focused guardrail test
+    └── Integration/
+        └── ShellHost/
+            └── FeatureAssemblySelectionIntegrationTests.cs
+```
+
+**Structure Decision**: Keep feature 004 centered on the existing assembly-discovery builder surface in `CShellsBuilderExtensions`. Protect that public surface with focused xUnit guardrails in the existing `tests/CShells.Tests` project, treat the current integration tests as behavior-level regression support, and limit documentation/sample work to the assets that already describe assembly discovery. This delivers a real execution scope for downstream tasks without reopening the approved naming decision or expanding into unrelated builder APIs.
+
+## Complexity Tracking
+
+No constitution violations or justified complexity exceptions were identified during planning.
+

--- a/specs/004-builder-verb-naming/quickstart.md
+++ b/specs/004-builder-verb-naming/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart: Protect the Fluent Builder Naming Matrix
+
+## Purpose
+
+Use this guide when implementing feature `004-builder-verb-naming` so the repository keeps the approved assembly-discovery naming surface, adds durable regression protection, and only edits the guidance assets that already describe that surface.
+
+## 1. Confirm the shipped public baseline
+
+Inspect the current builder extension surface before planning any code changes.
+
+- `FromAssemblies(...)` must remain the explicit source-selection entry point.
+- `FromHostAssemblies()` must remain the host-derived source-selection entry point.
+- `WithAssemblyProvider(...)` must remain the provider-attachment entry point, including any valid overload shapes already shipped.
+
+Primary inspection target:
+
+```bash
+cd /Users/sipke/Projects/ValenceWorks/cshells/main
+grep -n "FromAssemblies\|FromHostAssemblies\|WithAssemblyProvider" src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
+```
+
+## 2. Add a focused naming guardrail in the existing xUnit suite
+
+Implement the smallest repository-native verification that protects the public naming surface.
+
+- Prefer a focused unit test in `tests/CShells.Tests/Unit/DependencyInjection/`.
+- Verify the approved method groups are publicly present on `CShellsBuilderExtensions`.
+- Allow multiple overloads under `WithAssemblyProvider(...)`.
+- Fail if competing public names such as `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, or `AddHostAssemblies` are introduced for the same assembly-discovery responsibilities.
+
+## 3. Reuse current behavior tests as supporting regression coverage
+
+Do not redesign assembly-discovery behavior for this feature.
+
+- Keep the existing assembly-source semantics tests as the behavior baseline.
+- Only extend integration coverage if the naming guardrail needs additional proof about approved overload usage.
+- Avoid touching runtime behavior unless the guardrail exposes a real naming inconsistency.
+
+## 4. Audit only the guidance assets that already describe assembly discovery
+
+Review the small set of in-scope assets already identified by repository search:
+
+- `README.md`
+- `docs/getting-started.md`
+- `docs/multiple-shell-providers.md`
+- `src/CShells.AspNetCore/README.md`
+- `src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`
+- `src/CShells.AspNetCore/Extensions/ShellExtensions.cs`
+- `wiki/Getting-Started.md`
+- `samples/CShells.Workbench/Program.cs`
+
+For each asset:
+
+- keep `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` intact,
+- reinforce `From*` for source selection and `With*` for provider attachment when explanation is present,
+- avoid unrelated wording cleanup or broad example rewrites.
+
+## 5. Record the required candidate outcomes
+
+Keep the decision record explicit even though the public names are already approved.
+
+- Approve: `FromAssemblies(...)`, `FromHostAssemblies()`, `WithAssemblyProvider(...)`
+- Reject: `WithAssemblies(...)`, `WithHostAssemblies()`, `AddAssemblies(...)`, `AddHostAssemblies()`
+
+If a future contributor wants to revisit those decisions, that work must happen in a separate approved feature rather than inside 004.
+
+## 6. Run focused verification
+
+After implementing the guardrail and any targeted guidance cleanup, run the relevant tests.
+
+```bash
+cd /Users/sipke/Projects/ValenceWorks/cshells/main
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~CShellsBuilder"
+
+dotnet test tests/CShells.Tests/
+```
+
+## Expected Outcome
+
+- The repository keeps the approved public naming surface unchanged.
+- Automated verification fails if the approved names drift or rejected competing names are introduced.
+- In-scope docs, samples, and comments continue to teach the same `From*` versus `With*` matrix.
+- Feature 004 remains minimal, implementation-backed, and free of unrelated renames.
+

--- a/specs/004-builder-verb-naming/research.md
+++ b/specs/004-builder-verb-naming/research.md
@@ -1,0 +1,66 @@
+# Phase 0 Research: Fluent Builder Naming Matrix
+
+## Decision: Treat feature 004 as implementation-backed protection of an already approved API surface
+
+**Rationale**: The current repository already ships the approved assembly-discovery entry points in `src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`: `FromAssemblies(...)`, `FromHostAssemblies()`, and three overload shapes under `WithAssemblyProvider(...)`. The new planning scope therefore should not reopen naming design or force renames. Instead, it should define the smallest execution scope that preserves those shipped names, protects them against regression, and keeps guidance aligned with the same decision.
+
+**Alternatives considered**:
+
+- Reframe 004 as design-only again: rejected because the updated spec now requires repository guardrails and guidance alignment, not just decision recording.
+- Reopen the public naming surface and search for alternative verbs: rejected because the approved matrix and names remain fixed for this feature.
+
+## Decision: Reuse `specs/003-fluent-assembly-selection` as prior art, not as the implementation backlog for 004
+
+**Rationale**: Feature 003 remains the original decision context for the assembly-discovery API and already explains why `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` were approved. Feature 004 now builds on that baseline by defining how the repository keeps those decisions intact through tests and guidance audits. This preserves one naming trajectory while giving downstream task generation a real implementation scope.
+
+**Alternatives considered**:
+
+- Replace 003 with 004 as the sole source of truth: rejected because it would blur prior-art rationale with current enforcement work.
+- Duplicate every 003 artifact in 004: rejected because 004 only needs the parts of 003 that inform naming preservation and verification.
+
+## Decision: Keep the approved verb-family matrix fixed as `From*` for source selection and `With*` for provider attachment
+
+**Rationale**: The existing builder surface cleanly maps to the approved responsibilities. `FromAssemblies(...)` and `FromHostAssemblies()` answer where discovery gets assemblies from, so they stay in the source-selection family. `WithAssemblyProvider(...)` attaches an extensibility component, so it stays in the provider-attachment family. Keeping this matrix fixed prevents future contributions from relitigating already approved naming intent.
+
+**Alternatives considered**:
+
+- Allow both `From*` and `With*` for source-selection methods: rejected because it weakens the distinction the repository already relies on.
+- Allow `Add*` aliases for convenience: rejected because those names communicate raw mutation rather than the approved builder vocabulary.
+
+## Decision: Implement naming guardrails as focused xUnit public-surface tests in the existing test project
+
+**Rationale**: The constitution requires xUnit for new verification, and the repository already has focused unit coverage around assembly-source behavior in `tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`. A small reflection-based or equivalent public-surface test in the same area can assert that the approved method groups remain present, that `WithAssemblyProvider(...)` may have multiple overloads under the same approved name, and that rejected replacement names such as `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, and `AddHostAssemblies` are not introduced as competing public entry points.
+
+**Alternatives considered**:
+
+- Rely on manual review only: rejected because the spec now requires durable regression protection.
+- Add a Roslyn analyzer or third-party public API validation package: rejected because it is heavier than needed, adds tooling complexity, and is not required to protect this narrow surface.
+- Use integration tests alone: rejected because behavior tests confirm discovery semantics but do not directly lock the public naming surface.
+
+## Decision: Treat `WithAssemblyProvider(...)` as one approved naming family with multiple valid overload shapes
+
+**Rationale**: The current implementation exposes the approved provider-attachment entry point through generic, instance, and factory overloads. That variation is consistent with the spec and should not be treated as naming drift. The guardrails should verify that all supported attachment shapes continue to use the approved `WithAssemblyProvider(...)` name rather than constraining the implementation to a single overload.
+
+**Alternatives considered**:
+
+- Require exactly one `WithAssemblyProvider(...)` overload: rejected because it would incorrectly classify legitimate API convenience overloads as violations.
+- Ignore overload shape entirely: rejected because the spec explicitly wants protection that still acknowledges multiple supported attachment forms.
+
+## Decision: Limit guidance alignment to assets that already describe assembly discovery in code comments, docs, wiki, or samples
+
+**Rationale**: Repository search shows the approved naming surface is already echoed in a small, identifiable set of assets: `README.md`, `docs/getting-started.md`, `docs/multiple-shell-providers.md`, `src/CShells.AspNetCore/README.md`, `src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`, `src/CShells.AspNetCore/Extensions/ShellExtensions.cs`, `wiki/Getting-Started.md`, and `samples/CShells.Workbench/Program.cs`. That makes the documentation scope concrete and minimal: verify those assets keep using the approved names and the `From*` versus `With*` rationale, and only edit files that actually drift.
+
+**Alternatives considered**:
+
+- Sweep all markdown and sample files in the repo: rejected because it expands beyond the assembly-discovery builder surface.
+- Skip guidance review because the API already conforms: rejected because the spec explicitly includes samples, docs, and comments in scope.
+
+## Decision: Do not plan unrelated runtime changes, public aliases, or non-naming refactors under feature 004
+
+**Rationale**: The current repository already appears to conform to the approved naming matrix. The value in feature 004 comes from preserving that surface, not from manufacturing change. The implementation plan should therefore stay focused on verification and targeted guidance cleanup, leaving unrelated runtime refactors and broader builder vocabulary work to separate features.
+
+**Alternatives considered**:
+
+- Add new convenience aliases while preserving the approved names: rejected because duplicate public names for the same responsibility still create naming drift.
+- Bundle broader fluent API cleanup into 004: rejected because the spec explicitly says to avoid unrelated renames.
+

--- a/specs/004-builder-verb-naming/spec.md
+++ b/specs/004-builder-verb-naming/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Fluent Builder Naming Matrix
+
+**Feature Branch**: `004-builder-verb-naming`  
+**Created**: 2026-04-12  
+**Status**: Draft  
+**Input**: User description: "Update the existing 004 feature so it remains the naming decision record for the fluent builder matrix, but also covers implementing and protecting that approved naming scheme in the repository. Keep `From*` for source selection, `With*` for provider attachment, preserve `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`, and keep the implementation scope minimal and grounded in the current repository reality."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve the Approved Public Naming Surface (Priority: P1)
+
+As a CShells maintainer, I want the approved fluent builder naming matrix applied to the shipped assembly-discovery API so the public surface keeps the intended `From*` versus `With*` meaning without reopening already approved names.
+
+**Why this priority**: The main product value is no longer just documenting the naming rule. The repository must actually keep the approved names in the codebase so downstream work does not drift or re-litigate the decision.
+
+**Independent Test**: Inspect the repository's public assembly-discovery builder entry points and verify that source-selection calls use `From*`, provider-attachment calls use `With*`, and the approved names remain present without introducing replacement names for the same responsibilities.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fluent builder method that selects where feature discovery gets assemblies from, **When** the assembly-discovery API is reviewed, **Then** that public entry point uses the `From*` verb family.
+2. **Given** a fluent builder method that attaches a provider instance, factory, or provider type for discovery extensibility, **When** the public API is reviewed, **Then** that public entry point uses the `With*` verb family.
+3. **Given** the approved assembly-discovery names `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`, **When** feature `004-builder-verb-naming` is implemented, **Then** those names remain the approved and shipped naming surface for this repository.
+4. **Given** the repository already conforms to the approved names, **When** this feature is implemented, **Then** the work does not invent unrelated renames or replacement verbs.
+
+---
+
+### User Story 2 - Guard Against Naming Regression (Priority: P2)
+
+As a CShells maintainer, I want implementation guardrails around the assembly-discovery naming surface so future changes fail review or validation if they drift away from the approved verb-family scheme.
+
+**Why this priority**: A naming matrix only stays effective if the repository has a durable way to detect accidental renames, stale aliases, or newly introduced conflicting verbs.
+
+**Independent Test**: Run the repository verification added for this feature and confirm it passes when the approved naming surface is intact and would fail if an approved entry point were removed, renamed, or replaced with an unapproved alternative.
+
+**Acceptance Scenarios**:
+
+1. **Given** the approved assembly-discovery naming surface, **When** repository validation runs, **Then** there is automated or equivalently enforceable verification that the approved names are still present.
+2. **Given** a future change that introduces `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, or `AddHostAssemblies` as replacement public names for the same responsibilities, **When** the guardrails are evaluated, **Then** the change is detected as violating feature `004-builder-verb-naming`.
+3. **Given** `WithAssemblyProvider(...)` includes more than one supported way to attach a provider, **When** the guardrails are evaluated, **Then** they protect the approved naming surface without treating valid overload variations as naming drift.
+
+---
+
+### User Story 3 - Keep Developer-Facing Guidance Consistent (Priority: P3)
+
+As a CShells developer or maintainer, I want samples, docs, and explanatory comments aligned with the approved naming direction so usage guidance matches the public API and reinforces the same builder vocabulary.
+
+**Why this priority**: Even when code already uses the correct names, stale documentation or comments can reintroduce confusion and encourage regressions in future contributions.
+
+**Independent Test**: Review the in-scope developer-facing guidance for assembly discovery and verify it consistently uses the approved names and verb-family rationale, with any stale or conflicting terminology removed or corrected.
+
+**Acceptance Scenarios**:
+
+1. **Given** developer-facing samples or documentation that describe assembly discovery configuration, **When** they are reviewed for this feature, **Then** they use `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` consistently.
+2. **Given** comments or inline guidance that explain the builder vocabulary, **When** they mention source selection versus provider attachment, **Then** they reflect the approved `From*` and `With*` matrix.
+3. **Given** the prior-art decision from `specs/003-fluent-assembly-selection`, **When** this feature is reviewed, **Then** the implementation-backed scope remains aligned with that prior decision while enabling real repository changes in code, tests, samples, and documentation where needed.
+
+### Edge Cases
+
+- The repository already uses the approved public method names; implementation must still produce value through guardrails or guidance cleanup rather than forcing renames for the sake of change.
+- A future contributor adds an alias with the wrong verb family while leaving the approved method in place; the feature must treat that as naming drift, not as harmless duplication.
+- Multiple overloads or generic forms exist under `WithAssemblyProvider(...)`; verification must protect the approved naming family without requiring only one attachment shape.
+- A sample or comment uses an unapproved verb even though the runtime API is correct; the feature must treat that as an in-scope consistency defect.
+- A future builder API outside assembly discovery borrows the matrix; the recorded rationale must still distinguish source selection from provider attachment without requiring unrelated renames in this feature.
+
+## Approved Naming Matrix
+
+| Builder responsibility | Approved verb family | Rationale |
+| --- | --- | --- |
+| Select where feature discovery gets assemblies from | `From*` | The method describes the source of discovery input, not the attachment of an extensibility component. |
+| Attach a provider instance, factory, or provider type that contributes assemblies | `With*` | The method adds an extension component to the builder and should read as provider attachment. |
+
+## Candidate Evaluation Record
+
+| Candidate | Outcome | Reason |
+| --- | --- | --- |
+| `FromAssemblies(...)` | Approved | It clearly communicates explicit assembly source selection and matches the approved `From*` family for discovery inputs. |
+| `FromHostAssemblies()` | Approved | It clearly communicates selection of the host-derived assembly source and preserves the approved source-selection verb family. |
+| `WithAssemblyProvider(...)` | Approved | It clearly communicates attachment of a provider extension point and matches the approved `With*` family for provider inputs. |
+| `WithAssemblies(...)` | Rejected | It blurs source selection with attachment language and suggests assemblies are being attached as components rather than selected as discovery input. |
+| `WithHostAssemblies()` | Rejected | It uses provider-attachment wording for a source-selection action and weakens the distinction between host-derived sources and provider extensions. |
+| `AddAssemblies(...)` | Rejected | It sounds like raw collection mutation instead of a fluent source-selection decision and does not reinforce the approved builder vocabulary. |
+| `AddHostAssemblies()` | Rejected | It suggests additive mutation rather than an explicit source-selection directive and does not preserve the approved naming matrix. |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Feature `004-builder-verb-naming` MUST define the fluent builder naming matrix that distinguishes source-selection verbs from provider-attachment verbs.
+- **FR-002**: The naming matrix MUST state that methods describing where discovery gets assemblies from belong to the `From*` verb family.
+- **FR-003**: The naming matrix MUST state that methods attaching provider instances, factories, or provider types belong to the `With*` verb family.
+- **FR-004**: The feature MUST explicitly evaluate the candidates `FromAssemblies`, `FromHostAssemblies`, `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, `AddHostAssemblies`, and `WithAssemblyProvider`.
+- **FR-005**: The candidate evaluation MUST record an approved or rejected outcome and rationale for each candidate.
+- **FR-006**: The approved assembly-discovery names for this feature MUST remain `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- **FR-007**: The repository implementation scope for this feature MUST keep the existing approved public API names in code rather than introducing alternative public names for the same responsibilities.
+- **FR-008**: If the repository already conforms to the approved names, this feature MUST allow implementation to conclude without public API renames and instead focus on protection and alignment work.
+- **FR-009**: The implementation for this feature MUST add guardrails that verify the approved public naming surface and detect regression if an unapproved replacement or conflicting name is introduced.
+- **FR-010**: The guardrails MUST protect the approved naming surface for source-selection and provider-attachment entry points without flagging legitimate overloads or equivalent attachment forms that retain the approved names.
+- **FR-011**: The implementation for this feature MUST align in-scope developer-facing samples, documentation, and explanatory comments with the approved naming matrix wherever those assets describe the assembly-discovery builder surface.
+- **FR-012**: The feature MUST keep scope minimal and grounded in current repository reality by avoiding unrelated builder renames outside the approved assembly-discovery naming surface.
+- **FR-013**: The feature MUST remain aligned with the prior approved naming direction from `specs/003-fluent-assembly-selection` while converting feature `004-builder-verb-naming` into an implementation-backed feature that permits real code, test, sample, documentation, and comment updates.
+
+### Key Entities *(include if feature involves data)*
+
+- **Fluent Builder Naming Matrix**: The verb-family decision table that maps builder responsibilities to `From*` or `With*` naming.
+- **Approved Naming Surface**: The shipped public assembly-discovery entry points that must remain `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- **Candidate Name Evaluation**: A recorded decision for one candidate name, including its verb family, approved or rejected status, and rationale.
+- **Naming Guardrail**: Repository validation that protects the approved naming surface against regression.
+- **Developer-Facing Guidance Asset**: Any sample, documentation, or explanatory comment that teaches or reinforces the assembly-discovery builder vocabulary.
+- **Prior-Art Feature Context**: The existing `003-fluent-assembly-selection` decision record that established the approved assembly-discovery names.
+
+### Assumptions
+
+- The current repository already appears to expose `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`, so the most likely implementation work is guardrails plus targeted guidance cleanup rather than API renaming.
+- CShells builder vocabulary continues to treat `From*` as source selection and `With*` as provider attachment, and this feature does not reopen that decision.
+- Multiple supported attachment shapes may exist under the approved `WithAssemblyProvider(...)` name, and they should continue to count as one approved naming family.
+- The feature is intentionally limited to the assembly-discovery builder surface and the developer-facing assets that describe it.
+- Prior-art in `specs/003-fluent-assembly-selection` remains authoritative context for the approved names, while feature `004-builder-verb-naming` now governs implementing and protecting that decision in the repository.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of public assembly-discovery builder entry points covered by this feature use the approved naming surface: `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- **SC-002**: Repository validation includes at least one guardrail that passes when the approved naming surface is intact and fails when an unapproved replacement name is introduced for an in-scope responsibility.
+- **SC-003**: 100% of in-scope developer-facing assembly-discovery examples and guidance reviewed for this feature use the approved naming matrix consistently.
+- **SC-004**: The implementation for this feature can be completed without public API renames when the repository already conforms, with change scope limited to the guardrails and alignment work needed to protect the approved naming direction.

--- a/specs/004-builder-verb-naming/tasks.md
+++ b/specs/004-builder-verb-naming/tasks.md
@@ -1,0 +1,193 @@
+# Tasks: Fluent Builder Naming Matrix
+
+**Input**: Design documents from `/specs/004-builder-verb-naming/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/builder-naming-matrix.md`
+
+**Tests**: Focused xUnit guardrails and targeted `dotnet test`/`dotnet build` validation are required for this feature because the implementation scope now includes protecting the shipped assembly-discovery API surface.
+
+**Organization**: Tasks are grouped by user story so the approved naming surface can be preserved in code first, then protected with regression tests, then reflected in the small set of in-scope guidance assets.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., `US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Repository root: `/Users/sipke/Projects/ValenceWorks/cshells/main`
+- Runtime implementation stays limited to `src/CShells/` and code-adjacent XML comments in `src/CShells.AspNetCore/`
+- Regression guardrails stay inside `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/`
+- Guidance alignment stays limited to the already relevant README/doc/wiki/sample assets that describe assembly discovery
+
+## Phase 1: Setup (Scope Lock)
+
+**Purpose**: Confirm the current repository baseline and keep the execution scope minimal before changing code, tests, or guidance.
+
+- [X] T001 [P] Audit the current assembly-discovery public surface in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs` and the current coverage baseline in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`
+- [X] T002 [P] Audit the in-scope assembly-discovery guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/README.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/getting-started.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/multiple-shell-providers.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/README.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ShellExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Getting-Started.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Capture the targeted verification baseline so later validation stays focused on the approved naming surface and in-scope assets only.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T003 Baseline targeted verification against `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/CShells.Workbench.csproj` so the implementation stays minimal and implementation-backed
+
+**Checkpoint**: The exact code, test, guidance, and validation touchpoints are locked.
+
+---
+
+## Phase 3: User Story 1 - Preserve the Approved Public Naming Surface (Priority: P1) 🎯 MVP
+
+**Goal**: Keep the shipped assembly-discovery API fixed to `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` while reinforcing the approved `From*` versus `With*` meaning in code-adjacent guidance.
+
+**Independent Test**: Inspect `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ShellExtensions.cs` and confirm the only in-scope public assembly-discovery names are `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`, with no competing aliases or conflicting verb-family wording.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Update `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs` only as needed to keep the assembly-discovery public surface fixed to `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)` without introducing unrelated renames or aliases
+- [X] T005 [P] [US1] Align the assembly-discovery remarks in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs` with the approved `From*` source-selection and `With*` provider-attachment terminology
+- [X] T006 [P] [US1] Align the assembly-discovery remarks in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Extensions/ShellExtensions.cs` with the approved `From*` source-selection and `With*` provider-attachment terminology
+
+**Checkpoint**: The code surface and code-adjacent comments preserve the approved naming matrix.
+
+---
+
+## Phase 4: User Story 2 - Guard Against Naming Regression (Priority: P2)
+
+**Goal**: Add focused repository-native guardrails in the existing xUnit project so future naming drift is caught automatically.
+
+**Independent Test**: Run targeted xUnit validation and confirm it passes only when `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs` still exposes `FromAssemblies(...)`, `FromHostAssemblies()`, and the approved `WithAssemblyProvider(...)` overload family while rejecting `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, and `AddHostAssemblies`.
+
+### Tests for User Story 2 ⚠️
+
+> **NOTE: Add the focused guardrails before finalizing implementation so they would fail if the approved names drift.**
+
+- [X] T007 [P] [US2] Add public-surface naming guardrails in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderNamingGuardrailTests.cs` that require `FromAssemblies(...)`, `FromHostAssemblies()`, and the `WithAssemblyProvider(...)` overload family while rejecting `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, and `AddHostAssemblies`
+- [X] T008 [P] [US2] Update `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs` to keep behavior-level coverage aligned with the approved `From*`/`With*` surface and supported `WithAssemblyProvider(...)` overload shapes
+
+**Checkpoint**: The approved naming surface is protected by focused automated regression coverage.
+
+---
+
+## Phase 5: User Story 3 - Keep Developer-Facing Guidance Consistent (Priority: P3)
+
+**Goal**: Align only the existing docs, samples, and guidance that already describe assembly discovery so they reinforce the shipped naming surface without broad rewrites.
+
+**Independent Test**: Review the in-scope guidance assets and confirm they consistently teach `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`, reinforce the `From*` versus `With*` distinction, and avoid rejected alternative names.
+
+### Implementation for User Story 3
+
+- [X] T009 [P] [US3] Align assembly-discovery guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/README.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/getting-started.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/multiple-shell-providers.md` so they reinforce the approved names without teaching replacement verbs
+- [X] T010 [P] [US3] Align assembly-discovery guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/README.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Getting-Started.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs` so examples and comments use the approved names and valid current overloads only
+
+**Checkpoint**: All in-scope guidance assets describe assembly discovery with the same approved vocabulary as the code.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the completed implementation with focused tests and targeted builds.
+
+- [X] T011 Run `dotnet test /Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/ --filter "FullyQualifiedName~CShellsBuilder"` to validate `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderNamingGuardrailTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs`
+- [X] T012 Run `dotnet test /Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/ --filter "FullyQualifiedName~FeatureAssemblySelectionIntegrationTests"` to validate `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs`
+- [X] T013 Run targeted build validation for `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/CShells.csproj`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/CShells.AspNetCore.csproj`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/CShells.Workbench.csproj`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies; start immediately.
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3: User Story 1 (P1)**: Depends on Phase 2 because the final guardrails and guidance must target the locked public surface.
+- **Phase 4: User Story 2 (P2)**: Depends on User Story 1 so the regression tests lock the final approved code surface rather than an intermediate state.
+- **Phase 5: User Story 3 (P3)**: Depends on User Story 1; it can proceed after the code surface is stable, even though normal delivery still follows P1 → P2 → P3 priority order.
+- **Phase 6: Polish**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP; no dependency on later stories.
+- **User Story 2 (P2)**: Depends on User Story 1 because the new guardrails must reflect the preserved public naming surface.
+- **User Story 3 (P3)**: Depends on User Story 1 because docs, samples, and comments must mirror the final approved code surface.
+
+### Within Each User Story
+
+- Preserve the public API before locking it with tests.
+- Add focused tests before widening any documentation/sample cleanup.
+- Keep guidance edits restricted to assets that already describe assembly discovery.
+- Finish with targeted validation only; avoid unrelated renames or broad repository sweeps.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel during scope lock.
+- T005 and T006 can run in parallel after T004 stabilizes the approved code surface.
+- T007 and T008 can run in parallel inside the existing xUnit project because they touch different test files.
+- T009 and T010 can run in parallel because they touch different guidance assets.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T004 preserves the public code surface, align the code-adjacent remarks in parallel:
+Task: "Align the assembly-discovery remarks in src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs"
+Task: "Align the assembly-discovery remarks in src/CShells.AspNetCore/Extensions/ShellExtensions.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Build the focused regression coverage in parallel inside the existing xUnit project:
+Task: "Add public-surface naming guardrails in tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderNamingGuardrailTests.cs"
+Task: "Update tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Split the guidance cleanup by asset group:
+Task: "Align assembly-discovery guidance in README.md, docs/getting-started.md, and docs/multiple-shell-providers.md"
+Task: "Align assembly-discovery guidance in src/CShells.AspNetCore/README.md, wiki/Getting-Started.md, and samples/CShells.Workbench/Program.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Validate the approved assembly-discovery surface in code before adding guardrails or guidance cleanup.
+
+### Incremental Delivery
+
+1. Lock the minimal implementation/test/doc scope.
+2. Preserve the approved public naming surface in code and code-adjacent comments.
+3. Add focused xUnit guardrails that keep the approved names fixed.
+4. Align only the already relevant docs, samples, and guidance assets.
+5. Finish with targeted tests and builds.
+
+### Parallel Team Strategy
+
+1. One contributor can baseline code/tests while another baselines docs/samples during Phase 1.
+2. After User Story 1 stabilizes the code surface, split the ASP.NET Core comment alignment work across two contributors.
+3. During User Story 2, one contributor can add the new naming guardrail file while another tightens the existing assembly-source behavior tests.
+4. During User Story 3, split the markdown asset cleanup from the sample/package guidance cleanup.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and can be completed in parallel safely.
+- `[US1]`, `[US2]`, and `[US3]` map directly to the prioritized stories in `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/004-builder-verb-naming/spec.md`.
+- This task list keeps the approved names fixed as `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`.
+- Scope is intentionally minimal: preserve the current naming surface, add focused regression guardrails, align only in-scope guidance, and validate with targeted tests/builds.
+

--- a/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,8 @@ public static class ServiceCollectionExtensions
     /// <returns>The CShells builder for further configuration.</returns>
     /// <remarks>
     /// Configure feature discovery assemblies through the returned <see cref="CShellsBuilder"/> using
-    /// <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>, or <c>WithAssemblyProvider(...)</c>.
+    /// <c>FromAssemblies(...)</c> or <c>FromHostAssemblies()</c> to select discovery sources, and
+    /// <c>WithAssemblyProvider(...)</c> to attach a provider-based source.
     /// </remarks>
     /// <example>
     /// <code>

--- a/src/CShells.AspNetCore/Extensions/ShellExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ShellExtensions.cs
@@ -29,7 +29,8 @@ public static class ShellExtensions
         /// <param name="sectionName">The configuration section name to bind CShells options from.</param>
         /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
         /// <remarks>
-        /// Configure feature discovery assemblies through the fluent <see cref="CShellsBuilder"/> APIs when needed.
+        /// Configure feature discovery assemblies through the fluent <see cref="CShellsBuilder"/> APIs when needed,
+        /// using <c>From*</c> members for source selection and <c>WithAssemblyProvider(...)</c> for provider attachment.
         /// </remarks>
         public WebApplicationBuilder AddShells(string sectionName)
         {
@@ -45,8 +46,9 @@ public static class ShellExtensions
         /// <param name="configureCShells">Callback used to configure the CShells builder.</param>
         /// <returns>The same <see cref="WebApplicationBuilder"/> instance for chaining.</returns>
         /// <remarks>
-        /// Configure feature discovery assemblies through <c>FromAssemblies(...)</c>, <c>FromHostAssemblies()</c>,
-        /// or <c>WithAssemblyProvider(...)</c> inside <paramref name="configureCShells"/>.
+        /// Configure feature discovery assemblies through <c>FromAssemblies(...)</c> or <c>FromHostAssemblies()</c>
+        /// to select discovery sources, and <c>WithAssemblyProvider(...)</c> to attach provider-based sources,
+        /// inside <paramref name="configureCShells"/>.
         /// </remarks>
         public WebApplicationBuilder AddShells(Action<CShellsBuilder> configureCShells)
         {

--- a/src/CShells.AspNetCore/README.md
+++ b/src/CShells.AspNetCore/README.md
@@ -99,6 +99,8 @@ app.Run();
 
 **Explicit feature assembly selection:**
 
+Use `From*` members to select discovery sources, and `WithAssemblyProvider(...)` when attaching a provider that contributes assemblies.
+
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
@@ -50,6 +50,18 @@ public class CShellsBuilderAssemblySourceTests
     }
 
     [Fact]
+    public void FromHostAssemblies_AppendsHostProviderAndActivatesExplicitMode()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        CShellsBuilderExtensions.FromHostAssemblies(builder);
+
+        Assert.True(builder.UsesExplicitFeatureAssemblyProviders);
+        Assert.IsType<HostFeatureAssemblyProvider>(Assert.Single(builder.BuildFeatureAssemblyProviders(serviceProvider)));
+    }
+
+    [Fact]
     public void WithAssemblyProvider_GenericOverloadResolvesProviderFromRootServiceProvider()
     {
         var services = new ServiceCollection();
@@ -101,6 +113,30 @@ public class CShellsBuilderAssemblySourceTests
 
         var provider = Assert.IsType<DelegateFeatureAssemblyProvider>(Assert.Single(builder.BuildFeatureAssemblyProviders(serviceProvider)));
         Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(provider.GetAssemblies(serviceProvider)));
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_OverloadsComposeAdditivelyInRegistrationOrder()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestFeatureAssemblyProvider>();
+        var builder = new CShellsBuilder(services);
+        var instanceProvider = new DelegateFeatureAssemblyProvider(_ => [typeof(CShellsBuilderAssemblySourceTests).Assembly]);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        CShellsBuilderExtensions.WithAssemblyProvider<TestFeatureAssemblyProvider>(builder);
+        CShellsBuilderExtensions.WithAssemblyProvider(builder, instanceProvider);
+        CShellsBuilderExtensions.WithAssemblyProvider(builder, _ => new DelegateFeatureAssemblyProvider(_ => [typeof(MarkerService).Assembly]));
+
+        Assert.Collection(
+            builder.BuildFeatureAssemblyProviders(serviceProvider),
+            provider => Assert.Same(serviceProvider.GetRequiredService<TestFeatureAssemblyProvider>(), provider),
+            provider => Assert.Same(instanceProvider, provider),
+            provider =>
+            {
+                var delegateProvider = Assert.IsType<DelegateFeatureAssemblyProvider>(provider);
+                Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(delegateProvider.GetAssemblies(serviceProvider)));
+            });
     }
 
     [Fact]

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderNamingGuardrailTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderNamingGuardrailTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using CShells.DependencyInjection;
+using CShells.Features;
+
+namespace CShells.Tests.Unit.DependencyInjection;
+
+public class CShellsBuilderNamingGuardrailTests
+{
+    [Fact]
+    public void PublicAssemblyDiscoverySurface_UsesOnlyApprovedMethodNames()
+    {
+        var methodNames = GetPublicAssemblyDiscoveryMethods()
+            .Select(method => method.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                nameof(CShellsBuilderExtensions.FromAssemblies),
+                nameof(CShellsBuilderExtensions.FromHostAssemblies),
+                nameof(CShellsBuilderExtensions.WithAssemblyProvider)
+            ],
+            methodNames);
+    }
+
+    [Fact]
+    public void WithAssemblyProvider_ExposesApprovedOverloadShapes()
+    {
+        var overloads = GetPublicAssemblyDiscoveryMethods()
+            .Where(method => method.Name == nameof(CShellsBuilderExtensions.WithAssemblyProvider))
+            .ToArray();
+
+        Assert.Contains(overloads, IsGenericProviderAttachmentOverload);
+        Assert.Contains(overloads, method => HasParameters(method, typeof(CShellsBuilder), typeof(IFeatureAssemblyProvider)));
+        Assert.Contains(overloads, method => HasParameters(method, typeof(CShellsBuilder), typeof(Func<IServiceProvider, IFeatureAssemblyProvider>)));
+    }
+
+    [Theory]
+    [InlineData("WithAssemblies")]
+    [InlineData("WithHostAssemblies")]
+    [InlineData("AddAssemblies")]
+    [InlineData("AddHostAssemblies")]
+    public void PublicAssemblyDiscoverySurface_DoesNotExposeRejectedAliases(string rejectedMethodName)
+    {
+        Assert.DoesNotContain(
+            GetPublicAssemblyDiscoveryMethods(),
+            method => string.Equals(method.Name, rejectedMethodName, StringComparison.Ordinal));
+    }
+
+    private static MethodInfo[] GetPublicAssemblyDiscoveryMethods() => typeof(CShellsBuilderExtensions)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Where(method => method.ReturnType == typeof(CShellsBuilder))
+        .Where(method => method.GetParameters() is [{ ParameterType: var firstParameterType }, ..] && firstParameterType == typeof(CShellsBuilder))
+        .Where(method => method.Name.Contains("Assembl", StringComparison.Ordinal))
+        .ToArray();
+
+    private static bool IsGenericProviderAttachmentOverload(MethodInfo method)
+    {
+        if (!method.IsGenericMethodDefinition || method.GetGenericArguments().Length != 1)
+        {
+            return false;
+        }
+
+        if (!HasParameters(method, typeof(CShellsBuilder)))
+        {
+            return false;
+        }
+
+        var genericArgument = method.GetGenericArguments()[0];
+        var constraints = genericArgument.GetGenericParameterConstraints();
+
+        return constraints.Contains(typeof(IFeatureAssemblyProvider))
+            && (genericArgument.GenericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+    }
+
+    private static bool HasParameters(MethodInfo method, params Type[] parameterTypes) => method
+        .GetParameters()
+        .Select(parameter => parameter.ParameterType)
+        .SequenceEqual(parameterTypes);
+}

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -126,6 +126,8 @@ app.Run();
 
 `AddShells()` preserves the default host-derived feature assembly discovery behavior. To switch to explicit feature assembly selection:
 
+Use `From*` members to select discovery sources, and `WithAssemblyProvider(...)` when attaching a provider that contributes assemblies.
+
 ```csharp
 builder.AddShells(cshells =>
 {


### PR DESCRIPTION
## Summary
- turn `specs/004-builder-verb-naming` into an implementation-backed feature and add the supporting plan/tasks artifacts
- preserve the approved assembly-discovery naming surface and add focused xUnit guardrails for `FromAssemblies(...)`, `FromHostAssemblies()`, and `WithAssemblyProvider(...)`
- align in-scope docs, wiki guidance, ASP.NET Core remarks, and the Workbench sample with the approved `From*` vs `With*` terminology

## Details
- add `CShellsBuilderNamingGuardrailTests` to require the approved public method groups and reject competing aliases such as `WithAssemblies`, `WithHostAssemblies`, `AddAssemblies`, and `AddHostAssemblies`
- expand `CShellsBuilderAssemblySourceTests` to cover `FromHostAssemblies()` explicit-mode behavior and additive `WithAssemblyProvider(...)` overload composition
- fix the invalid zero-argument `WithAssemblyProvider()` call in `samples/CShells.Workbench/Program.cs`
- record the naming decision, implementation plan, and completed task list under `specs/004-builder-verb-naming/`

## Validation
- `dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~CShellsBuilder"`
- `dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~FeatureAssemblySelectionIntegrationTests"`
- `dotnet build src/CShells/CShells.csproj`
- `dotnet build src/CShells.AspNetCore/CShells.AspNetCore.csproj`
- `dotnet build samples/CShells.Workbench/CShells.Workbench.csproj`