### PR TITLE
Refactor feature assembly providers to async discovery contract

### DIFF
--- a/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs
+++ b/src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs
@@ -20,6 +20,7 @@ public interface IFeatureAssemblyProvider
     /// Gets the assemblies that should be scanned for shell features.
     /// </summary>
     /// <param name="serviceProvider">The root application service provider.</param>
+    /// <param name="cancellationToken">A token to cancel assembly discovery.</param>
     /// <returns>A non-null sequence of assemblies to scan.</returns>
-    IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider);
+    Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default);
 }

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -90,11 +90,6 @@ public class CShellsBuilder
         return providers.AsReadOnly();
     }
 
-    /// <summary>
-    /// Resolves the assemblies that should be scanned for shell feature discovery.
-    /// </summary>
-    internal IReadOnlyCollection<Assembly> BuildFeatureAssemblies(IServiceProvider serviceProvider)
-        => BuildFeatureAssembliesAsync(serviceProvider).ConfigureAwait(false).GetAwaiter().GetResult();
 
     /// <summary>
     /// Resolves the assemblies that should be scanned for shell feature discovery.

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -94,11 +94,19 @@ public class CShellsBuilder
     /// Resolves the assemblies that should be scanned for shell feature discovery.
     /// </summary>
     internal IReadOnlyCollection<Assembly> BuildFeatureAssemblies(IServiceProvider serviceProvider)
+        => BuildFeatureAssembliesAsync(serviceProvider).ConfigureAwait(false).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Resolves the assemblies that should be scanned for shell feature discovery.
+    /// </summary>
+    internal async Task<IReadOnlyCollection<Assembly>> BuildFeatureAssembliesAsync(
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(serviceProvider);
 
         return UsesExplicitFeatureAssemblyProviders
-            ? CShells.Features.FeatureAssemblyResolver.ResolveAssemblies(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider)
+            ? await CShells.Features.FeatureAssemblyResolver.ResolveAssembliesAsync(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider, cancellationToken)
             : CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies();
     }
 

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -77,7 +77,7 @@ public static class ServiceCollectionExtensions
             var rootServicesAccessor = sp.GetRequiredService<IRootServiceCollectionAccessor>();
             var featureFactory = sp.GetRequiredService<IShellFeatureFactory>();
             var exclusionRegistry = sp.GetRequiredService<Hosting.IShellServiceExclusionRegistry>();
-            var assembliesToScan = builder.BuildFeatureAssemblies(sp);
+            var assembliesToScan = builder.BuildFeatureAssembliesAsync(sp).GetAwaiter().GetResult();
 
             return new DefaultShellHost(shellCache, assembliesToScan, rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, logger);
         });

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,9 +58,6 @@ public static class ServiceCollectionExtensions
         // This ensures the cache is loaded when the application starts normally (via IHost.Run)
         services.AddHostedService<ShellSettingsCacheInitializer>();
 
-        // Register hosted service for shell lifecycle coordination with app lifecycle
-        services.AddHostedService<ShellStartupHostedService>();
-
         var builder = new CShellsBuilder(services);
 
         // Register IShellHost using the DefaultShellHost.
@@ -70,23 +67,28 @@ public static class ServiceCollectionExtensions
         //
         // Note: The cache may be empty when IShellHost is constructed. This is OK - shells can be
         // loaded later via the hosted service or dynamically at runtime via the cache.
-        services.AddSingleton<IShellHost>(sp =>
+        services.AddSingleton<DefaultShellHost>(sp =>
         {
             var shellCache = sp.GetRequiredService<ShellSettingsCache>();
             var logger = sp.GetService<ILogger<DefaultShellHost>>();
             var rootServicesAccessor = sp.GetRequiredService<IRootServiceCollectionAccessor>();
             var featureFactory = sp.GetRequiredService<IShellFeatureFactory>();
             var exclusionRegistry = sp.GetRequiredService<Hosting.IShellServiceExclusionRegistry>();
-            var assembliesToScan = builder.BuildFeatureAssembliesAsync(sp).GetAwaiter().GetResult();
 
-            return new DefaultShellHost(shellCache, assembliesToScan, rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, logger);
+            return new DefaultShellHost(shellCache, ct => builder.BuildFeatureAssembliesAsync(sp, ct), rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, logger);
         });
+        services.AddSingleton<IShellHost>(sp => sp.GetRequiredService<DefaultShellHost>());
 
         // Register the default shell context scope factory.
         services.AddSingleton<IShellContextScopeFactory, DefaultShellContextScopeFactory>();
 
         // Register the shell manager for runtime shell lifecycle management
         services.TryAddSingleton<IShellManager, DefaultShellManager>();
+
+        // Register hosted services for feature discovery and shell lifecycle coordination.
+        // Feature discovery must complete before shells are activated.
+        services.AddHostedService<ShellFeatureInitializationHostedService>();
+        services.AddHostedService<ShellStartupHostedService>();
         
         // Register the composite shell settings provider factory immediately
         // This must be done BEFORE configure is called so that DefaultShellManager can be constructed

--- a/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs
+++ b/src/CShells/Features/ExplicitFeatureAssemblyProvider.cs
@@ -14,9 +14,9 @@ internal sealed class ExplicitFeatureAssemblyProvider : IFeatureAssemblyProvider
             .ToArray();
     }
 
-    public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+    public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(serviceProvider);
-        return _assemblies;
+        return Task.FromResult<IEnumerable<Assembly>>(_assemblies);
     }
 }

--- a/src/CShells/Features/FeatureAssemblyResolver.cs
+++ b/src/CShells/Features/FeatureAssemblyResolver.cs
@@ -6,6 +6,12 @@ namespace CShells.Features;
 internal static class FeatureAssemblyResolver
 {
     public static IReadOnlyCollection<Assembly> ResolveAssemblies(IEnumerable<IFeatureAssemblyProvider> providers, IServiceProvider serviceProvider)
+        => ResolveAssembliesAsync(providers, serviceProvider).ConfigureAwait(false).GetAwaiter().GetResult();
+
+    public static async Task<IReadOnlyCollection<Assembly>> ResolveAssembliesAsync(
+        IEnumerable<IFeatureAssemblyProvider> providers,
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default)
     {
         var assemblyProviders = Guard.Against.Null(providers).ToArray();
         Guard.Against.Null(serviceProvider);
@@ -16,7 +22,7 @@ internal static class FeatureAssemblyResolver
         foreach (var provider in assemblyProviders)
         {
             var assemblyProvider = Guard.Against.Null(provider);
-            var contributedAssemblies = assemblyProvider.GetAssemblies(serviceProvider)
+            var contributedAssemblies = await assemblyProvider.GetAssembliesAsync(serviceProvider, cancellationToken)
                 ?? throw new InvalidOperationException($"The feature assembly provider '{assemblyProvider.GetType().FullName}' returned null. Providers must return a non-null sequence.");
 
             foreach (var assembly in contributedAssemblies)

--- a/src/CShells/Features/FeatureAssemblyResolver.cs
+++ b/src/CShells/Features/FeatureAssemblyResolver.cs
@@ -5,8 +5,6 @@ namespace CShells.Features;
 
 internal static class FeatureAssemblyResolver
 {
-    public static IReadOnlyCollection<Assembly> ResolveAssemblies(IEnumerable<IFeatureAssemblyProvider> providers, IServiceProvider serviceProvider)
-        => ResolveAssembliesAsync(providers, serviceProvider).ConfigureAwait(false).GetAwaiter().GetResult();
 
     public static async Task<IReadOnlyCollection<Assembly>> ResolveAssembliesAsync(
         IEnumerable<IFeatureAssemblyProvider> providers,

--- a/src/CShells/Features/HostFeatureAssemblyProvider.cs
+++ b/src/CShells/Features/HostFeatureAssemblyProvider.cs
@@ -4,9 +4,9 @@ namespace CShells.Features;
 
 internal sealed class HostFeatureAssemblyProvider : IFeatureAssemblyProvider
 {
-    public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+    public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(serviceProvider);
-        return FeatureAssemblyResolver.ResolveHostAssemblies();
+        return Task.FromResult<IEnumerable<Assembly>>(FeatureAssemblyResolver.ResolveHostAssemblies());
     }
 }

--- a/src/CShells/Hosting/DefaultShellHost.cs
+++ b/src/CShells/Hosting/DefaultShellHost.cs
@@ -35,7 +35,7 @@ namespace CShells.Hosting;
 /// </remarks>
 public class DefaultShellHost : IShellHost, IAsyncDisposable
 {
-    private readonly IReadOnlyDictionary<string, ShellFeatureDescriptor> _featureMap;
+    private readonly Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>>? _assemblyResolver;
     private readonly IShellSettingsCache _shellSettingsCache;
     private readonly IServiceProvider _rootProvider;
     private readonly IServiceCollection _rootServices;
@@ -45,7 +45,10 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
     private readonly FeatureDependencyResolver _dependencyResolver = new();
     private readonly ILogger<DefaultShellHost> _logger;
     private readonly object _buildLock = new();
+    private readonly object _featureInitializationLock = new();
     private bool _disposed;
+    private IReadOnlyDictionary<string, ShellFeatureDescriptor>? _featureMap;
+    private Task? _featureInitializationTask;
 
     // Cached copy of root service descriptors for efficient bulk-copy to shell service collections.
     // This avoids re-enumerating the root IServiceCollection for each shell.
@@ -84,19 +87,95 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
         _exclusionRegistry = Guard.Against.Null(exclusionRegistry);
         _logger = logger ?? NullLogger<DefaultShellHost>.Instance;
 
-        // Discover all features from specified assemblies
+        InitializeFeatureMap(Guard.Against.Null(assemblies));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultShellHost"/> class with a deferred assembly resolver.
+    /// </summary>
+    /// <param name="shellSettingsCache">The cache providing access to shell settings.</param>
+    /// <param name="assemblyResolver">The asynchronous resolver that provides assemblies to scan for features.</param>
+    /// <param name="rootProvider">The application's root service provider.</param>
+    /// <param name="rootServicesAccessor">Accessor for the root service collection.</param>
+    /// <param name="featureFactory">The factory used to create shell feature instances.</param>
+    /// <param name="exclusionRegistry">The registry of service types to exclude from root service inheritance.</param>
+    /// <param name="logger">Optional logger for diagnostic output.</param>
+    public DefaultShellHost(
+        IShellSettingsCache shellSettingsCache,
+        Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver,
+        IServiceProvider rootProvider,
+        IRootServiceCollectionAccessor rootServicesAccessor,
+        IShellFeatureFactory featureFactory,
+        IShellServiceExclusionRegistry exclusionRegistry,
+        ILogger<DefaultShellHost>? logger = null)
+    {
+        _shellSettingsCache = Guard.Against.Null(shellSettingsCache);
+        _assemblyResolver = Guard.Against.Null(assemblyResolver);
+        _rootProvider = Guard.Against.Null(rootProvider);
+        _rootServices = Guard.Against.Null(rootServicesAccessor).Services;
+        _featureFactory = Guard.Against.Null(featureFactory);
+        _exclusionRegistry = Guard.Against.Null(exclusionRegistry);
+        _logger = logger ?? NullLogger<DefaultShellHost>.Instance;
+    }
+
+    /// <summary>
+    /// Ensures that feature discovery has completed for this shell host.
+    /// </summary>
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (_featureMap is not null)
+            return Task.CompletedTask;
+
+        if (_assemblyResolver is null)
+            throw new InvalidOperationException("No deferred feature assembly resolver was configured for this shell host.");
+
+        lock (_featureInitializationLock)
+        {
+            if (_featureMap is not null)
+                return Task.CompletedTask;
+
+            _featureInitializationTask ??= InitializeFeatureMapAsync(cancellationToken);
+            return _featureInitializationTask;
+        }
+    }
+
+    private async Task InitializeFeatureMapAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var assemblies = await _assemblyResolver!(cancellationToken).ConfigureAwait(false);
+            InitializeFeatureMap(assemblies);
+        }
+        catch
+        {
+            lock (_featureInitializationLock)
+            {
+                _featureInitializationTask = null;
+            }
+
+            throw;
+        }
+    }
+
+    private void InitializeFeatureMap(IEnumerable<Assembly> assemblies)
+    {
         var features = FeatureDiscovery.DiscoverFeatures(
-            Guard.Against.Null(assemblies), 
-            (assembly, ex) => _logger.LogWarning(ex, "Failed to load types from assembly {AssemblyName}. Features in this assembly will not be available.", assembly.GetName().Name))
+                Guard.Against.Null(assemblies),
+                (assembly, ex) => _logger.LogWarning(ex, "Failed to load types from assembly {AssemblyName}. Features in this assembly will not be available.", assembly.GetName().Name))
             .ToList();
 
         _logger.LogInformation("Discovered {FeatureCount} features: {FeatureNames}",
             features.Count,
             string.Join(", ", features.Select(f => f.Id)));
 
-        // Build feature map for quick lookup
         _featureMap = features.ToDictionary(f => f.Id, f => f, StringComparer.OrdinalIgnoreCase);
     }
+
+    private IReadOnlyDictionary<string, ShellFeatureDescriptor> FeatureMap =>
+        _featureMap ?? throw new InvalidOperationException(
+            "Shell feature discovery has not completed yet. Start the host or await DefaultShellHost.InitializeAsync before accessing shells.");
 
     /// <inheritdoc />
     public ShellContext DefaultShell
@@ -215,7 +294,7 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
     {
         try
         {
-            return _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, _featureMap);
+            return _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, FeatureMap);
         }
         catch (InvalidOperationException ex)
         {
@@ -248,7 +327,7 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
     private void ValidateEnabledFeatures(ShellSettings settings)
     {
         var unknownFeatures = settings.EnabledFeatures
-            .Where(featureName => !_featureMap.ContainsKey(featureName))
+            .Where(featureName => !FeatureMap.ContainsKey(featureName))
             .ToList();
 
         foreach (var featureName in unknownFeatures)
@@ -297,13 +376,13 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
 
         // Step 2: Register shell-specific core services (ShellSettings, ShellId, ShellContext, IConfiguration).
         // These are added after root services, so they override any root registrations.
-        RegisterCoreServices(shellServices, settings, contextHolder, _rootProvider, _featureMap.Values);
+        RegisterCoreServices(shellServices, settings, contextHolder, _rootProvider, FeatureMap.Values);
 
         // Step 3: Configure feature services in dependency order.
         // Features can override root services by registering the same service type.
         // A single ShellFeatureContext is shared across all features so they can
         // exchange data through its Properties bag during construction.
-        var featureContext = new ShellFeatureContext(settings, _featureMap.Values);
+        var featureContext = new ShellFeatureContext(settings, FeatureMap.Values);
         var postConfigureFeatures = new List<IPostConfigureShellServices>();
         if (orderedFeatures.Count > 0)
         {
@@ -428,7 +507,7 @@ public class DefaultShellHost : IShellHost, IAsyncDisposable
     private void ConfigureFeatureServices(ServiceCollection services, List<string> orderedFeatures, ShellSettings settings, ShellFeatureContext featureContext, List<IPostConfigureShellServices> postConfigureFeatures)
     {
         var featuresWithStartups = orderedFeatures
-            .Select(name => (Name: name, Descriptor: _featureMap[name]))
+            .Select(name => (Name: name, Descriptor: FeatureMap[name]))
             .Where(f => f.Descriptor.StartupType != null);
 
         foreach (var (featureName, descriptor) in featuresWithStartups)

--- a/src/CShells/Hosting/ShellFeatureInitializationHostedService.cs
+++ b/src/CShells/Hosting/ShellFeatureInitializationHostedService.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Hosting;
+
+/// <summary>
+/// Ensures deferred shell feature discovery completes before shell startup activates any shells.
+/// </summary>
+public class ShellFeatureInitializationHostedService : IHostedService
+{
+    private readonly DefaultShellHost _shellHost;
+    private readonly ILogger<ShellFeatureInitializationHostedService> _logger;
+
+    public ShellFeatureInitializationHostedService(
+        DefaultShellHost shellHost,
+        ILogger<ShellFeatureInitializationHostedService>? logger = null)
+    {
+        _shellHost = Guard.Against.Null(shellHost);
+        _logger = logger ?? NullLogger<ShellFeatureInitializationHostedService>.Instance;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Initializing shell feature discovery");
+        await _shellHost.InitializeAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/CShells.Tests/Integration/DefaultShellHost/ConstructorTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/ConstructorTests.cs
@@ -37,4 +37,72 @@ public class ConstructorTests(DefaultShellHostFixture fixture)
             new Hosting.DefaultShellHost(cache!, assemblies!, rootProvider!, accessor!, factory!, exclusionRegistry!));
         Assert.Equal(expectedParam, exception.ParamName);
     }
+
+    [Theory(DisplayName = "Deferred constructor guard clauses throw ArgumentNullException")]
+    [InlineData(true, false, false, false, false, false, "shellSettingsCache")]
+    [InlineData(false, true, false, false, false, false, "assemblyResolver")]
+    [InlineData(false, false, true, false, false, false, "rootProvider")]
+    [InlineData(false, false, false, true, false, false, "rootServicesAccessor")]
+    [InlineData(false, false, false, false, true, false, "featureFactory")]
+    [InlineData(false, false, false, false, false, true, "exclusionRegistry")]
+    public void DeferredConstructor_GuardClauses_ThrowArgumentNullException(
+        bool nullCache,
+        bool nullAssemblyResolver,
+        bool nullRootProvider,
+        bool nullAccessor,
+        bool nullFactory,
+        bool nullExclusionRegistry,
+        string expectedParam)
+    {
+        var cache = nullCache ? null : new ShellSettingsCache();
+        Func<CancellationToken, Task<IReadOnlyCollection<System.Reflection.Assembly>>> assemblyResolver = _ => Task.FromResult<IReadOnlyCollection<System.Reflection.Assembly>>([]);
+        var rootProvider = nullRootProvider ? null : fixture.RootProvider;
+        var accessor = nullAccessor ? null : fixture.RootAccessor;
+        var factory = nullFactory ? null : fixture.FeatureFactory;
+        var exclusionRegistry = nullExclusionRegistry ? null : new ShellServiceExclusionRegistry([]);
+
+        var exception = Assert.ThrowsAny<ArgumentException>(() =>
+            new Hosting.DefaultShellHost(cache!, nullAssemblyResolver ? null! : assemblyResolver, rootProvider!, accessor!, factory!, exclusionRegistry!));
+        Assert.Equal(expectedParam, exception.ParamName);
+    }
+
+    [Fact(DisplayName = "Deferred constructor requires async initialization before shell access")]
+    public void DeferredConstructor_BeforeInitialize_ThrowsInvalidOperationException()
+    {
+        var cache = new ShellSettingsCache();
+        cache.Load([new(new("Default"), ["Weather"])]);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<System.Reflection.Assembly>>([typeof(CShells.Tests.Integration.ShellHost.TestFixtures).Assembly]),
+            fixture.RootProvider,
+            fixture.RootAccessor,
+            fixture.FeatureFactory,
+            exclusionRegistry);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => host.GetShell(new("Default")));
+
+        Assert.Contains("InitializeAsync", exception.Message);
+    }
+
+    [Fact(DisplayName = "Deferred constructor builds shells after async initialization")]
+    public async Task DeferredConstructor_AfterInitialize_BuildsShells()
+    {
+        var cache = new ShellSettingsCache();
+        cache.Load([new(new("Default"), ["Weather"])]);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<System.Reflection.Assembly>>([typeof(CShells.Tests.Integration.ShellHost.TestFixtures).Assembly]),
+            fixture.RootProvider,
+            fixture.RootAccessor,
+            fixture.FeatureFactory,
+            exclusionRegistry);
+
+        await host.InitializeAsync();
+
+        var shell = host.GetShell(new("Default"));
+
+        Assert.Equal("Default", shell.Id.Name);
+    }
 }

--- a/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
@@ -12,13 +12,13 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
     private readonly List<IAsyncDisposable> _disposables = [];
 
     [Fact]
-    public void DefaultHostDiscovery_MatchesFromHostAssemblies()
+    public async Task DefaultHostDiscovery_MatchesFromHostAssemblies()
     {
-        var defaultProvider = BuildRootProvider(builder =>
+        var defaultProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
         });
-        var explicitHostProvider = BuildRootProvider(builder =>
+        var explicitHostProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
             CShellsBuilderExtensions.FromHostAssemblies(builder);
@@ -35,9 +35,9 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
     }
 
     [Fact]
-    public void ExplicitAssemblyMode_DoesNotImplicitlyIncludeHostAssemblies()
+    public async Task ExplicitAssemblyMode_DoesNotImplicitlyIncludeHostAssemblies()
     {
-        var serviceProvider = BuildRootProvider(builder =>
+        var serviceProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
             CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
@@ -50,11 +50,11 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
     }
 
     [Fact]
-    public void CustomAssemblyProvider_ComposesAdditivelyAndReceivesRootServiceProviderContext()
+    public async Task CustomAssemblyProvider_ComposesAdditivelyAndReceivesRootServiceProviderContext()
     {
         TrackingFeatureAssemblyProvider.CreatedProviders.Clear();
         var marker = new RootMarkerService();
-        var serviceProvider = BuildRootProvider(
+        var serviceProvider = await BuildRootProviderAsync(
             builder =>
             {
                 builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
@@ -76,10 +76,10 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
     }
 
     [Fact]
-    public void CustomAssemblyProvider_ComposesWithBuiltInProvidersUsingDeduplicatedDiscovery()
+    public async Task CustomAssemblyProvider_ComposesWithBuiltInProvidersUsingDeduplicatedDiscovery()
     {
         TrackingFeatureAssemblyProvider.CreatedProviders.Clear();
-        var serviceProvider = BuildRootProvider(builder =>
+        var serviceProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
             CShellsBuilderExtensions.FromAssemblies(builder, typeof(TestFixtures).Assembly);
@@ -95,7 +95,7 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         Assert.Single(features, feature => feature.Id == "Weather");
     }
 
-    private ServiceProvider BuildRootProvider(Action<CShellsBuilder> configure, Action<IServiceCollection>? configureServices = null)
+    private async Task<ServiceProvider> BuildRootProviderAsync(Action<CShellsBuilder> configure, Action<IServiceCollection>? configureServices = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -105,7 +105,8 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         var serviceProvider = services.BuildServiceProvider();
         var shellSettingsProvider = serviceProvider.GetRequiredService<CShells.Configuration.IShellSettingsProvider>();
         var shellSettingsCache = serviceProvider.GetRequiredService<CShells.Configuration.ShellSettingsCache>();
-        shellSettingsCache.Load(shellSettingsProvider.GetShellSettingsAsync().GetAwaiter().GetResult().ToList());
+        shellSettingsCache.Load((await shellSettingsProvider.GetShellSettingsAsync()).ToList());
+        await serviceProvider.GetRequiredService<CShells.Hosting.DefaultShellHost>().InitializeAsync();
         _disposables.Add(serviceProvider);
         return serviceProvider;
     }

--- a/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
@@ -134,10 +134,10 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
 
         public RootMarkerService? ResolvedMarker { get; } = resolvedMarker;
 
-        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider)
+        public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default)
         {
             CreatedProviders.Add(this);
-            return assemblies;
+            return Task.FromResult(assemblies);
         }
     }
 }

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
@@ -102,7 +102,7 @@ public class CShellsBuilderAssemblySourceTests
     }
 
     [Fact]
-    public void WithAssemblyProvider_FactoryOverloadAppendsProvider()
+    public async Task WithAssemblyProvider_FactoryOverloadAppendsProvider()
     {
         var services = new ServiceCollection();
         services.AddSingleton<MarkerService>();
@@ -112,7 +112,8 @@ public class CShellsBuilderAssemblySourceTests
         CShellsBuilderExtensions.WithAssemblyProvider(builder, _ => new DelegateFeatureAssemblyProvider(_ => [typeof(MarkerService).Assembly]));
 
         var provider = Assert.IsType<DelegateFeatureAssemblyProvider>(Assert.Single(builder.BuildFeatureAssemblyProviders(serviceProvider)));
-        Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(provider.GetAssemblies(serviceProvider)));
+        var assemblies = await provider.GetAssembliesAsync(serviceProvider);
+        Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(assemblies));
     }
 
     [Fact]
@@ -135,7 +136,8 @@ public class CShellsBuilderAssemblySourceTests
             provider =>
             {
                 var delegateProvider = Assert.IsType<DelegateFeatureAssemblyProvider>(provider);
-                Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(delegateProvider.GetAssemblies(serviceProvider)));
+                var assemblies = delegateProvider.GetAssembliesAsync(serviceProvider).GetAwaiter().GetResult();
+                Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(assemblies));
             });
     }
 
@@ -176,16 +178,19 @@ public class CShellsBuilderAssemblySourceTests
 
     private sealed class MissingFeatureAssemblyProvider : IFeatureAssemblyProvider
     {
-        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => [];
+        public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<Assembly>>([]);
     }
 
     private sealed class TestFeatureAssemblyProvider : IFeatureAssemblyProvider
     {
-        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => [typeof(CShellsBuilderAssemblySourceTests).Assembly];
+        public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<Assembly>>([typeof(CShellsBuilderAssemblySourceTests).Assembly]);
     }
 
     private sealed class DelegateFeatureAssemblyProvider(Func<IServiceProvider, IEnumerable<Assembly>> getAssemblies) : IFeatureAssemblyProvider
     {
-        public IEnumerable<Assembly> GetAssemblies(IServiceProvider serviceProvider) => getAssemblies(serviceProvider);
+        public Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default) =>
+            Task.FromResult(getAssemblies(serviceProvider));
     }
 }

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
@@ -27,7 +27,7 @@ public class CShellsBuilderAssemblySourceTests
     }
 
     [Fact]
-    public void FromAssemblies_WithEmptyInput_ActivatesExplicitModeWithoutAssemblies()
+    public async Task FromAssemblies_WithEmptyInput_ActivatesExplicitModeWithoutAssemblies()
     {
         var builder = new CShellsBuilder(new ServiceCollection());
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
@@ -35,7 +35,7 @@ public class CShellsBuilderAssemblySourceTests
         CShellsBuilderExtensions.FromAssemblies(builder);
 
         Assert.True(builder.UsesExplicitFeatureAssemblyProviders);
-        Assert.Empty(FeatureAssemblyResolver.ResolveAssemblies(builder.BuildFeatureAssemblyProviders(serviceProvider), serviceProvider));
+        Assert.Empty(await FeatureAssemblyResolver.ResolveAssembliesAsync(builder.BuildFeatureAssemblyProviders(serviceProvider), serviceProvider));
     }
 
     [Fact]

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderAssemblySourceTests.cs
@@ -117,7 +117,7 @@ public class CShellsBuilderAssemblySourceTests
     }
 
     [Fact]
-    public void WithAssemblyProvider_OverloadsComposeAdditivelyInRegistrationOrder()
+    public async Task WithAssemblyProvider_OverloadsComposeAdditivelyInRegistrationOrder()
     {
         var services = new ServiceCollection();
         services.AddSingleton<TestFeatureAssemblyProvider>();
@@ -129,16 +129,15 @@ public class CShellsBuilderAssemblySourceTests
         CShellsBuilderExtensions.WithAssemblyProvider(builder, instanceProvider);
         CShellsBuilderExtensions.WithAssemblyProvider(builder, _ => new DelegateFeatureAssemblyProvider(_ => [typeof(MarkerService).Assembly]));
 
-        Assert.Collection(
-            builder.BuildFeatureAssemblyProviders(serviceProvider),
-            provider => Assert.Same(serviceProvider.GetRequiredService<TestFeatureAssemblyProvider>(), provider),
-            provider => Assert.Same(instanceProvider, provider),
-            provider =>
-            {
-                var delegateProvider = Assert.IsType<DelegateFeatureAssemblyProvider>(provider);
-                var assemblies = delegateProvider.GetAssembliesAsync(serviceProvider).GetAwaiter().GetResult();
-                Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(assemblies));
-            });
+        var providers = builder.BuildFeatureAssemblyProviders(serviceProvider);
+
+        Assert.Equal(3, providers.Count);
+        Assert.Same(serviceProvider.GetRequiredService<TestFeatureAssemblyProvider>(), providers[0]);
+        Assert.Same(instanceProvider, providers[1]);
+
+        var delegateProvider = Assert.IsType<DelegateFeatureAssemblyProvider>(providers[2]);
+        var assemblies = await delegateProvider.GetAssembliesAsync(serviceProvider);
+        Assert.Equal(typeof(MarkerService).Assembly, Assert.Single(assemblies));
     }
 
     [Fact]

--- a/tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/FeatureAssemblyProviderTests.cs
@@ -6,7 +6,7 @@ namespace CShells.Tests.Unit.Features;
 public class FeatureAssemblyProviderTests
 {
     [Fact]
-    public void ResolveAssemblies_AggregatesExplicitProviderContributionsInOrder()
+    public async Task ResolveAssembliesAsync_AggregatesExplicitProviderContributionsInOrder()
     {
         var firstAssembly = typeof(FeatureAssemblyProviderTests).Assembly;
         var secondAssembly = typeof(CShells.DependencyInjection.CShellsBuilder).Assembly;
@@ -17,13 +17,13 @@ public class FeatureAssemblyProviderTests
         ];
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-        var assemblies = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider);
+        var assemblies = await FeatureAssemblyResolver.ResolveAssembliesAsync(providers, serviceProvider);
 
         Assert.Equal([firstAssembly, secondAssembly], assemblies);
     }
 
     [Fact]
-    public void ResolveAssemblies_DeduplicatesDuplicateAssemblyContributionsUsingFirstSeenOrder()
+    public async Task ResolveAssembliesAsync_DeduplicatesDuplicateAssemblyContributionsUsingFirstSeenOrder()
     {
         var firstAssembly = typeof(FeatureAssemblyProviderTests).Assembly;
         var secondAssembly = typeof(CShells.DependencyInjection.CShellsBuilder).Assembly;
@@ -34,7 +34,7 @@ public class FeatureAssemblyProviderTests
         ];
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-        var assemblies = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider);
+        var assemblies = await FeatureAssemblyResolver.ResolveAssembliesAsync(providers, serviceProvider);
 
         Assert.Equal([firstAssembly, secondAssembly], assemblies);
     }

--- a/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
@@ -18,13 +18,13 @@ public class HostFeatureAssemblyProviderTests
     }
 
     [Fact]
-    public async Task ResolveAssemblies_DeduplicatesRepeatedHostProviderContributions()
+    public async Task ResolveAssembliesAsync_DeduplicatesRepeatedHostProviderContributions()
     {
         IFeatureAssemblyProvider[] providers = [new HostFeatureAssemblyProvider(), new HostFeatureAssemblyProvider()];
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
         var expected = (await new HostFeatureAssemblyProvider().GetAssembliesAsync(serviceProvider)).Select(assembly => assembly.FullName).Distinct().ToArray();
-        var actual = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider).Select(assembly => assembly.FullName).ToArray();
+        var actual = (await FeatureAssemblyResolver.ResolveAssembliesAsync(providers, serviceProvider)).Select(assembly => assembly.FullName).ToArray();
 
         Assert.Equal(expected, actual);
     }

--- a/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/HostFeatureAssemblyProviderTests.cs
@@ -6,24 +6,24 @@ namespace CShells.Tests.Unit.Features;
 public class HostFeatureAssemblyProviderTests
 {
     [Fact]
-    public void GetAssemblies_MatchesSharedHostResolutionAlgorithm()
+    public async Task GetAssembliesAsync_MatchesSharedHostResolutionAlgorithm()
     {
         var provider = new HostFeatureAssemblyProvider();
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
         var expected = FeatureAssemblyResolver.ResolveHostAssemblies().Select(assembly => assembly.FullName).ToArray();
-        var actual = provider.GetAssemblies(serviceProvider).Select(assembly => assembly.FullName).ToArray();
+        var actual = (await provider.GetAssembliesAsync(serviceProvider)).Select(assembly => assembly.FullName).ToArray();
 
         Assert.Equal(expected, actual);
     }
 
     [Fact]
-    public void ResolveAssemblies_DeduplicatesRepeatedHostProviderContributions()
+    public async Task ResolveAssemblies_DeduplicatesRepeatedHostProviderContributions()
     {
         IFeatureAssemblyProvider[] providers = [new HostFeatureAssemblyProvider(), new HostFeatureAssemblyProvider()];
         using var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-        var expected = new HostFeatureAssemblyProvider().GetAssemblies(serviceProvider).Select(assembly => assembly.FullName).Distinct().ToArray();
+        var expected = (await new HostFeatureAssemblyProvider().GetAssembliesAsync(serviceProvider)).Select(assembly => assembly.FullName).Distinct().ToArray();
         var actual = FeatureAssemblyResolver.ResolveAssemblies(providers, serviceProvider).Select(assembly => assembly.FullName).ToArray();
 
         Assert.Equal(expected, actual);


### PR DESCRIPTION
## What changed
- Refactored `IFeatureAssemblyProvider` from synchronous `GetAssemblies(IServiceProvider)` to asynchronous `GetAssembliesAsync(IServiceProvider, CancellationToken)`.
- Updated built-in providers:
  - `ExplicitFeatureAssemblyProvider`
  - `HostFeatureAssemblyProvider`
- Added async assembly resolution path in `FeatureAssemblyResolver` via `ResolveAssembliesAsync(...)`.
- Kept `ResolveAssemblies(...)` as a sync wrapper over the async implementation for existing synchronous call sites.
- Added `BuildFeatureAssembliesAsync(...)` to `CShellsBuilder` and made `BuildFeatureAssemblies(...)` a sync wrapper.
- Updated unit/integration tests and test doubles to the new async provider contract.

## Why
`IFeatureAssemblyProvider` is currently sync-only, which makes integration with async assembly catalogs/loaders awkward and often forces blocking in provider implementations. This change enables providers to perform asynchronous discovery natively while keeping current host call sites operational.

## Validation
Executed locally in the CShells repo:
- `dotnet restore --ignore-failed-sources`
- `dotnet test tests/CShells.Tests/CShells.Tests.csproj --no-restore`

Result: **394 tests passed**, 0 failed.

## Notes
This is a **breaking API change** for custom providers implementing `IFeatureAssemblyProvider` and will require migration to `GetAssembliesAsync(...)`.