### PR TITLE
Implement deferred shell activation and atomic shell reconciliation

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -6,6 +6,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-08
 - C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.Configuration`, `System.Text.Json`, existing `CShells.Configuration` helpers and converters, FluentStorage JSON provider integration (002-feature-object-map)
 - N/A at the feature level; shell definitions originate from configuration providers, in-memory/config models, and FluentStorage JSON blobs (002-feature-object-map)
 - C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.DependencyModel`, `Microsoft.AspNetCore.Builder`, existing `CShells.Features` discovery code, `CShells.DependencyInjection` builder extensions, and ASP.NET Core registration helpers (003-fluent-assembly-selection)
+- C# 14 on .NET 10 for implementation, multi-targeted source projects (`net8.0;net9.0;net10.0`), xUnit for tests, and Markdown planning artifacts + Existing runtime seams in `src/CShells/Hosting/DefaultShellHost.cs`, `src/CShells/Management/DefaultShellManager.cs`, `src/CShells/Configuration/ShellSettingsCache.cs`, `src/CShells/Features/FeatureDiscovery.cs`, `src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`, `src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, and `src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs` (005-deferred-shell-activation)
+- In-memory desired-state and applied-runtime records sourced from `IShellSettingsProvider`; no new external persistence is required for this feature (005-deferred-shell-activation)
 
 - C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Logging`, ASP.NET Core integration packages in adjacent projects, internal notification pipeline in `CShells.Notifications` (001-shell-reload-semantics)
 
@@ -25,10 +27,10 @@ tests/
 C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`): Follow standard conventions
 
 ## Recent Changes
+- 005-deferred-shell-activation: Added C# 14 on .NET 10 for implementation, multi-targeted source projects (`net8.0;net9.0;net10.0`), xUnit for tests, and Markdown planning artifacts + Existing runtime seams in `src/CShells/Hosting/DefaultShellHost.cs`, `src/CShells/Management/DefaultShellManager.cs`, `src/CShells/Configuration/ShellSettingsCache.cs`, `src/CShells/Features/FeatureDiscovery.cs`, `src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`, `src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, and `src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
 - 003-fluent-assembly-selection: Added C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.DependencyModel`, `Microsoft.AspNetCore.Builder`, existing `CShells.Features` discovery code, `CShells.DependencyInjection` builder extensions, and ASP.NET Core registration helpers
 - 002-feature-object-map: Added C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.Configuration`, `System.Text.Json`, existing `CShells.Configuration` helpers and converters, FluentStorage JSON provider integration
 
-- 001-shell-reload-semantics: Added C# 14 on .NET 10 with multi-targeted source projects (`net8.0;net9.0;net10.0`) + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Logging`, ASP.NET Core integration packages in adjacent projects, internal notification pipeline in `CShells.Notifications`
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -2,6 +2,19 @@
 
 CShells provides lifecycle hooks that let shell-scoped services perform work when a shell starts up or shuts down. This is the recommended approach for per-tenant initialization and cleanup — simpler than `IHostedService` because the work runs inside the shell's own DI scope automatically.
 
+## Desired State vs. Applied Runtime
+
+As of the deferred-activation model, CShells tracks two truths for every configured shell:
+
+- **Desired state** — the latest `ShellSettings` definition the runtime has recorded
+- **Applied runtime** — the last fully built, committed shell runtime that is safe to serve
+
+Lifecycle handlers run only for **applied runtime transitions**.
+
+- Recording a new desired generation does **not** trigger `IShellActivatedHandler` by itself.
+- If the new desired generation is deferred (for example, because a feature is missing) or fails to build, the previous applied runtime stays live and no new activation occurs.
+- `IShellDeactivatingHandler` runs only when an applied runtime is actually being replaced or intentionally removed.
+
 ## Overview
 
 | Interface | When It Runs | Use Cases |
@@ -46,11 +59,13 @@ public class PostsFeature : IShellFeature
 
 ### When It Fires
 
-- **Application startup** — all configured shells are activated in order
-- **Dynamic shell addition** — `await shellManager.AddShellAsync(settings)` activates the new shell
-- **Shell reload** — `await shellManager.ReloadShellAsync(id)` or `await shellManager.ReloadAllShellsAsync()` re-activates the rebuilt shell after eviction
+- **Application startup** — every shell that can be reconciled into an applied runtime is activated in order
+- **Dynamic shell addition** — `await shellManager.AddShellAsync(settings)` activates the new shell only after its candidate runtime commits successfully
+- **Shell reload** — `await shellManager.ReloadShellAsync(id)` or `await shellManager.ReloadAllShellsAsync()` re-activates a shell only when a new applied runtime is committed
 - Handlers run in **registration order**
 - If a handler throws, the exception is logged and **propagated** (the shell activation fails)
+
+If a shell's latest desired generation is deferred or failed, no activation handler runs for that attempt. The last-known-good applied runtime, if any, continues serving.
 
 ## IShellDeactivatingHandler
 
@@ -90,9 +105,11 @@ public class AnalyticsFeature : IShellFeature
 
 - **Application shutdown** — all shells are deactivated
 - **Dynamic shell removal** — `await shellManager.RemoveShellAsync(shellId)`
-- **Shell reload** — `await shellManager.ReloadShellAsync(id)` or `await shellManager.ReloadAllShellsAsync()` deactivates the old shell before evicting its service provider
+- **Shell reload** — `await shellManager.ReloadShellAsync(id)` or `await shellManager.ReloadAllShellsAsync()` deactivates the old applied runtime only when a successor runtime is ready to commit
 - Handlers run in **reverse registration order** (LIFO)
 - Exceptions are **logged but swallowed** — all handlers get a chance to run
+
+If a reload records a newer desired generation but that generation is deferred or failed, the currently applied runtime is **not** deactivated.
 
 ## Lifecycle vs. Background Services
 

--- a/docs/shell-resolution.md
+++ b/docs/shell-resolution.md
@@ -1,10 +1,16 @@
 # Shell Resolution
 
-Shell resolution determines which shell handles an incoming HTTP request. CShells provides a configurable resolver pipeline.
+Shell resolution determines which shell handles an incoming HTTP request. CShells provides a configurable resolver pipeline, but only **committed applied runtimes** participate in routing and endpoint exposure.
 
 ## Overview
 
-When a request arrives, the `ShellMiddleware` runs it through an ordered list of `IShellResolverStrategy` implementations. The first strategy that returns a match wins. If none match, the `DefaultShellResolverStrategy` falls back to the shell named `"Default"`.
+When a request arrives, the `ShellMiddleware` runs it through an ordered list of `IShellResolverStrategy` implementations. The first strategy that returns a match wins. Desired-only shells do not participate until they have an applied runtime.
+
+If none of the earlier strategies match, the `DefaultShellResolverStrategy` behaves as follows:
+
+- if an explicit shell named `"Default"` is configured **and currently applied**, it is used
+- if an explicit `"Default"` shell is configured but **not applied**, the resolver returns no shell instead of silently substituting another shell
+- if no explicit `"Default"` shell exists, fallback can choose only from currently applied shells
 
 Important: the middleware gives precedence to the shell that owns a matched endpoint (via `ShellEndpointMetadata` applied to endpoints). If routing has selected an endpoint that was registered by a shell, that endpoint will execute inside the service scope of the shell that registered it — even if the resolver pipeline would otherwise pick a different shell. For this to work the routing middleware must run before the shell middleware (i.e., `UseRouting()` / endpoint routing must be in place before the shell middleware).
 
@@ -101,7 +107,7 @@ Configure a path prefix per shell in `appsettings.json`:
 }
 ```
 
-Result:
+Result (assuming both shells are currently applied):
 
 - `GET /` → Default shell
 - `GET /acme/` → Acme shell
@@ -156,7 +162,14 @@ Result: if the authenticated user has claim `tenant_id = "Acme"`, the request ro
 
 ## Default Shell Fallback
 
-If no strategy matches, `DefaultShellResolverStrategy` resolves to the shell named `"Default"` (case-insensitive).
+If no strategy matches, `DefaultShellResolverStrategy` resolves to the shell named `"Default"` only when that explicit default shell currently has an applied runtime. If an explicit `Default` shell is configured but deferred or failed, fallback returns no shell rather than routing to another tenant.
+
+## Applied-Only Routing and Endpoints
+
+- `WebRoutingShellResolver` evaluates only applied shells.
+- Desired shells that are deferred or failed contribute **no** shell resolution result.
+- `ShellEndpointRegistrationHandler` and dynamic endpoint routing expose endpoints only for applied shells.
+- Operator tooling can still inspect deferred/failed shells through `IShellRuntimeStateAccessor`.
 
 ## Excluding Paths
 

--- a/samples/CShells.Workbench/Program.cs
+++ b/samples/CShells.Workbench/Program.cs
@@ -1,5 +1,6 @@
 using CShells.AspNetCore.Extensions;
 using CShells.DependencyInjection;
+using CShells.Management;
 using CShells.Workbench.Background;
 using CShells.Workbench.Features.Core;
 
@@ -22,6 +23,22 @@ var app = builder.Build();
 
 app.UseHttpsRedirection();
 app.UseRouting();
+
+// Host-level diagnostics stay available even when a shell's newest desired state is deferred.
+// Shell-owned routes are still exposed only for committed applied runtimes via MapShells().
+app.MapGet("/_shells/status", (IShellRuntimeStateAccessor runtimeState) =>
+    Results.Ok(runtimeState.GetAllShells().Select(status => new
+    {
+        shellId = status.ShellId.Name,
+        status.DesiredGeneration,
+        status.AppliedGeneration,
+        outcome = status.Outcome.ToString(),
+        status.IsInSync,
+        status.IsRoutable,
+        status.BlockingReason,
+        missingFeatures = status.MissingFeatures
+    })));
+
 app.MapShells();
 app.Run();
 

--- a/samples/CShells.Workbench/README.md
+++ b/samples/CShells.Workbench/README.md
@@ -50,6 +50,18 @@ The Analytics feature demonstrates `IConfigurableFeature<AnalyticsOptions>` with
 
 `ShellDemoWorker` demonstrates running background tasks within each shell's service scope using `IShellHost` and `IShellContextScopeFactory`.
 
+### 6. Desired vs. Applied Runtime Status
+
+The sample now exposes a host-level diagnostic endpoint at `GET /_shells/status`. It shows, for each configured shell:
+
+- the latest desired generation
+- the currently applied generation (if any)
+- whether the shell is in sync
+- whether it is currently routable
+- any blocking reason / missing features
+
+This helps demonstrate the deferred-activation behavior: configured shells can exist without exposing shell-owned routes until an applied runtime is committed.
+
 ## Running
 
 ```bash
@@ -60,6 +72,9 @@ dotnet run
 ## Example Requests
 
 ```bash
+# Desired vs. applied runtime status for all configured shells
+curl http://localhost:5031/_shells/status
+
 # Default shell (Free plan) — info
 curl http://localhost:5031/
 
@@ -86,6 +101,12 @@ curl http://localhost:5031/acme/posts/1/comments
 # Analytics — only available on Enterprise
 curl http://localhost:5031/contoso/analytics
 ```
+
+## Applied-Only Routing Notes
+
+- Shell-owned routes such as `/`, `/acme/*`, and `/contoso/*` are exposed only for **applied** shells.
+- If the explicit `Default` shell is configured but cannot currently be applied, CShells does **not** silently route `/` to another tenant.
+- The `/_shells/status` endpoint is host-owned, so you can still inspect desired-vs-applied state while a shell is deferred.
 
 ## Project Structure
 

--- a/specs/005-deferred-shell-activation/checklists/requirements.md
+++ b/specs/005-deferred-shell-activation/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Deferred Shell Activation and Runtime Feature Reconciliation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-15  
+**Feature**: [`../spec.md`](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: All checklist items pass for the revised specification.
+- The spec now models two explicit layers of truth per shell: configured desired state and separately committed applied runtime state.
+- The revised requirements make reconciliation atomic and preserve the last-known-good applied runtime until a successor runtime for a newer desired generation is fully ready to commit.
+- The spec applies those semantics to every shell, while still preserving explicit behavior for an explicitly configured `Default` shell with no silent substitution.
+- The spec preserves the originally requested edge cases and outcomes, including refreshable feature catalog behavior, duplicate feature ID failure, deferred and failed outcomes, active-only routing and endpoints, and partial startup with mixed shell readiness.
+

--- a/specs/005-deferred-shell-activation/contracts/runtime-feature-catalog-contract.md
+++ b/specs/005-deferred-shell-activation/contracts/runtime-feature-catalog-contract.md
@@ -1,0 +1,49 @@
+# Public Contract: Runtime Feature Catalog Refresh
+
+## Feature Assembly Provider Contract
+
+Feature assembly providers already participate in discovery through `IFeatureAssemblyProvider`. Under this feature, they also participate in repeated runtime catalog refreshes.
+
+This public interface remains in `CShells.Abstractions`.
+
+```csharp
+namespace CShells.Features;
+
+public interface IFeatureAssemblyProvider
+{
+    Task<IEnumerable<Assembly>> GetAssembliesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken = default);
+}
+```
+
+### Behavioral Rules
+
+- Providers may be called multiple times during the application lifetime, not only once during startup.
+- Each call must return a non-null sequence of assemblies representing the provider's current discoverable contribution.
+- Returning an empty sequence is allowed.
+- Providers must not assume that previously returned assemblies remain the committed runtime catalog input for future refreshes.
+- Providers should be safe for repeated invocation during single-shell and full-shell reconciliation.
+
+## Runtime Feature Catalog Contract
+
+The runtime feature catalog is an implementation-level snapshot in `CShells`, but it exposes externally meaningful behavior because `IFeatureAssemblyProvider` results and shell reconciliation depend on it.
+
+### Behavioral Rules
+
+- Every startup, single-shell reload, and full-shell reload operation refreshes the runtime feature catalog before shell candidate evaluation begins.
+- Catalog refresh builds a candidate snapshot from all configured assembly-provider sources before changing the committed catalog.
+- The candidate snapshot is committed only if feature discovery succeeds and every discovered feature ID is unique.
+- If refresh detects duplicate feature IDs or another catalog-level inconsistency, the refresh fails explicitly and the previously committed catalog remains in effect.
+- A failed catalog refresh aborts the reconciliation operation before any applied shell runtime is changed.
+
+## Shell Candidate Evaluation Contract
+
+Shell reconciliation consumes only the committed feature catalog snapshot from the current refresh pass.
+
+### Behavioral Rules
+
+- Missing required features in the committed catalog produce `DeferredDueToMissingFeatures`, not silent desired-state mutation.
+- Non-missing-feature build or validation problems produce `Failed`.
+- A shell candidate runtime becomes routable only after it is fully built, validated, and atomically committed.
+- A previously applied runtime remains active while a newer desired generation is deferred or failed.
+- Once a later catalog refresh makes a deferred desired generation satisfiable, reconciliation builds a fresh candidate runtime against the newly committed catalog and may promote it in the same pass.
+

--- a/specs/005-deferred-shell-activation/contracts/shell-runtime-reconciliation-contract.md
+++ b/specs/005-deferred-shell-activation/contracts/shell-runtime-reconciliation-contract.md
@@ -1,0 +1,109 @@
+# Public Contract: Shell Runtime Reconciliation
+
+## Runtime Management Contract
+
+The runtime management surface continues to manage shell configuration changes and reconciliation, but its behavioral contract changes to use desired-state recording plus applied-runtime reconciliation instead of immediate in-place activation.
+
+This public interface belongs in `CShells.Abstractions`, even though its implementation stays in `CShells`.
+
+```csharp
+namespace CShells.Management;
+
+public interface IShellManager
+{
+    Task AddShellAsync(ShellSettings settings, CancellationToken cancellationToken = default);
+    Task RemoveShellAsync(ShellId shellId, CancellationToken cancellationToken = default);
+    Task UpdateShellAsync(ShellSettings settings, CancellationToken cancellationToken = default);
+    Task ReloadShellAsync(ShellId shellId, CancellationToken cancellationToken = default);
+    Task ReloadAllShellsAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### Behavioral Rules
+
+- `AddShellAsync(settings)` records a new desired generation for the shell and then runs reconciliation for that shell.
+- `UpdateShellAsync(settings)` records a newer desired generation and then runs reconciliation for that shell.
+- `ReloadShellAsync(shellId)` refreshes the runtime feature catalog first, obtains the latest desired definition for that shell from the configured provider, records it as desired state, and reconciles the shell using the same candidate-build semantics as startup and full reload.
+- `ReloadAllShellsAsync()` refreshes the runtime feature catalog first, obtains the latest desired shell set from the configured provider, records those desired generations, and reconciles every configured shell independently.
+- If a shell's latest desired generation is `DeferredDueToMissingFeatures` or `Failed`, the command still succeeds as a reconciliation operation provided the catalog refresh itself succeeded and the desired state was recorded.
+- `RemoveShellAsync(shellId)` is the explicit operation that removes a shell from desired state and tears down its applied runtime if one exists.
+
+## Runtime State Inspection Contract
+
+Operators and runtime components need a queryable read model for desired-vs-applied shell truth.
+
+This public interface belongs in `CShells.Abstractions`.
+
+```csharp
+namespace CShells.Management;
+
+public interface IShellRuntimeStateAccessor
+{
+    IReadOnlyCollection<ShellRuntimeStatus> GetAllShells();
+    ShellRuntimeStatus? GetShell(ShellId shellId);
+}
+
+public enum ShellReconciliationOutcome
+{
+    Active,
+    DeferredDueToMissingFeatures,
+    Failed
+}
+
+public sealed record ShellRuntimeStatus(
+    ShellId ShellId,
+    long DesiredGeneration,
+    long? AppliedGeneration,
+    ShellReconciliationOutcome Outcome,
+    bool IsInSync,
+    bool IsRoutable,
+    string? BlockingReason,
+    IReadOnlyCollection<string> MissingFeatures);
+```
+
+### Behavioral Rules
+
+- Every configured shell appears in `GetAllShells()`, even when it has no applied runtime.
+- `DesiredGeneration` is always the latest configured generation for the shell.
+- `AppliedGeneration` is null when no runtime has ever been committed or when the shell has been explicitly removed/deactivated.
+- `Outcome == Active` means the shell has an applied runtime, but `IsInSync` may still be false if the shell is serving a last-known-good runtime while a newer desired generation is deferred or failed.
+- `BlockingReason` explains why the latest desired generation is not currently applied.
+- `MissingFeatures` is populated only when the latest desired generation is deferred because the committed catalog does not contain required features.
+
+## Applied Runtime Hosting Contract
+
+The hosting layer continues to expose runtime shell contexts, but only committed applied runtimes are eligible.
+
+Current host implementation remains in `CShells` and does not require a new consumer-extensibility contract for the internal candidate-build pipeline.
+
+### Behavioral Rules
+
+- `IShellHost.GetShell(shellId)` succeeds only for shells with a committed applied runtime.
+- `IShellHost.AllShells` returns only committed applied runtimes.
+- `IShellHost.DefaultShell` returns the explicitly configured `Default` shell only when it currently has an applied runtime.
+- If `Default` is explicitly configured but currently unapplied, default resolution reports it unavailable instead of silently returning another shell.
+- If no explicit `Default` shell is configured, fallback selection may choose only from shells with applied active runtimes.
+
+## Lifecycle and Reconciliation Notification Contract
+
+Framework-owned notifications remain in `CShells`, but their behavioral meaning changes to align with applied-runtime commits.
+
+```csharp
+namespace CShells.Notifications;
+
+public record ShellActivated(/* committed applied runtime */) : INotification;
+public record ShellDeactivating(/* currently applied runtime being replaced or removed */) : INotification;
+public record ShellReloading(/* reconciliation scope metadata */) : INotification;
+public record ShellReloaded(/* reconciliation result metadata */) : INotification;
+public record ShellsReloaded(/* aggregate reconciliation snapshot */) : INotification;
+```
+
+### Behavioral Rules
+
+- `ShellActivated` is emitted only when a candidate runtime is committed and becomes applied.
+- Recording a new desired generation that later defers or fails does not emit `ShellActivated`.
+- `ShellDeactivating` is emitted only for a currently applied runtime that is about to be replaced or removed.
+- Desired-state events such as `ShellAdded`, `ShellUpdated`, and `ShellRemoved` describe configuration intent changes and must not by themselves imply endpoint eligibility.
+- Aggregate reconciliation notifications must give consumers enough information to distinguish active, deferred, and failed shells after a reconciliation pass.
+- Endpoint registration and routing consumers must respond only to applied-runtime results, not to desired-state updates alone.
+

--- a/specs/005-deferred-shell-activation/data-model.md
+++ b/specs/005-deferred-shell-activation/data-model.md
@@ -1,0 +1,171 @@
+# Data Model: Deferred Shell Activation and Atomic Shell Reconciliation
+
+## Configured Desired Shell Generation
+
+Represents the latest configured version of a shell that operators want the system to run, regardless of whether the runtime can currently apply it.
+
+### Fields
+
+- `ShellId`: stable shell identifier
+- `DesiredGeneration`: monotonically increasing generation or revision token for that shell's desired definition
+- `DesiredSettings`: the authoritative `ShellSettings` payload for the generation
+- `ConfiguredFeatures`: required configured features after configuration binding and normalization
+- `ConfigurationData`: shell-scoped configuration values for that generation
+- `RecordedAt`: the time the desired generation became current in the runtime state store
+
+### Validation Rules
+
+- `ShellId` must remain unique among configured shells.
+- `DesiredGeneration` must advance whenever the authoritative desired definition changes.
+- `ConfiguredFeatures` remain required by default; missing catalog entries do not remove them from desired state.
+- Removing a shell from desired state is an explicit operation, not an inferred consequence of deferred or failed reconciliation.
+
+## Applied Shell Runtime
+
+Represents the last committed runtime instance for a shell that is currently safe to serve.
+
+### Fields
+
+- `ShellId`: stable shell identifier
+- `AppliedGeneration`: the desired generation from which the current runtime was committed
+- `ShellContext`: the committed runtime context and service provider for the shell
+- `CatalogGeneration`: the runtime feature catalog snapshot used to build the applied runtime
+- `ActivatedAt`: the time the runtime became active
+- `IsActive`: whether this applied runtime is currently eligible for routing, endpoints, and active-shell enumeration
+
+### State Transitions
+
+- `NotApplied` → `Active`: the shell's first satisfiable desired generation is built and committed
+- `Active(generation N)` → `Active(generation N+1)`: a newer desired generation is built as a candidate and atomically committed
+- `Active` → `NotApplied`: the shell is explicitly removed or deactivated and the applied runtime is intentionally torn down
+
+### Validation Rules
+
+- At most one applied runtime may be active per shell at a time.
+- `AppliedGeneration` must never be greater than the current `DesiredGeneration`.
+- Routing and endpoints may use only `IsActive == true` applied runtimes.
+
+## Runtime Feature Catalog Snapshot
+
+Represents one validated, immutable view of the discoverable feature catalog assembled from all configured feature assembly providers.
+
+### Fields
+
+- `CatalogGeneration`: monotonically increasing snapshot identifier
+- `Assemblies`: the resolved assembly set used for discovery during this refresh
+- `FeatureDescriptors`: discovered feature descriptors keyed by feature ID
+- `ProviderInputs`: the assembly-provider sources that contributed to the snapshot
+- `RefreshedAt`: refresh completion time
+- `ValidationOutcome`: `Valid` or `Invalid`
+- `ValidationFailure`: optional duplicate-ID or catalog-level failure details
+
+### State Transitions
+
+- `Current` → `CandidateRefresh`: provider assemblies are re-evaluated and a new snapshot is built off to the side
+- `CandidateRefresh` → `Current`: the candidate snapshot validates successfully and becomes the applied catalog
+- `CandidateRefresh` → `Discarded`: duplicate IDs or other catalog-level validation failures prevent commit
+
+### Validation Rules
+
+- A catalog snapshot is committed only if every discovered feature ID is unique.
+- An invalid candidate catalog must not replace the current applied catalog.
+- Shell candidate builds for one reconciliation pass use the same committed catalog snapshot.
+
+## Candidate Shell Runtime
+
+Represents a not-yet-serving runtime built for a specific desired shell generation against a specific catalog snapshot.
+
+### Fields
+
+- `ShellId`: stable shell identifier
+- `TargetDesiredGeneration`: the desired generation this candidate attempts to apply
+- `CatalogGeneration`: the catalog snapshot used for validation and build
+- `ResolvedFeatures`: ordered feature set used for the candidate build
+- `BuildOutcome`: `ReadyToCommit`, `DeferredDueToMissingFeatures`, or `Failed`
+- `MissingFeatures`: explicit required feature IDs missing from the committed catalog, if any
+- `FailureReason`: non-missing-feature build or validation failure details, if any
+- `CandidateContext`: the built `ShellContext` when `BuildOutcome == ReadyToCommit`
+
+### State Transitions
+
+- `Planned` → `DeferredDueToMissingFeatures`: required configured features are absent from the committed catalog
+- `Planned` → `Failed`: feature dependency resolution, configuration binding, service registration, or validation fails for a non-missing-feature reason
+- `Planned` → `ReadyToCommit`: the runtime is fully built and validated off to the side
+- `ReadyToCommit` → `Committed`: the candidate atomically replaces the previous applied runtime, if any
+- `ReadyToCommit` → `Discarded`: a newer desired generation supersedes the candidate before commit
+
+### Validation Rules
+
+- `MissingFeatures` is populated only for deferred outcomes.
+- `FailureReason` is populated only for failed outcomes.
+- `CandidateContext` exists only for `ReadyToCommit` candidates.
+- A candidate must never become routable before the commit transition completes.
+
+## Shell Reconciliation Status
+
+Represents the operator-visible record for one configured shell after a reconciliation pass.
+
+### Fields
+
+- `ShellId`: stable shell identifier
+- `DesiredGeneration`: latest configured desired generation
+- `AppliedGeneration`: nullable currently committed generation
+- `Outcome`: `Active`, `DeferredDueToMissingFeatures`, or `Failed`
+- `IsInSync`: whether `AppliedGeneration` matches `DesiredGeneration`
+- `IsRoutable`: whether the shell currently has an applied active runtime
+- `DriftReason`: explanation when `IsInSync == false`
+- `BlockingReason`: explanation when the latest desired generation is deferred or failed
+- `MissingFeatures`: required feature IDs still blocking application, if any
+
+### Relationships
+
+- Every configured shell has exactly one current reconciliation status.
+- A status references one current desired generation.
+- A status references zero or one applied runtime.
+- A status may reference the latest candidate outcome even when the applied runtime remains older and active.
+
+### Validation Rules
+
+- `Outcome == Active` does not imply `IsInSync == true`; a shell may remain active on the last-known-good applied generation while the newest desired generation is deferred or failed.
+- `IsRoutable` is true only when an applied runtime exists and is active.
+- `BlockingReason` is required whenever the latest desired generation is not currently applied.
+
+## Default Shell Resolution State
+
+Represents fallback-resolution eligibility for the shell named `Default` and the runtime's applied-shell fallback policy.
+
+### Fields
+
+- `HasExplicitDefault`: whether a shell named `Default` exists in configured desired state
+- `DefaultDesiredGeneration`: the latest desired generation for the explicit default shell, if configured
+- `DefaultAppliedGeneration`: the currently applied generation for the explicit default shell, if any
+- `IsExplicitDefaultAvailable`: whether the explicit default currently has an applied active runtime
+- `FallbackCandidateShellIds`: shells eligible for fallback only when no explicit default shell is configured
+
+### Validation Rules
+
+- If `HasExplicitDefault == true` and `IsExplicitDefaultAvailable == false`, fallback resolution must report `Default` as unavailable rather than selecting another shell.
+- `FallbackCandidateShellIds` must contain only shells with applied active runtimes.
+- If no shells have an applied active runtime, fallback resolution yields no shell.
+
+## Reconciliation Operation
+
+Represents one startup, single-shell, or full-shell runtime reconciliation pass.
+
+### Fields
+
+- `Scope`: `Startup`, `SingleShell`, or `AllShells`
+- `TargetShellId`: nullable; populated only for single-shell reconciliation
+- `DesiredStateSet`: configured shells considered during the pass
+- `CatalogGeneration`: the committed feature catalog snapshot used by the pass
+- `PerShellStatuses`: resulting status records for affected shells
+- `CommittedShellIds`: shells whose applied runtimes changed during the pass
+- `FailedShellIds`: shells whose latest desired generation ended in `Failed`
+- `DeferredShellIds`: shells whose latest desired generation ended in `DeferredDueToMissingFeatures`
+
+### Validation Rules
+
+- Every reconciliation operation refreshes the catalog before evaluating shell candidate builds.
+- Single-shell and all-shell reconciliation share the same candidate-build and atomic-commit semantics.
+- A catalog-refresh failure aborts the operation before any `CommittedShellIds` are recorded.
+

--- a/specs/005-deferred-shell-activation/plan.md
+++ b/specs/005-deferred-shell-activation/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Deferred Shell Activation and Atomic Shell Reconciliation
+
+**Branch**: `005-deferred-shell-activation` | **Date**: 2026-04-15 | **Spec**: `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/005-deferred-shell-activation/spec.md`
+**Input**: Feature specification from `/specs/005-deferred-shell-activation/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Redesign shell activation around two separate truths per configured shell: the latest configured desired generation and the last committed applied runtime generation. The implementation should stop treating `ShellSettingsCache` plus `DefaultShellHost`'s current cache as a single mutable truth, introduce a refreshable runtime feature catalog that can be rebuilt safely during the app lifetime, and run startup/add/update/reload through a shell-agnostic reconciliation pipeline that builds candidate runtimes against the refreshed catalog before atomically committing them. Deferred or failed desired generations must preserve the last-known-good applied runtime when one exists, routing and endpoint registration must enumerate applied active runtimes only, and explicit `Default` behavior must remain strict: if `Default` is configured but unapplied, the runtime reports it as unavailable instead of silently substituting another shell.
+
+## Technical Context
+
+**Language/Version**: C# 14 on .NET 10 for implementation, multi-targeted source projects (`net8.0;net9.0;net10.0`), xUnit for tests, and Markdown planning artifacts  
+**Primary Dependencies**: Existing runtime seams in `src/CShells/Hosting/DefaultShellHost.cs`, `src/CShells/Management/DefaultShellManager.cs`, `src/CShells/Configuration/ShellSettingsCache.cs`, `src/CShells/Features/FeatureDiscovery.cs`, `src/CShells.Abstractions/Features/IFeatureAssemblyProvider.cs`, `src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, and `src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`  
+**Storage**: In-memory desired-state and applied-runtime records sourced from `IShellSettingsProvider`; no new external persistence is required for this feature  
+**Testing**: xUnit unit tests in `tests/CShells.Tests/Unit/`, integration tests in `tests/CShells.Tests/Integration/`, and ASP.NET Core end-to-end verification in `tests/CShells.Tests.EndToEnd/` for routing and explicit default behavior  
+**Target Platform**: Cross-platform .NET class libraries with ASP.NET Core runtime integration  
+**Project Type**: Multi-project framework/library with abstractions, implementation packages, tests, docs, wiki, and sample app  
+**Performance Goals**: Refresh the runtime feature catalog once per reconciliation operation, keep the current applied runtime serving until a successor candidate is fully ready, avoid tearing down unaffected shells during partial reconciliation, and keep routing/endpoints stable for already applied shells when newer desired generations defer or fail  
+**Constraints**: Preserve strict required-feature semantics, fail duplicate feature IDs before mutating the applied catalog or applied runtimes, support partial startup, keep routing and lifecycle behavior applied-runtime-only, allow breaking changes where necessary, and place any new public operator/extensibility contracts in `*.Abstractions` projects  
+**Scale/Scope**: Planning covers `src/CShells.Abstractions/`, `src/CShells/`, `src/CShells.AspNetCore/`, focused documentation updates, and new unit/integration/E2E coverage around reconciliation state, feature catalog refresh, atomic commit semantics, active-only routing, and explicit `Default` resolution
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Abstraction-First Architecture**: PASS. The redesign can keep catalog refresh and candidate-commit orchestration as internal framework seams in `CShells`, while any new operator-visible read model or runtime-state inspection API is planned for `CShells.Abstractions` before implementation.
+- **Feature Modularity**: PASS. The work changes shell orchestration, catalog refresh, routing eligibility, and lifecycle semantics without weakening per-feature isolation, dependency ordering, or constructor constraints.
+- **Modern C# Style**: PASS. The plan stays within the repository’s existing C# 14, file-scoped namespace, nullable, explicit-access, and xUnit conventions.
+- **Explicit Error Handling**: PASS. Deferred missing-feature outcomes, failed candidate builds, duplicate feature ID refresh failures, and explicit `Default` unavailability will all be surfaced as first-class outcomes instead of silent mutation or fallback.
+- **Test Coverage**: PASS. The feature requires new unit, integration, and likely E2E coverage for mixed shell states, catalog refresh failure, atomic runtime replacement, and active-only routing behavior.
+- **Simplicity & Minimalism**: PASS. The chosen direction introduces the minimum architecture needed to separate desired from applied truth, reuses the existing manager/host/resolver/notification seams where practical, and avoids speculative optional-feature modeling.
+
+**Post-Design Re-check**: PASS. The design artifacts keep the implementation centered on a small set of runtime-state records, a refreshable catalog snapshot, an atomic per-shell candidate commit flow, and one public status-inspection seam rather than a broad new abstraction graph.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-deferred-shell-activation/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── shell-runtime-reconciliation-contract.md
+│   └── runtime-feature-catalog-contract.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells.Abstractions/
+│   ├── Configuration/
+│   │   └── IShellSettingsProvider.cs
+│   ├── Features/
+│   │   └── IFeatureAssemblyProvider.cs
+│   └── Management/
+│       ├── IShellManager.cs
+│       ├── IShellRuntimeStateAccessor.cs           # likely new public read contract
+│       ├── ShellReconciliationOutcome.cs           # likely new public outcome vocabulary
+│       └── ShellRuntimeStatus.cs                   # likely new public desired-vs-applied snapshot
+├── CShells/
+│   ├── Configuration/
+│   │   ├── IShellSettingsCache.cs
+│   │   ├── ShellSettingsCache.cs
+│   │   └── ShellSettingsCacheInitializer.cs
+│   ├── Features/
+│   │   ├── FeatureDiscovery.cs
+│   │   └── RuntimeFeatureCatalog.cs               # likely new internal refreshable catalog snapshot
+│   ├── Hosting/
+│   │   ├── DefaultShellHost.cs
+│   │   ├── IShellHost.cs
+│   │   ├── ShellContext.cs
+│   │   └── ShellStartupHostedService.cs
+│   ├── Management/
+│   │   └── DefaultShellManager.cs
+│   ├── Notifications/
+│   │   ├── ShellActivated.cs
+│   │   ├── ShellAdded.cs
+│   │   ├── ShellDeactivating.cs
+│   │   ├── ShellReloaded.cs
+│   │   ├── ShellReloading.cs
+│   │   ├── ShellRemoved.cs
+│   │   ├── ShellsReloaded.cs
+│   │   └── ShellUpdated.cs
+│   └── Resolution/
+│       └── DefaultShellResolverStrategy.cs
+└── CShells.AspNetCore/
+    ├── Notifications/
+    │   └── ShellEndpointRegistrationHandler.cs
+    ├── Resolution/
+    │   └── WebRoutingShellResolver.cs
+    └── Routing/
+        └── DynamicShellEndpointDataSource.cs
+
+tests/
+├── CShells.Tests/
+│   ├── Unit/
+│   │   ├── Features/
+│   │   ├── Hosting/
+│   │   ├── Management/
+│   │   └── Resolution/
+│   └── Integration/
+│       ├── DefaultShellHost/
+│       ├── Management/
+│       └── AspNetCore/
+└── CShells.Tests.EndToEnd/
+
+docs/
+├── shell-lifecycle.md
+└── shell-resolution.md
+
+wiki/
+├── Runtime-Shell-Management.md
+├── Shell-Lifecycle.md
+└── Shell-Resolution.md
+```
+
+**Structure Decision**: Keep the runtime orchestration work inside the existing `CShells` implementation projects instead of inventing a separate reconciliation package. The internal redesign centers on `DefaultShellHost`, `DefaultShellManager`, the in-memory shell settings/runtime caches, and a new refreshable catalog snapshot near feature discovery. The only planned new public surface is a minimal operator-facing desired-vs-applied state inspection contract in `CShells.Abstractions/Management`, plus any supporting public records or enums it returns. ASP.NET Core changes remain focused on routing and endpoint registration so only committed applied runtimes are visible to the web layer.
+
+## Complexity Tracking
+
+No constitution violations or justified complexity exceptions were identified during planning.

--- a/specs/005-deferred-shell-activation/quickstart.md
+++ b/specs/005-deferred-shell-activation/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: Implement Deferred Shell Activation and Atomic Shell Reconciliation
+
+## Purpose
+
+Use this guide when implementing feature `005-deferred-shell-activation` so CShells records desired shell definitions immediately, preserves last-known-good applied runtimes, refreshes the feature catalog safely, and exposes only committed applied runtimes to routing and endpoints.
+
+## 1. Confirm the current single-truth seams
+
+Inspect the existing runtime pieces that currently blend configured shell data and active runtime availability.
+
+Primary inspection targets:
+
+```bash
+cd /Users/sipke/Projects/ValenceWorks/cshells/main
+
+grep -n "DefaultShell\|GetShell\|AllShells\|EvictShell" src/CShells/Hosting/DefaultShellHost.cs
+
+grep -n "ReloadShellAsync\|ReloadAllShellsAsync\|AddShellAsync\|UpdateShellAsync\|RemoveShellAsync" src/CShells/Management/DefaultShellManager.cs
+
+grep -n "GetAll\|GetById\|Load" src/CShells/Configuration/IShellSettingsCache.cs src/CShells/Configuration/ShellSettingsCache.cs
+
+grep -n "Resolve" src/CShells/Resolution/DefaultShellResolverStrategy.cs src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
+
+grep -n "ShellAdded\|ShellRemoved\|ShellReloaded\|ShellsReloaded" src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+```
+
+## 2. Introduce a dual-state runtime model
+
+Add a runtime-state model that keeps configured desired state separate from applied runtime state.
+
+- Preserve `ShellSettings` as the authoritative desired definition input.
+- Add per-shell runtime records that store desired generation, applied generation, reconciliation outcome, and blocking reason.
+- Ensure a shell can remain configured with no applied runtime.
+- Add a small public inspection surface in `CShells.Abstractions` for operator-visible desired-vs-applied status.
+
+## 3. Add a refreshable runtime feature catalog
+
+Replace one-time feature discovery assumptions with a refreshable snapshot model.
+
+- Re-evaluate all configured `IFeatureAssemblyProvider` sources before each reconciliation pass.
+- Build a candidate catalog snapshot off to the side.
+- Fail the refresh explicitly on duplicate feature IDs or catalog inconsistencies.
+- Keep the previously committed catalog untouched on refresh failure.
+
+## 4. Implement candidate-build then atomic commit semantics per shell
+
+Reconciliation should build successor runtimes before mutating applied runtime state.
+
+- Validate the latest desired generation against the committed catalog snapshot.
+- Record `DeferredDueToMissingFeatures` with missing-feature details when the catalog does not satisfy the desired definition.
+- Record `Failed` with an actionable failure reason when candidate build or validation fails for other reasons.
+- Preserve the last-known-good applied runtime until a ready candidate can be committed.
+- Publish deactivation/activation lifecycle events only around real applied-runtime commits.
+
+## 5. Unify startup, single-shell reload, and full reconciliation semantics
+
+Move startup and runtime management flows onto one reconciliation model.
+
+- Startup records desired state for every configured shell and applies only satisfiable shells.
+- `ReloadShellAsync(shellId)` refreshes the catalog first and reconciles the targeted shell with the same candidate-build semantics.
+- `ReloadAllShellsAsync()` refreshes the catalog first and re-evaluates every configured shell independently.
+- Removal remains the only path that intentionally deletes a shell from desired state.
+
+## 6. Align routing, endpoints, and fallback resolution to applied state only
+
+Ensure web runtime behavior never exposes desired-only shells.
+
+- `WebRoutingShellResolver` should resolve only shells with an applied active runtime.
+- `DefaultShellResolverStrategy` must preserve explicit `Default` semantics: if `Default` is configured but unapplied, fallback must report it unavailable.
+- `ShellEndpointRegistrationHandler` and `DynamicShellEndpointDataSource` should register endpoints only for committed applied runtimes.
+- Desired-only deferred or failed shells must contribute no endpoints.
+
+## 7. Add operator-visible reconciliation status and clear notifications
+
+Make drift and blocking reasons observable without confusing desired-state updates with activations.
+
+- Expose desired generation, applied generation, reconciliation outcome, sync status, and blocking/drift reason for each configured shell.
+- Keep desired-state notifications separate from applied-runtime lifecycle notifications.
+- Ensure aggregate reload notifications provide enough information for endpoint registration and operator inspection to distinguish active, deferred, and failed shells.
+
+## 8. Validate the mixed-state scenarios
+
+Run focused tests for the revised architecture, then the broader suites.
+
+```bash
+cd /Users/sipke/Projects/ValenceWorks/cshells/main
+
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~DeferredShellActivation|FullyQualifiedName~ShellManager|FullyQualifiedName~DefaultShellHost|FullyQualifiedName~ShellResolver"
+
+dotnet test tests/CShells.Tests.EndToEnd/
+
+dotnet test tests/CShells.Tests/
+```
+
+## Expected Outcomes
+
+- Desired shell definitions remain authoritative even when not currently buildable.
+- The runtime preserves last-known-good applied shells during deferred or failed updates.
+- Feature catalog refreshes can make previously deferred shells satisfiable without restart.
+- Duplicate feature IDs fail the refresh before any applied state changes.
+- Only committed applied runtimes are routable and endpoint-visible.
+- Explicit `Default` fallback behavior is strict and never silently substitutes another shell.
+

--- a/specs/005-deferred-shell-activation/research.md
+++ b/specs/005-deferred-shell-activation/research.md
@@ -1,0 +1,92 @@
+# Phase 0 Research: Deferred Shell Activation and Atomic Shell Reconciliation
+
+## Decision: Model each configured shell with separate desired and applied runtime state
+
+**Rationale**: The current runtime effectively treats `IShellSettingsCache` plus `DefaultShellHost`'s built `ShellContext` cache as one mutable truth. That is incompatible with the feature spec because desired configuration must be recorded immediately even when the runtime cannot apply it yet. The design therefore uses a per-shell runtime record with two distinct layers: the latest configured desired generation and the last committed applied runtime generation, if any. This gives reconciliation a stable place to record drift, deferred outcomes, and last-known-good preservation without mutating away operator intent.
+
+**Alternatives considered**:
+
+- Keep `ShellSettingsCache` as the only authoritative state and encode deferred state indirectly in exceptions or logs: rejected because it cannot represent desired-versus-applied drift explicitly.
+- Mutate configured features to match what is currently buildable: rejected because the spec forbids silent feature removal and requires the desired definition to remain authoritative.
+- Track only an applied runtime and force operators to infer desired state from providers: rejected because reconciliation status must remain inspectable even when no runtime is currently applied.
+
+## Decision: Refresh the runtime feature catalog as a snapshot before every reconciliation operation
+
+**Rationale**: The revised architecture depends on late-loaded assemblies becoming discoverable during the application lifetime. A one-time feature discovery pass at host initialization is not sufficient. The feature catalog should therefore become a refreshable snapshot produced by re-evaluating all configured `IFeatureAssemblyProvider` sources before startup reconciliation, single-shell reload, and full-shell reload. That snapshot becomes the input to candidate validation and build decisions.
+
+**Alternatives considered**:
+
+- Keep feature discovery one-time and require process restart to pick up new assemblies: rejected because the spec explicitly requires refreshable catalog behavior.
+- Refresh feature discovery only for full reloads: rejected because the spec requires one-shell and full-shell reconciliation to use the same refresh-first semantics.
+- Merge newly discovered features directly into the existing feature map without a snapshot boundary: rejected because duplicate detection and rollback become ambiguous.
+
+## Decision: Treat duplicate feature IDs and catalog-level inconsistencies as atomic catalog-refresh failures
+
+**Rationale**: The runtime must preserve the previously applied catalog and all previously applied shell runtimes if a refresh discovers duplicate feature IDs or another catalog-level inconsistency. The safest model is a candidate catalog snapshot that is validated in isolation and committed only after the full refresh succeeds. Shell reconciliation must not begin against a partially valid catalog.
+
+**Alternatives considered**:
+
+- Keep the first discovered feature and log a warning for duplicates: rejected because the spec requires explicit failure, not silent precedence.
+- Refresh unaffected shells against the new catalog while skipping only the duplicate IDs: rejected because the catalog itself is defined as invalid for that refresh cycle.
+- Tear down current applied runtimes before building the replacement catalog: rejected because it violates last-known-good preservation.
+
+## Decision: Reconcile shells through a candidate-build-then-atomic-commit pipeline
+
+**Rationale**: The spec requires the currently serving runtime to remain active until a fully buildable successor for a newer desired generation is ready. That means reconciliation must build and validate a `Candidate Runtime` off to the side, using the latest desired generation and refreshed catalog snapshot, before any applied runtime swap occurs. Only after candidate validation succeeds should the runtime publish deactivation/activation events, replace the applied runtime, and update applied-state metadata as one logical commit.
+
+**Alternatives considered**:
+
+- Evict the old `ShellContext` first and rebuild in place: rejected because failures would create avoidable downtime and lose the last-known-good runtime.
+- Record a desired generation as active before the service provider is built: rejected because routing and endpoints must reflect only committed applied runtimes.
+- Use a global all-shell cutover barrier that blocks every shell on the slowest candidate: rejected because the spec calls for shell-agnostic reconciliation where unaffected shells continue serving.
+
+## Decision: Preserve the last-known-good applied runtime for both deferred and failed desired generations
+
+**Rationale**: Missing required features are a recoverable deferred outcome, and non-missing-feature candidate build problems are failed outcomes, but neither should tear down a healthy applied runtime for the same shell. The reconciliation record should store the latest desired generation outcome and reason while leaving the prior applied runtime active until a later desired generation can be committed or the shell is explicitly removed from desired state.
+
+**Alternatives considered**:
+
+- Deactivate the shell whenever the newest desired generation cannot be applied: rejected because it creates unnecessary downtime and violates the spec.
+- Preserve last-known-good only for missing-feature deferrals, not for general failures: rejected because the spec explicitly requires preservation for non-missing-feature failures too.
+- Automatically roll desired state back to the last applied generation: rejected because it would discard operator intent.
+
+## Decision: Make routing, endpoint registration, and active-shell enumeration depend on applied runtime state only
+
+**Rationale**: `WebRoutingShellResolver`, `DefaultShellResolverStrategy`, `ShellEndpointRegistrationHandler`, and `DynamicShellEndpointDataSource` currently reason from configured shells and can therefore over-expose shells that are not safely serving. Under the revised model, those components must consult the applied runtime set only. Desired-only shells stay visible through status inspection but contribute no resolved shell, no endpoints, and no active-shell enumeration until a candidate runtime has been committed.
+
+**Alternatives considered**:
+
+- Let deferred desired generations continue contributing endpoints from configuration alone: rejected because the spec explicitly requires active-only routing and endpoints.
+- Keep resolution based on configured shells and fail later during request activation: rejected because it produces misleading routing behavior and late failures.
+- Hide deferred or failed shells entirely, including from operator inspection: rejected because the spec requires clear visibility into drift and blocking reasons.
+
+## Decision: Apply the same reconciliation semantics to every configured shell, with explicit `Default` fallback rules
+
+**Rationale**: The spec rejects a `Default`-only activation model. Every configured shell must have the same desired/applied separation and reconciliation lifecycle. `Default` keeps one special rule only in fallback resolution: if a shell named `Default` is explicitly configured but currently unapplied, fallback resolution must report that explicit default as unavailable instead of silently selecting another configured shell. If no explicit `Default` exists, fallback may choose only from shells with an applied active runtime.
+
+**Alternatives considered**:
+
+- Preserve special activation rules only for `Default`: rejected because the feature must apply to every shell.
+- When explicit `Default` is unavailable, silently use the first applied shell: rejected because the spec explicitly forbids silent substitution.
+- Disable all fallback selection when no explicit `Default` exists: rejected because the existing default-resolution model can still operate safely when limited to applied active runtimes.
+
+## Decision: Add a minimal public runtime-state inspection contract in `CShells.Abstractions`
+
+**Rationale**: Operators and integration code need a stable way to inspect desired generation, applied generation, in-sync status, outcome, and blocking reason for each configured shell. Because that is an external consumer-facing contract, it belongs in `CShells.Abstractions` under the constitution. A small read-only accessor and corresponding status records are sufficient; the candidate build pipeline, catalog refresh internals, and atomic commit mechanics stay implementation-only in `CShells`.
+
+**Alternatives considered**:
+
+- Expose internal caches from `DefaultShellHost` directly: rejected because that leaks implementation details and violates the abstraction-first rule.
+- Reuse `IShellManager` for both commands and status reads: rejected because it mixes mutation and inspection concerns and makes the status surface harder to evolve.
+- Provide status only through logging and notifications: rejected because operators need queryable current state, not just event history.
+
+## Decision: Tie lifecycle notifications to applied runtime changes, not merely to desired-state updates
+
+**Rationale**: `ShellActivated` and `ShellDeactivating` must describe real applied-runtime transitions. Recording a new desired generation that is deferred or failed is not a successful activation. The notification model should therefore treat desired-state events (`ShellAdded`, `ShellUpdated`, `ShellRemoved`) separately from applied-runtime commit events and ensure aggregate reload notifications convey reconciliation results rich enough for endpoint registration and operator visibility.
+
+**Alternatives considered**:
+
+- Keep publishing `ShellActivated` immediately for every desired update: rejected because it conflicts with active-only semantics.
+- Remove desired-state notifications entirely: rejected because explicit configuration changes remain meaningful operator events.
+- Require endpoint registration handlers to infer applied-state changes by rebuilding every shell on each event: rejected because it couples web runtime behavior to expensive guesswork instead of clear reconciliation outcomes.
+

--- a/specs/005-deferred-shell-activation/spec.md
+++ b/specs/005-deferred-shell-activation/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Deferred Shell Activation and Atomic Shell Reconciliation
+
+**Feature Branch**: `005-deferred-shell-activation`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: User description: "Revise the existing deferred shell activation feature to prefer a cleaner ideal architecture with breaking changes allowed. The model must apply to every shell, not only `Default`, and must explicitly separate configured desired state from applied runtime state. Reconciliation must be atomic: the last-known-good active runtime stays in service until a valid successor runtime for a newer desired generation is fully buildable and ready to commit. Configuration updates that reference not-yet-available features must become pending or deferred desired state instead of tearing down the currently active runtime. Once late-loaded assemblies become available and the refreshed feature catalog satisfies the desired shell, the system must build a candidate runtime and atomically swap to it. Routing and endpoints must stay active-only. The spec must preserve refreshable feature catalog behavior, duplicate feature ID failure, deferred or failed outcomes, partial startup, and explicit semantics for an explicitly configured `Default` shell with no silent substitution." 
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve Live Service While New Desired State Waits (Priority: P1)
+
+As an application operator, I want each shell's latest configured definition to be recorded immediately while the last-known-good applied runtime stays live until a newer valid runtime is ready, so configuration changes never silently discard intent or cause avoidable downtime.
+
+**Why this priority**: This is the central architecture shift. The feature must separate what operators want the shell to be from what runtime is currently safe to serve.
+
+**Independent Test**: Start with an active shell, update its configuration so the new desired version references a not-yet-available feature, and confirm that the new desired version is recorded as pending with a deferred reason while the previously applied runtime remains active and routable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shell already has an active applied runtime and a newer configuration version references a required feature that is missing from the refreshed feature catalog, **When** reconciliation evaluates that newer desired version, **Then** the newer desired version is recorded as `DeferredDueToMissingFeatures`, the previously applied runtime remains in service, and the shell is marked as out of sync until reconciliation succeeds.
+2. **Given** a shell has no previously applied runtime and its configured desired version references one or more missing required features, **When** startup reconciliation runs, **Then** the shell has no active runtime, its desired version is recorded as `DeferredDueToMissingFeatures`, and its configured features remain intact rather than being silently removed.
+3. **Given** a shell already has an active applied runtime and a newer desired version fails to build for a reason other than missing required features, **When** reconciliation attempts to build a replacement runtime, **Then** the newer desired version is recorded as `Failed`, the last-known-good applied runtime remains in service, and the failure reason is visible to operators.
+4. **Given** a shell named `Default` is explicitly configured and its latest desired version is not currently applied, **When** fallback shell resolution is attempted, **Then** the system does not silently substitute a different configured shell for that explicit default shell.
+
+---
+
+### User Story 2 - Atomically Reconcile All Shells After Catalog Refresh (Priority: P2)
+
+As an application operator, I want runtime refresh and reload operations to refresh the feature catalog and reconcile every affected shell atomically, so newly satisfiable desired versions can replace older runtimes without partial cutovers or service gaps.
+
+**Why this priority**: Deferred activation only becomes operationally useful when late-arriving feature assemblies can move shells from pending desired state to applied runtime state without restarts or unstable transitions.
+
+**Independent Test**: Start with one shell deferred and another shell running an older applied runtime because its newer desired version is currently unsatisfied, then make the missing features discoverable, trigger reconciliation, and confirm that the refreshed catalog enables candidate build and atomic replacement for each newly satisfiable shell.
+
+**Acceptance Scenarios**:
+
+1. **Given** any shell has a desired version that is newer than its applied runtime because required features were previously missing, **When** a refresh or reload operation runs after those features become discoverable, **Then** the system refreshes the feature catalog first, builds a candidate runtime for the desired version, and atomically swaps to that new runtime only after it is fully ready.
+2. **Given** some shells are already in sync and others are pending newer desired versions, **When** a full reconciliation runs after a catalog refresh, **Then** each shell is re-evaluated independently against the refreshed catalog and latest desired configuration, allowing newly satisfiable shells to advance without disrupting shells that already have valid applied runtimes.
+3. **Given** a catalog refresh discovers duplicate feature IDs from the configured assembly-provider set, **When** reconciliation is requested, **Then** the refresh fails explicitly and the previously applied catalog and all previously applied shell runtimes remain unchanged.
+
+---
+
+### User Story 3 - Expose Clear Desired-vs-Applied Status to Operators and Routing (Priority: P3)
+
+As a CShells maintainer, I want routing, endpoints, and operator-visible status to reflect the applied runtime state while also exposing drift from the latest desired state, so the system serves only committed active runtimes and still explains why a shell is pending or blocked.
+
+**Why this priority**: The architecture is only trustworthy if operators can distinguish "what is configured now" from "what is actually serving now" and if request handling respects that distinction.
+
+**Independent Test**: Exercise startup and later reconciliation with shells in mixed conditions, including in-sync active shells, shells with active last-known-good runtimes but pending desired updates, and shells with no applied runtime, then confirm that only committed active runtimes are routable and that status inspection shows desired generation, applied generation, drift, and blocking reason for every shell.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shell has an older applied runtime still serving while a newer desired version is deferred, **When** endpoint registration and request resolution are evaluated, **Then** routing and endpoints continue to use only the applied active runtime while operator status shows the newer desired version as pending with its blocking reason.
+2. **Given** one or more shells have no applied runtime because their desired versions are deferred or failed, **When** endpoint registration and request resolution are evaluated, **Then** those shells contribute no routable endpoints and no successful resolution outcomes.
+3. **Given** startup or reload finishes with a mix of in-sync shells, shells serving last-known-good runtimes, and shells with no applied runtime, **When** operators inspect shell status, **Then** they can see the desired generation, applied generation if any, reconciliation outcome, and blocking or drift reason for each configured shell.
+
+### Edge Cases
+
+- A catalog refresh discovers the same feature ID from two different late-loaded assemblies; the refresh must fail explicitly before any applied catalog or applied shell runtime is changed.
+- A shell is active on generation N, but generation N+1 is configured with a missing required feature; the system must keep generation N serving while recording generation N+1 as deferred pending desired state.
+- A shell has no previously applied runtime and its first desired generation cannot be satisfied; startup must leave that shell unapplied while still allowing unrelated shells to activate.
+- A refreshed catalog again makes a pending desired generation satisfiable after several unsuccessful attempts; the system must build a fresh candidate and atomically commit it without requiring manual re-entry of the desired configuration.
+- A shell's desired generation becomes invalid for a non-missing-features reason while an older applied runtime remains healthy; the system must preserve the older applied runtime and record the newer desired generation as failed.
+- A configured `Default` shell is pending or failed while other shells are active; fallback resolution must not silently route requests to a different shell that the operator did not explicitly configure as the default.
+- A catalog refresh removes a feature required by the latest desired generation of multiple shells while older applied runtimes still exist; each shell must record deferred drift independently while preserving its last-known-good applied runtime until a valid successor can be committed or the desired state changes.
+- No shells have an applied runtime after reconciliation because every configured shell is deferred or failed; routing must expose no shell-backed endpoints and operator status must report the system as configured but currently unapplied.
+
+## Two-Layer Shell Truth Model
+
+### Per-Shell Sources of Truth
+
+| Layer | Meaning | Update rule |
+| --- | --- | --- |
+| Configured desired state | The latest configured shell definition, including required features and configuration, regardless of whether it can currently run. | It updates whenever configuration providers publish a newer shell definition. |
+| Applied runtime state | The last committed runtime for that shell that is safe to serve, if one exists. | It changes only after a candidate runtime for a target desired generation has been fully built, validated, and atomically committed. |
+
+### Reconciliation Outcome Vocabulary
+
+| Outcome | Meaning | Availability rules |
+| --- | --- | --- |
+| `Active` | The applied runtime exists and is currently serving. This may be fully in sync with desired state or may be the last-known-good runtime while a newer desired generation is pending. | Only the applied active runtime may be resolved, expose endpoints, and participate in active lifecycle behavior. |
+| `DeferredDueToMissingFeatures` | The latest desired generation cannot yet be built because one or more required features are not present in the refreshed feature catalog. | If an older applied runtime exists, it remains active until a valid successor is ready; otherwise the shell has no applied runtime and is unavailable. |
+| `Failed` | The latest desired generation cannot currently be built for a reason other than missing required features. | If an older applied runtime exists, it remains active until a later desired generation can be committed; otherwise the shell has no applied runtime and is unavailable. |
+
+### Required Operator Visibility Per Shell
+
+Operators and runtime components must be able to inspect, for each configured shell, the latest desired generation, the currently applied generation if any, whether those generations are in sync, the reconciliation outcome for the latest desired generation, and the blocking or drift reason when the desired generation is not currently applied.
+
+## Current Architecture Interaction Analysis
+
+| Component | Current role in CShells | Required behavior direction for this feature |
+| --- | --- | --- |
+| `DefaultShellHost` | Discovers features, validates configured features, and lazily builds `ShellContext` instances from `ShellSettings`. | It must separate desired shell definitions from applied shell runtimes, preserve last-known-good applied runtimes, and participate in candidate-build-then-commit reconciliation instead of treating one mutable runtime view as the only truth. |
+| `DefaultShellManager` | Reloads one shell or all shells from provider data and evicts or rebuilds runtime contexts. | It must refresh the feature catalog before evaluation, compute the latest desired generation for each affected shell, build candidate runtimes off to the side, and atomically commit only those candidates that are fully ready while leaving existing applied runtimes untouched on deferred or failed outcomes. |
+| `ShellStartupHostedService` | Eagerly activates all shells at startup and publishes startup lifecycle notifications. | It must support partial startup by recording desired state for every configured shell, applying runtimes only for satisfiable shells, and leaving the rest deferred or failed without deleting their desired definitions. |
+| `ShellEndpointRegistrationHandler` | Registers or removes shell endpoints in response to shell lifecycle notifications. | It must treat committed applied active runtimes as the only endpoint-eligible source and react to atomic swaps, removals, and loss of applied runtime without exposing pending desired generations. |
+| Feature assembly providers | Supply assemblies used for feature discovery, including host and explicit assembly sources. | They must participate in repeatable catalog refresh cycles so late-loaded assemblies can satisfy pending desired generations after startup. |
+| Resolver behavior, including `DefaultShellResolverStrategy` | Chooses which shell should handle a request, with a fallback that currently resolves `Default`. | Resolution must consult only applied active runtimes. If `Default` is explicitly configured but does not currently have an applied runtime for its latest desired state, the system must report that explicit default as unavailable rather than silently substituting another shell. |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST treat configured features as required by default and MUST NOT silently drop a configured feature merely because that feature is missing from the current runtime feature catalog.
+- **FR-002**: The system MUST maintain, for every configured shell, a configured desired state that is authoritative even when no runtime can currently be applied.
+- **FR-003**: The system MUST maintain, separately from desired state, an applied runtime state representing the last committed runtime that is currently safe to serve, if any.
+- **FR-004**: The system MUST expose whether each shell's desired state and applied runtime state are in sync or whether the shell is serving a last-known-good applied runtime while a newer desired generation remains pending.
+- **FR-005**: When a newer desired shell generation references one or more required features that are missing from the refreshed runtime feature catalog, the system MUST record that desired generation as `DeferredDueToMissingFeatures` instead of mutating its configured feature set.
+- **FR-006**: When a shell has an existing applied runtime and its newer desired generation is `DeferredDueToMissingFeatures`, the system MUST preserve the existing applied runtime in service until a valid successor runtime for a newer desired generation is fully ready to commit or the shell is explicitly removed from desired state.
+- **FR-007**: When a shell has no existing applied runtime and its desired generation is `DeferredDueToMissingFeatures`, the system MUST keep the shell unapplied and unavailable for routing while preserving the full desired configuration.
+- **FR-008**: If a desired shell generation cannot be built for a reason other than missing required features, the system MUST record that desired generation as `Failed` and MUST preserve any existing applied runtime for that shell until a valid successor is ready or the shell is explicitly removed from desired state.
+- **FR-009**: The system MUST retain the reason for each deferred or failed desired generation, including which required features are missing for deferred outcomes and what failure blocked candidate build or validation for failed outcomes.
+- **FR-010**: The system MUST provide a refreshable runtime feature catalog that can re-evaluate all configured feature assembly providers multiple times during the application lifetime.
+- **FR-011**: Every shell reload or shell-set reconciliation operation MUST refresh the runtime feature catalog before evaluating and mutating shell runtime state.
+- **FR-012**: If a catalog refresh detects duplicate feature IDs or any other catalog-level inconsistency, the refresh MUST fail explicitly and MUST leave the previously applied catalog and all previously applied shell runtimes unchanged.
+- **FR-013**: For any shell whose desired generation is eligible to advance, the system MUST build and validate a candidate runtime before changing the currently applied runtime for that shell.
+- **FR-014**: Reconciliation MUST commit a shell runtime update atomically: the system MUST keep the current applied runtime serving until the successor runtime for the target desired generation is fully ready, and the system MUST swap from old applied runtime to new applied runtime as one logical commit.
+- **FR-015**: Once a pending or deferred desired generation becomes satisfiable after a later catalog refresh, the system MUST build a candidate runtime for that desired generation and atomically promote it to the applied runtime during the same reconciliation pass.
+- **FR-016**: Startup MUST support partial startup by recording desired state for every configured shell, applying runtimes only for shells whose desired generations are buildable, and leaving other shells deferred or failed without blocking unrelated shells.
+- **FR-017**: Shell reconciliation semantics MUST apply to every configured shell, not only to `Default`, although the spec MUST retain explicit resolver behavior for an explicitly configured `Default` shell.
+- **FR-018**: If a shell named `Default` is explicitly configured but does not currently have an applied runtime for its latest desired state, default-shell resolution MUST report that shell as unavailable and MUST NOT silently substitute a different configured shell.
+- **FR-019**: If no shell named `Default` is configured, any fallback default-shell selection behavior MUST choose only from shells that currently have an applied active runtime.
+- **FR-020**: Only shells with an applied active runtime MUST be eligible for request resolution, route registration, endpoint exposure, and active-shell enumeration used by the web runtime.
+- **FR-021**: A pending desired generation that is deferred or failed MUST NOT expose endpoints or routing independently of the currently applied runtime.
+- **FR-022**: Endpoint-registration behavior MUST respond to atomic shell commits so newly applied runtimes gain endpoints only after commit, and shells that lose their applied runtime through removal or explicit deactivation lose endpoints before reconciliation is considered complete.
+- **FR-023**: Lifecycle behavior tied to shell activation and deactivation MUST apply only to changes in applied active runtime state; recording a new desired generation that has not yet been committed MUST NOT be treated as a completed activation.
+- **FR-024**: The system MUST expose, for every configured shell, the desired generation, applied generation if any, reconciliation outcome, in-sync or out-of-sync status, and blocking or drift reason so operators can inspect why a shell is active, pending, deferred, or failed.
+- **FR-025**: A configured shell MUST remain part of desired state until it is removed from shell configuration; deferred or failed outcomes for the latest desired generation MUST NOT imply silent deletion.
+- **FR-026**: Runtime management behavior for one-shell reloads and full-shell reconciliation MUST use the same catalog-refresh-first, candidate-build, and atomic-commit semantics.
+- **FR-027**: Any future support for optional configured features MUST require explicit modeling in shell configuration or feature metadata; optionality MUST NOT be inferred from missing catalog entries.
+- **FR-028**: The design for this feature MAY introduce breaking changes to existing public contracts and internal architecture where needed to support separate desired and applied state, atomic runtime replacement, and refreshable catalog behavior.
+
+### Key Entities *(include if feature involves data)*
+
+- **Configured Desired Shell Generation**: The latest configured version of a shell, including its required features and configuration, regardless of whether it can currently be applied.
+- **Applied Shell Runtime**: The last committed runtime instance for a shell that is currently serving traffic, if one exists.
+- **Shell Reconciliation Record**: The operator-visible record for one shell that links desired generation, applied generation, in-sync or out-of-sync status, reconciliation outcome, and blocking or drift reason.
+- **Runtime Feature Catalog**: The current discoverable set of feature definitions assembled from all configured feature assembly providers during a refresh cycle.
+- **Candidate Runtime**: A fully built and validated prospective runtime for a target desired shell generation that is not yet serving until atomic commit occurs.
+- **Deferred Activation Reason**: The explicit record of which required configured features are currently missing and therefore block application of the latest desired generation.
+- **Failure Reason**: The explicit record of a non-deferred candidate-build or validation problem that blocks application of the latest desired generation.
+
+### Assumptions
+
+- Late-loaded assemblies may become available through the same configured feature assembly providers that participate in initial discovery, so refresh must re-evaluate providers rather than relying on one-time discovery.
+- Missing required features are treated as a recoverable deferred outcome for the latest desired generation rather than as permission to drop configuration or tear down an existing applied runtime.
+- Candidate runtimes can be built and validated before they replace an existing applied runtime, enabling atomic commit semantics.
+- Partial startup is preferred over all-or-nothing startup when the runtime feature catalog itself is valid and at least one shell can apply successfully.
+- A shell may legitimately have no applied runtime even while its desired state exists, and operator tooling needs to show that distinction clearly.
+- Explicit optional-feature semantics may be introduced later, but this feature assumes strict required semantics unless configuration says otherwise in a future design.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In startup tests where configured shells have mixed readiness, 100% of shells whose desired generations are buildable become usable, and 100% of shells whose desired generations are not buildable are reported as deferred or failed without silent feature removal.
+- **SC-002**: In update tests where an already active shell receives a newer desired generation that is not yet satisfiable, 100% of those shells continue serving their previously applied runtime until a valid successor runtime is ready or the desired state is explicitly changed again.
+- **SC-003**: After additional feature packages become discoverable and reconciliation is triggered, 100% of previously deferred desired generations that are now satisfiable are promoted to applied runtime without requiring an application restart.
+- **SC-004**: In reconciliation tests where a catalog refresh detects duplicate feature IDs or another catalog-level inconsistency, 100% of such refresh attempts fail before any previously applied shell availability is changed.
+- **SC-005**: In routing and endpoint verification after startup and reconciliation, 0 shells without an applied active runtime are routable, and 100% of exposed shell-backed endpoints belong only to committed applied runtimes.
+- **SC-006**: In mixed-outcome reconciliation tests, operators can inspect the desired generation, applied generation if any, reconciliation outcome, and blocking or drift reason for 100% of configured shells.

--- a/specs/005-deferred-shell-activation/tasks.md
+++ b/specs/005-deferred-shell-activation/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: Deferred Shell Activation and Atomic Shell Reconciliation
+
+**Input**: Design documents from `/specs/005-deferred-shell-activation/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/runtime-feature-catalog-contract.md`, `contracts/shell-runtime-reconciliation-contract.md`
+
+**Tests**: Include focused xUnit and ASP.NET Core end-to-end coverage because the specification, plan, research, and quickstart explicitly require verification for desired-vs-applied shell state, refreshable feature catalog behavior, atomic reconciliation, active-only routing/endpoints, and strict explicit `Default` semantics.
+
+**Organization**: Tasks are grouped by user story so the dual-state runtime model lands first, catalog refresh and atomic reconciliation build on that foundation second, and routing/operator visibility align to committed applied runtimes last.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., `US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Repository root: `/Users/sipke/Projects/ValenceWorks/cshells/main`
+- Public contracts belong in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/`
+- Runtime orchestration belongs in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/`
+- Web/runtime exposure belongs in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/`
+- Automated coverage belongs in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/`
+- Operator/sample guidance updates stay limited to the lifecycle, resolution, runtime-management, and workbench assets already in scope for this feature
+
+[US1]: #phase-3-user-story-1---preserve-live-service-while-new-desired-state-waits-priority-p1--mvp
+[US2]: #phase-4-user-story-2---atomically-reconcile-all-shells-after-catalog-refresh-priority-p2
+[US3]: #phase-5-user-story-3---expose-clear-desired-vs-applied-status-to-operators-and-routing-priority-p3
+
+## Phase 1: Setup (Architecture Baseline)
+
+**Purpose**: Lock the exact runtime, web, and test seams that the deferred-activation redesign will change before introducing new abstractions or reconciliation flow.
+
+- [ ] T001 [P] Audit the current single-truth runtime seams in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+- [ ] T002 [P] Audit the current routing/endpoint/test touchpoints in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce the shared desired-vs-applied state contracts, internal state store, and refreshable catalog scaffolding that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T003 Create the public runtime-state inspection contracts in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/IShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellRuntimeStatus.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellReconciliationOutcome.cs`
+- [ ] T004 [P] Add the internal desired/applied runtime records and state store in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeRecord.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
+- [ ] T005 [P] Add the refreshable runtime feature catalog snapshot/validation seam in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureDiscovery.cs`
+- [ ] T006 Wire the shared runtime-state and catalog services through `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+
+**Checkpoint**: The desired/applied read model, internal state storage, and refreshable catalog seam exist so user stories can build on one reconciliation architecture.
+
+---
+
+## Phase 3: User Story 1 - Preserve Live Service While New Desired State Waits (Priority: P1) 🎯 MVP
+
+**Goal**: Record every shell’s latest desired generation immediately while preserving the last-known-good applied runtime through deferred and failed successor attempts, including strict explicit `Default` semantics.
+
+**Independent Test**: Start with an active shell, update it to a desired generation that references an unavailable feature or fails candidate build, and confirm the new desired generation is recorded with a deferred/failed reason while the previous applied runtime remains active; if the shell is the explicit `Default`, fallback must report it unavailable instead of silently substituting another shell.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE**: Add these tests before finalizing implementation so the desired-vs-applied split, last-known-good preservation, and explicit `Default` behavior are locked by failing coverage first.
+
+- [ ] T007 [P] [US1] Add desired-versus-applied status projection coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs`
+- [ ] T008 [P] [US1] Extend deferred/failed last-known-good preservation coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs`
+- [ ] T009 [P] [US1] Add explicit configured `Default` unavailable fallback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Separate desired-state recording from applied-runtime commit in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`
+- [ ] T011 [US1] Implement candidate-build outcomes, blocking-reason capture, and last-known-good preservation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
+- [ ] T012 [US1] Enforce explicit `Default` applied-runtime semantics in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
+
+**Checkpoint**: Desired shell definitions remain authoritative, last-known-good runtimes stay active through deferred/failed successors, and explicit `Default` never silently falls through to another shell.
+
+---
+
+## Phase 4: User Story 2 - Atomically Reconcile All Shells After Catalog Refresh (Priority: P2)
+
+**Goal**: Refresh the runtime feature catalog before every reconciliation pass, build candidate runtimes against the committed snapshot, and atomically promote only fully ready successors while preserving the previous catalog and applied runtimes on refresh failure.
+
+**Independent Test**: Start with deferred and out-of-sync shells, make missing features discoverable, trigger single-shell and full reloads, and confirm the catalog refresh happens first, duplicate IDs abort the refresh without state mutation, and newly satisfiable shells atomically swap from their old applied runtime to the new committed runtime.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T013 [P] [US2] Add repeated provider-refresh and duplicate-feature-ID rollback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs`
+- [ ] T014 [P] [US2] Extend mixed-shell reconciliation and atomic replacement coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Implement candidate catalog refresh, provider re-evaluation, and duplicate-ID abort behavior in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`
+- [ ] T016 [US2] Move `ReloadShellAsync(...)` and `ReloadAllShellsAsync()` onto refresh-first shell-agnostic reconciliation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+- [ ] T017 [US2] Implement atomic per-shell candidate commit and applied-runtime lifecycle notifications in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellActivated.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellDeactivating.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloading.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloaded.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellsReloaded.cs`
+
+**Checkpoint**: Runtime feature discovery refreshes safely per reconciliation pass, duplicate IDs fail fast without mutating applied state, and newly satisfiable shells advance only through candidate-build then atomic commit.
+
+---
+
+## Phase 5: User Story 3 - Expose Clear Desired-vs-Applied Status to Operators and Routing (Priority: P3)
+
+**Goal**: Make routing, endpoints, and operator-visible status reflect applied active runtimes only while still surfacing desired-state drift, blocking reasons, and unapplied shells clearly.
+
+**Independent Test**: Reconcile shells into mixed states and confirm only committed applied runtimes resolve requests or expose endpoints, while runtime status inspection still reports desired generation, applied generation, outcome, sync/drift, and blocking details for every configured shell.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T018 [P] [US3] Add applied-active routing and unapplied-shell resolution coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
+- [ ] T019 [P] [US3] Add committed-runtime-only endpoint exposure coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs`
+- [ ] T020 [P] [US3] Add mixed-state runtime status and strict explicit `Default` end-to-end coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Restrict shell retrieval, `AllShells`, and default-shell enumeration to committed applied runtimes in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
+- [ ] T022 [US3] Align request resolution to applied-active shells only in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
+- [ ] T023 [US3] Align endpoint registration and dynamic routing refresh to applied-runtime commit events in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
+- [ ] T024 [US3] Implement the operator-facing runtime status accessor in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
+
+**Checkpoint**: Only committed applied runtimes are routable or endpoint-visible, and operators can inspect desired-versus-applied drift for every configured shell.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update the in-scope guidance assets and validate the final architecture against the quickstart scenarios and targeted test suites.
+
+- [ ] T025 [P] Update desired-vs-applied lifecycle and runtime-management guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-lifecycle.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Runtime-Shell-Management.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Lifecycle.md`
+- [ ] T026 [P] Update active-only routing and explicit `Default` guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/README.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs`
+- [ ] T027 Run the quickstart validation flow from `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/005-deferred-shell-activation/quickstart.md` against `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies; start immediately.
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3: User Story 1 (P1)**: Depends on Phase 2 because desired/applied separation, last-known-good preservation, and explicit `Default` semantics are the architectural MVP.
+- **Phase 4: User Story 2 (P2)**: Depends on User Story 1 because catalog refresh and atomic commit build directly on the dual-state runtime model and last-known-good behavior.
+- **Phase 5: User Story 3 (P3)**: Depends on User Story 2 so routing, endpoints, and operator visibility reflect the final applied-runtime-only reconciliation semantics.
+- **Phase 6: Polish**: Depends on the stories you intend to ship and should run after code, tests, and behavior are stable.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: MVP; no dependency on later stories.
+- **User Story 2 (P2)**: Depends on User Story 1 because refreshable catalogs and atomic candidate promotion need the desired/applied runtime split to exist first.
+- **User Story 3 (P3)**: Depends on User Story 2 because active-only routing/endpoints and operator visibility must reflect the committed reconciliation semantics, not an intermediate model.
+
+### Within Each User Story
+
+- Add story-specific failing tests before finalizing implementation.
+- Record or refresh desired/catalog state before mutating applied runtime state.
+- Build candidate runtimes before publishing applied-runtime lifecycle events.
+- Align routing/endpoints only after the committed applied-runtime semantics are stable.
+- Finish each story with its independent verification scenario before moving to the next priority.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel during the architecture baseline audit.
+- T004 and T005 can run in parallel after T003 defines the public read model.
+- T007, T008, and T009 can run in parallel for User Story 1 because they touch different test files.
+- T013 and T014 can run in parallel for User Story 2.
+- T018, T019, and T020 can run in parallel for User Story 3.
+- T025 and T026 can run in parallel during the final guidance update.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Build the User Story 1 guardrails in parallel:
+Task: "Add desired-versus-applied status projection coverage in tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs"
+Task: "Extend deferred/failed last-known-good preservation coverage in tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs"
+Task: "Add explicit configured Default unavailable fallback coverage in tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Split catalog-refresh and reconciliation verification across contributors:
+Task: "Add repeated provider-refresh and duplicate-feature-ID rollback coverage in tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs"
+Task: "Extend mixed-shell reconciliation and atomic replacement coverage in tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs and tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Build routing, endpoint, and operator-visibility verification in parallel:
+Task: "Add applied-active routing and unapplied-shell resolution coverage in tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs"
+Task: "Add committed-runtime-only endpoint exposure coverage in tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs"
+Task: "Add mixed-state runtime status and strict explicit Default end-to-end coverage in tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs and tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Validate that desired state and applied runtime state are separated, last-known-good runtimes stay live, and explicit `Default` remains strict before moving on.
+
+### Incremental Delivery
+
+1. Establish the public status contract, internal runtime state store, and refreshable catalog seam.
+2. Deliver User Story 1 so every shell records desired intent separately from applied runtime state and preserves last-known-good service.
+3. Deliver User Story 2 so reload and refresh flows re-evaluate provider assemblies, build candidates, and commit atomically.
+4. Deliver User Story 3 so routing, endpoints, and operator visibility reflect committed applied runtimes only.
+5. Finish with docs/sample updates and quickstart-driven validation.
+
+### Parallel Team Strategy
+
+1. Split the Phase 1 source audit from the web/test audit.
+2. After T003 lands, have one contributor build the internal runtime state store while another builds the refreshable catalog seam.
+3. During User Story 1, split unit coverage, manager reload coverage, and explicit `Default` integration coverage across contributors.
+4. During User Story 2, split catalog-refresh validation from lifecycle/reload integration coverage.
+5. During User Story 3, split routing, endpoint, and runtime-status coverage plus their corresponding implementation work by subsystem.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and can be completed in parallel safely once their prerequisites are satisfied.
+- `[US1]`, `[US2]`, and `[US3]` map directly to the prioritized stories in `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/005-deferred-shell-activation/spec.md`.
+- The task order intentionally mirrors the chosen architecture: separate desired state from applied runtime state first, refresh and validate the runtime feature catalog second, then build candidate runtimes and commit atomically before exposing applied state to routing and operator tooling.
+- Keep the implementation focused on the listed contracts, runtime orchestration seams, web integration points, and in-scope guidance assets; avoid reintroducing silent feature removal, configured-shell routing, or non-atomic runtime replacement paths.
+

--- a/specs/005-deferred-shell-activation/tasks.md
+++ b/specs/005-deferred-shell-activation/tasks.md
@@ -30,8 +30,8 @@
 
 **Purpose**: Lock the exact runtime, web, and test seams that the deferred-activation redesign will change before introducing new abstractions or reconciliation flow.
 
-- [ ] T001 [P] Audit the current single-truth runtime seams in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
-- [ ] T002 [P] Audit the current routing/endpoint/test touchpoints in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
+- [X] T001 [P] Audit the current single-truth runtime seams in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+- [X] T002 [P] Audit the current routing/endpoint/test touchpoints in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
 
 ---
 
@@ -41,10 +41,10 @@
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T003 Create the public runtime-state inspection contracts in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/IShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellRuntimeStatus.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellReconciliationOutcome.cs`
-- [ ] T004 [P] Add the internal desired/applied runtime records and state store in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeRecord.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
-- [ ] T005 [P] Add the refreshable runtime feature catalog snapshot/validation seam in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureDiscovery.cs`
-- [ ] T006 Wire the shared runtime-state and catalog services through `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+- [X] T003 Create the public runtime-state inspection contracts in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/IShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellRuntimeStatus.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Management/ShellReconciliationOutcome.cs`
+- [X] T004 [P] Add the internal desired/applied runtime records and state store in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeRecord.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
+- [X] T005 [P] Add the refreshable runtime feature catalog snapshot/validation seam in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureDiscovery.cs`
+- [X] T006 Wire the shared runtime-state and catalog services through `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
 
 **Checkpoint**: The desired/applied read model, internal state storage, and refreshable catalog seam exist so user stories can build on one reconciliation architecture.
 
@@ -60,15 +60,15 @@
 
 > **NOTE**: Add these tests before finalizing implementation so the desired-vs-applied split, last-known-good preservation, and explicit `Default` behavior are locked by failing coverage first.
 
-- [ ] T007 [P] [US1] Add desired-versus-applied status projection coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs`
-- [ ] T008 [P] [US1] Extend deferred/failed last-known-good preservation coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs`
-- [ ] T009 [P] [US1] Add explicit configured `Default` unavailable fallback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs`
+- [X] T007 [P] [US1] Add desired-versus-applied status projection coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs`
+- [X] T008 [P] [US1] Extend deferred/failed last-known-good preservation coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs`
+- [X] T009 [P] [US1] Add explicit configured `Default` unavailable fallback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Separate desired-state recording from applied-runtime commit in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`
-- [ ] T011 [US1] Implement candidate-build outcomes, blocking-reason capture, and last-known-good preservation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
-- [ ] T012 [US1] Enforce explicit `Default` applied-runtime semantics in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
+- [X] T010 [US1] Separate desired-state recording from applied-runtime commit in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/ShellSettingsCache.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/ShellStartupHostedService.cs`
+- [X] T011 [US1] Implement candidate-build outcomes, blocking-reason capture, and last-known-good preservation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateStore.cs`
+- [X] T012 [US1] Enforce explicit `Default` applied-runtime semantics in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
 
 **Checkpoint**: Desired shell definitions remain authoritative, last-known-good runtimes stay active through deferred/failed successors, and explicit `Default` never silently falls through to another shell.
 
@@ -82,14 +82,14 @@
 
 ### Tests for User Story 2 ⚠️
 
-- [ ] T013 [P] [US2] Add repeated provider-refresh and duplicate-feature-ID rollback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs`
-- [ ] T014 [P] [US2] Extend mixed-shell reconciliation and atomic replacement coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`
+- [X] T013 [P] [US2] Add repeated provider-refresh and duplicate-feature-ID rollback coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs`
+- [X] T014 [P] [US2] Extend mixed-shell reconciliation and atomic replacement coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Implement candidate catalog refresh, provider re-evaluation, and duplicate-ID abort behavior in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`
-- [ ] T016 [US2] Move `ReloadShellAsync(...)` and `ReloadAllShellsAsync()` onto refresh-first shell-agnostic reconciliation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
-- [ ] T017 [US2] Implement atomic per-shell candidate commit and applied-runtime lifecycle notifications in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellActivated.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellDeactivating.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloading.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloaded.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellsReloaded.cs`
+- [X] T015 [US2] Implement candidate catalog refresh, provider re-evaluation, and duplicate-ID abort behavior in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/RuntimeFeatureCatalog.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/HostFeatureAssemblyProvider.cs`
+- [X] T016 [US2] Move `ReloadShellAsync(...)` and `ReloadAllShellsAsync()` onto refresh-first shell-agnostic reconciliation in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`
+- [X] T017 [US2] Implement atomic per-shell candidate commit and applied-runtime lifecycle notifications in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellActivated.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellDeactivating.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloading.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellReloaded.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Notifications/ShellsReloaded.cs`
 
 **Checkpoint**: Runtime feature discovery refreshes safely per reconciliation pass, duplicate IDs fail fast without mutating applied state, and newly satisfiable shells advance only through candidate-build then atomic commit.
 
@@ -103,16 +103,16 @@
 
 ### Tests for User Story 3 ⚠️
 
-- [ ] T018 [P] [US3] Add applied-active routing and unapplied-shell resolution coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
-- [ ] T019 [P] [US3] Add committed-runtime-only endpoint exposure coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs`
-- [ ] T020 [P] [US3] Add mixed-state runtime status and strict explicit `Default` end-to-end coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs`
+- [X] T018 [P] [US3] Add applied-active routing and unapplied-shell resolution coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs`
+- [X] T019 [P] [US3] Add committed-runtime-only endpoint exposure coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs`
+- [X] T020 [P] [US3] Add mixed-state runtime status and strict explicit `Default` end-to-end coverage in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T021 [US3] Restrict shell retrieval, `AllShells`, and default-shell enumeration to committed applied runtimes in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
-- [ ] T022 [US3] Align request resolution to applied-active shells only in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
-- [ ] T023 [US3] Align endpoint registration and dynamic routing refresh to applied-runtime commit events in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
-- [ ] T024 [US3] Implement the operator-facing runtime status accessor in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
+- [X] T021 [US3] Restrict shell retrieval, `AllShells`, and default-shell enumeration to committed applied runtimes in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/IShellHost.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
+- [X] T022 [US3] Align request resolution to applied-active shells only in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Resolution/DefaultShellResolverStrategy.cs`
+- [X] T023 [US3] Align endpoint registration and dynamic routing refresh to applied-runtime commit events in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs` and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
+- [X] T024 [US3] Implement the operator-facing runtime status accessor in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/ShellRuntimeStateAccessor.cs`, `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Management/DefaultShellManager.cs`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Hosting/DefaultShellHost.cs`
 
 **Checkpoint**: Only committed applied runtimes are routable or endpoint-visible, and operators can inspect desired-versus-applied drift for every configured shell.
 
@@ -122,9 +122,9 @@
 
 **Purpose**: Update the in-scope guidance assets and validate the final architecture against the quickstart scenarios and targeted test suites.
 
-- [ ] T025 [P] Update desired-vs-applied lifecycle and runtime-management guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-lifecycle.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Runtime-Shell-Management.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Lifecycle.md`
-- [ ] T026 [P] Update active-only routing and explicit `Default` guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/README.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs`
-- [ ] T027 Run the quickstart validation flow from `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/005-deferred-shell-activation/quickstart.md` against `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/`
+- [X] T025 [P] Update desired-vs-applied lifecycle and runtime-management guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-lifecycle.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Runtime-Shell-Management.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Lifecycle.md`
+- [X] T026 [P] Update active-only routing and explicit `Default` guidance in `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/shell-resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/wiki/Shell-Resolution.md`, `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/README.md`, and `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/Program.cs`
+- [X] T027 Run the quickstart validation flow from `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/005-deferred-shell-activation/quickstart.md` against `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/` and `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests.EndToEnd/`
 
 ---
 

--- a/src/CShells.Abstractions/Management/IShellRuntimeStateAccessor.cs
+++ b/src/CShells.Abstractions/Management/IShellRuntimeStateAccessor.cs
@@ -1,0 +1,20 @@
+namespace CShells.Management;
+
+/// <summary>
+/// Provides a queryable read model for the latest desired shell definitions and the currently applied runtimes.
+/// </summary>
+public interface IShellRuntimeStateAccessor
+{
+    /// <summary>
+    /// Gets the runtime status for every configured shell.
+    /// </summary>
+    IReadOnlyCollection<ShellRuntimeStatus> GetAllShells();
+
+    /// <summary>
+    /// Gets the runtime status for a specific shell.
+    /// </summary>
+    /// <param name="shellId">The shell identifier.</param>
+    /// <returns>The current runtime status for the shell, or <see langword="null"/> when the shell is not configured.</returns>
+    ShellRuntimeStatus? GetShell(ShellId shellId);
+}
+

--- a/src/CShells.Abstractions/Management/ShellReconciliationOutcome.cs
+++ b/src/CShells.Abstractions/Management/ShellReconciliationOutcome.cs
@@ -1,0 +1,13 @@
+namespace CShells.Management;
+
+/// <summary>
+/// Describes the latest reconciliation outcome that determines whether a shell is currently serving,
+/// deferred because required features are unavailable, or failed due to a non-missing-feature error.
+/// </summary>
+public enum ShellReconciliationOutcome
+{
+    Active,
+    DeferredDueToMissingFeatures,
+    Failed
+}
+

--- a/src/CShells.Abstractions/Management/ShellRuntimeStatus.cs
+++ b/src/CShells.Abstractions/Management/ShellRuntimeStatus.cs
@@ -1,0 +1,23 @@
+namespace CShells.Management;
+
+/// <summary>
+/// Represents the operator-visible status for one configured shell, including desired-versus-applied drift.
+/// </summary>
+/// <param name="ShellId">The shell identifier.</param>
+/// <param name="DesiredGeneration">The latest configured desired generation.</param>
+/// <param name="AppliedGeneration">The generation currently committed in the runtime, if any.</param>
+/// <param name="Outcome">The current reconciliation outcome.</param>
+/// <param name="IsInSync">Whether the applied generation matches the desired generation.</param>
+/// <param name="IsRoutable">Whether the shell currently has a committed applied runtime.</param>
+/// <param name="BlockingReason">The reason the latest desired generation is not currently applied.</param>
+/// <param name="MissingFeatures">The required feature IDs still missing from the committed catalog, if any.</param>
+public sealed record ShellRuntimeStatus(
+    ShellId ShellId,
+    long DesiredGeneration,
+    long? AppliedGeneration,
+    ShellReconciliationOutcome Outcome,
+    bool IsInSync,
+    bool IsRoutable,
+    string? BlockingReason,
+    IReadOnlyCollection<string> MissingFeatures);
+

--- a/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
@@ -207,7 +207,8 @@ public static class CShellsBuilderExtensions
             builder.Services.TryAddSingleton<ApplicationBuilderAccessor>();
 
             // Register the endpoint registration notification handler
-            builder.Services.AddSingleton<INotificationHandler<ShellAdded>, Notifications.ShellEndpointRegistrationHandler>();
+            builder.Services.AddSingleton<INotificationHandler<ShellActivated>, Notifications.ShellEndpointRegistrationHandler>();
+            builder.Services.AddSingleton<INotificationHandler<ShellDeactivating>, Notifications.ShellEndpointRegistrationHandler>();
             builder.Services.AddSingleton<INotificationHandler<ShellRemoved>, Notifications.ShellEndpointRegistrationHandler>();
             builder.Services.AddSingleton<INotificationHandler<ShellsReloaded>, Notifications.ShellEndpointRegistrationHandler>();
 

--- a/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -94,7 +94,9 @@ public static class ServiceCollectionExtensions
             services.TryAddSingleton(new Resolution.WebRoutingShellResolverOptions());
 
             // Register strategies
-            services.AddSingleton<IShellResolverStrategy, Resolution.WebRoutingShellResolver>();
+            services.AddSingleton<IShellResolverStrategy>(sp => new Resolution.WebRoutingShellResolver(
+                sp.GetRequiredService<IShellHost>(),
+                sp.GetRequiredService<Resolution.WebRoutingShellResolverOptions>()));
             services.AddSingleton<IShellResolverStrategy, DefaultShellResolverStrategy>();
 
             // Configure their execution order

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -16,9 +16,9 @@ namespace CShells.AspNetCore.Notifications;
 /// Handles shell lifecycle notifications by registering/removing endpoints and middleware in the dynamic endpoint data source.
 /// </summary>
 public class ShellEndpointRegistrationHandler :
-    INotificationHandler<ShellAdded>,
+    INotificationHandler<ShellActivated>,
+    INotificationHandler<ShellDeactivating>,
     INotificationHandler<ShellRemoved>,
-    INotificationHandler<ShellReloaded>,
     INotificationHandler<ShellsReloaded>
 {
     private readonly DynamicShellEndpointDataSource _endpointDataSource;
@@ -51,17 +51,26 @@ public class ShellEndpointRegistrationHandler :
     }
 
     /// <inheritdoc />
-    public Task HandleAsync(ShellAdded notification, CancellationToken cancellationToken = default)
+    public Task HandleAsync(ShellActivated notification, CancellationToken cancellationToken = default)
     {
         if (_endpointRouteBuilderAccessor.EndpointRouteBuilder == null)
         {
             _logger.LogWarning("Cannot register endpoints for shell '{ShellId}': IEndpointRouteBuilder not available. " +
-                               "Endpoints will be registered on next application start.", notification.Settings.Id);
+                               "Endpoints will be registered on next application start.", notification.Context.Id);
             return Task.CompletedTask;
         }
 
-        _logger.LogInformation("Registering endpoints for shell '{ShellId}'", notification.Settings.Id);
-        RegisterShellEndpoints(notification.Settings);
+        _logger.LogInformation("Registering endpoints for applied shell '{ShellId}'", notification.Context.Id);
+        _endpointDataSource.RemoveEndpoints(notification.Context.Id);
+        RegisterShellEndpoints(notification.Context);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task HandleAsync(ShellDeactivating notification, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Removing endpoints for deactivating shell '{ShellId}'", notification.Context.Id);
+        _endpointDataSource.RemoveEndpoints(notification.Context.Id);
         return Task.CompletedTask;
     }
 
@@ -70,41 +79,6 @@ public class ShellEndpointRegistrationHandler :
     {
         _logger.LogInformation("Removing endpoints for shell '{ShellId}'", notification.ShellId);
         _endpointDataSource.RemoveEndpoints(notification.ShellId);
-        return Task.CompletedTask;
-    }
-
-    /// <inheritdoc />
-    public Task HandleAsync(ShellReloaded notification, CancellationToken cancellationToken = default)
-    {
-        // Only handle per-shell reload notifications (non-null ShellId).
-        // Aggregate (null ShellId) reloads are handled by ShellsReloaded.
-        if (notification.ShellId is not { } shellId)
-            return Task.CompletedTask;
-
-        if (_endpointRouteBuilderAccessor.EndpointRouteBuilder == null)
-        {
-            _logger.LogWarning("Cannot re-register endpoints for shell '{ShellId}': IEndpointRouteBuilder not available.", shellId);
-            return Task.CompletedTask;
-        }
-
-        _logger.LogInformation("Re-registering endpoints for reloaded shell '{ShellId}'", shellId);
-
-        // Remove stale endpoints for the reloaded shell
-        _endpointDataSource.RemoveEndpoints(shellId);
-
-        // Re-register endpoints from the refreshed shell context.
-        // The shell may have been removed during a full reload; in that case
-        // we only need to remove the endpoints (already done above).
-        try
-        {
-            var shellContext = _shellHost.GetShell(shellId);
-            RegisterShellEndpoints(shellContext.Settings);
-        }
-        catch (KeyNotFoundException)
-        {
-            _logger.LogDebug("Shell '{ShellId}' no longer exists after reload; endpoints removed", shellId);
-        }
-
         return Task.CompletedTask;
     }
 
@@ -118,15 +92,22 @@ public class ShellEndpointRegistrationHandler :
             return Task.CompletedTask;
         }
 
-        _logger.LogInformation("Registering endpoints for {Count} shell(s)", notification.AllShells.Count);
+        _logger.LogInformation("Registering endpoints for {Count} applied shell(s)", notification.Statuses.Count(status => status.IsRoutable));
 
         // Clear existing endpoints
         _endpointDataSource.Clear();
 
         // Register endpoints for all shells
-        foreach (var settings in notification.AllShells)
+        foreach (var status in notification.Statuses.Where(status => status.IsRoutable))
         {
-            RegisterShellEndpoints(settings);
+            try
+            {
+                RegisterShellEndpoints(_shellHost.GetShell(status.ShellId));
+            }
+            catch (KeyNotFoundException)
+            {
+                _logger.LogDebug("Shell '{ShellId}' is no longer applied while rebuilding endpoints; skipping", status.ShellId);
+            }
         }
 
         return Task.CompletedTask;
@@ -135,11 +116,13 @@ public class ShellEndpointRegistrationHandler :
     /// <summary>
     /// Registers endpoints for a single shell.
     /// </summary>
-    private void RegisterShellEndpoints(ShellSettings settings)
+    private void RegisterShellEndpoints(ShellContext shellContext)
     {
         var endpointRouteBuilder = _endpointRouteBuilderAccessor.EndpointRouteBuilder;
         if (endpointRouteBuilder == null)
             return;
+
+        var settings = shellContext.Settings;
 
         _logger.LogDebug("Registering endpoints for shell '{ShellId}'", settings.Id);
 
@@ -158,8 +141,6 @@ public class ShellEndpointRegistrationHandler :
             routePrefix ?? "(none)",
             combinedPrefix ?? "(none)");
 
-        // Get the shell context for accessing service provider and feature descriptors
-        var shellContext = _shellHost.GetShell(settings.Id);
 
         // Create shell-scoped endpoint builder with the combined prefix
         // This ensures that endpoint mapping (e.g., FastEndpoints) can resolve shell-scoped services

--- a/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
+++ b/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
@@ -1,5 +1,7 @@
 using CShells.Configuration;
+using CShells.Hosting;
 using CShells.Resolution;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CShells.AspNetCore.Resolution;
 
@@ -8,10 +10,27 @@ namespace CShells.AspNetCore.Resolution;
 /// URL path, HTTP host, custom headers, and user claims.
 /// </summary>
 [ResolverOrder(0)]
-public class WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellResolverOptions options) : IShellResolverStrategy
+public class WebRoutingShellResolver : IShellResolverStrategy
 {
-    private readonly IShellSettingsCache _cache = Guard.Against.Null(cache);
-    private readonly WebRoutingShellResolverOptions _options = Guard.Against.Null(options);
+    private readonly IShellHost _shellHost;
+    private readonly WebRoutingShellResolverOptions _options;
+
+    [ActivatorUtilitiesConstructor]
+    public WebRoutingShellResolver(IShellHost shellHost, WebRoutingShellResolverOptions options)
+    {
+        _shellHost = Guard.Against.Null(shellHost);
+        _options = Guard.Against.Null(options);
+    }
+
+    /// <summary>
+    /// Initializes a new resolver against a static shell settings cache.
+    /// This overload exists for compatibility with tests and non-DI callers; the runtime pipeline
+    /// should prefer the <see cref="IShellHost"/>-based constructor so only applied shells participate.
+    /// </summary>
+    public WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellResolverOptions options)
+        : this(new CacheBackedShellHost(cache), options)
+    {
+    }
 
     /// <inheritdoc />
     public ShellId? Resolve(ShellResolutionContext context)
@@ -75,9 +94,9 @@ public class WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellR
 
     private ShellId? FindMatchingShell(string valueToMatch, string configKey)
     {
-        foreach (var shell in _cache.GetAll())
+        foreach (var shell in _shellHost.AllShells)
         {
-            var routeValue = shell.GetConfiguration($"WebRouting:{configKey}");
+            var routeValue = shell.Settings.GetConfiguration($"WebRouting:{configKey}");
             
             // If the path starts with a slash, throw a configuration exception:
             if (routeValue?.StartsWith('/') == true)
@@ -91,9 +110,9 @@ public class WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellR
 
     private ShellId? FindMatchingShellByIdentifier(string identifierValue, string configuredKey, string configKey)
     {
-        foreach (var shell in _cache.GetAll())
+        foreach (var shell in _shellHost.AllShells)
         {
-            var shellConfigKey = shell.GetConfiguration($"WebRouting:{configKey}");
+            var shellConfigKey = shell.Settings.GetConfiguration($"WebRouting:{configKey}");
             if (string.IsNullOrEmpty(shellConfigKey))
                 continue;
 
@@ -136,9 +155,9 @@ public class WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellR
 
         ShellId? rootShellId = null;
 
-        foreach (var shell in _cache.GetAll())
+        foreach (var shell in _shellHost.AllShells)
         {
-            var routeValue = shell.GetConfiguration("WebRouting:Path");
+            var routeValue = shell.Settings.GetConfiguration("WebRouting:Path");
 
             // Only match a shell that explicitly set WebRouting:Path = "" (not null/absent).
             // A null value means the shell simply has no path routing configured.
@@ -156,5 +175,25 @@ public class WebRoutingShellResolver(IShellSettingsCache cache, WebRoutingShellR
         }
 
         return rootShellId;
+    }
+
+    private sealed class CacheBackedShellHost(IShellSettingsCache cache) : IShellHost
+    {
+        private readonly IShellSettingsCache cache = Guard.Against.Null(cache);
+
+        public ShellContext DefaultShell => AllShells.FirstOrDefault()
+            ?? throw new InvalidOperationException("No shells are configured.");
+
+        public IReadOnlyCollection<ShellContext> AllShells => cache.GetAll()
+            .Select(settings => new ShellContext(settings, new ServiceCollection().BuildServiceProvider(), settings.EnabledFeatures))
+            .ToList()
+            .AsReadOnly();
+
+        public ShellContext GetShell(ShellId id) => AllShells.FirstOrDefault(shell => shell.Id.Equals(id))
+            ?? throw new KeyNotFoundException($"Shell '{id}' was not found.");
+
+        public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
+
+        public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
+++ b/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
@@ -179,21 +179,50 @@ public class WebRoutingShellResolver : IShellResolverStrategy
 
     private sealed class CacheBackedShellHost(IShellSettingsCache cache) : IShellHost
     {
+        // Empty providers hold no resources; disposal is a no-op.
+        private static readonly IServiceProvider emptyServiceProvider = new ServiceCollection().BuildServiceProvider();
+
         private readonly IShellSettingsCache cache = Guard.Against.Null(cache);
+        private readonly object allShellsLock = new();
+        private IReadOnlyCollection<ShellContext>? allShells;
 
         public ShellContext DefaultShell => AllShells.FirstOrDefault()
             ?? throw new InvalidOperationException("No shells are configured.");
 
-        public IReadOnlyCollection<ShellContext> AllShells => cache.GetAll()
-            .Select(settings => new ShellContext(settings, new ServiceCollection().BuildServiceProvider(), settings.EnabledFeatures))
-            .ToList()
-            .AsReadOnly();
+        public IReadOnlyCollection<ShellContext> AllShells => GetAllShells();
 
         public ShellContext GetShell(ShellId id) => AllShells.FirstOrDefault(shell => shell.Id.Equals(id))
             ?? throw new KeyNotFoundException($"Shell '{id}' was not found.");
 
-        public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
+        public ValueTask EvictShellAsync(ShellId shellId)
+        {
+            InvalidateAllShells();
+            return ValueTask.CompletedTask;
+        }
 
-        public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
+        public ValueTask EvictAllShellsAsync()
+        {
+            InvalidateAllShells();
+            return ValueTask.CompletedTask;
+        }
+
+        private IReadOnlyCollection<ShellContext> GetAllShells()
+        {
+            lock (allShellsLock)
+            {
+                return allShells ??= cache.GetAll()
+                    .Select(settings => new ShellContext(settings, emptyServiceProvider, settings.EnabledFeatures))
+                    .ToList()
+                    .AsReadOnly();
+            }
+        }
+
+        private void InvalidateAllShells()
+        {
+            lock (allShellsLock)
+            {
+                allShells = null;
+            }
+        }
     }
 }

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -54,7 +54,17 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ShellSettingsCache>(cache);
         services.TryAddSingleton<IShellSettingsCache>(cache);
 
+        services.TryAddSingleton<ShellRuntimeStateStore>();
+        services.TryAddSingleton<ShellRuntimeStateAccessor>();
+        services.TryAddSingleton<IShellRuntimeStateAccessor>(sp => sp.GetRequiredService<ShellRuntimeStateAccessor>());
+
         var builder = new CShellsBuilder(services);
+
+        services.TryAddSingleton<RuntimeFeatureCatalog>(sp =>
+        {
+            var logger = sp.GetService<ILogger<RuntimeFeatureCatalog>>();
+            return new RuntimeFeatureCatalog(ct => builder.BuildFeatureAssembliesAsync(sp, ct), logger);
+        });
 
         // Register IShellHost using the DefaultShellHost.
         // The root IServiceProvider is passed to allow IShellFeature constructors to resolve root-level services.
@@ -70,8 +80,11 @@ public static class ServiceCollectionExtensions
             var rootServicesAccessor = sp.GetRequiredService<IRootServiceCollectionAccessor>();
             var featureFactory = sp.GetRequiredService<IShellFeatureFactory>();
             var exclusionRegistry = sp.GetRequiredService<Hosting.IShellServiceExclusionRegistry>();
+            var runtimeFeatureCatalog = sp.GetRequiredService<RuntimeFeatureCatalog>();
+            var runtimeStateStore = sp.GetRequiredService<ShellRuntimeStateStore>();
+            var notificationPublisher = sp.GetRequiredService<Notifications.INotificationPublisher>();
 
-            return new DefaultShellHost(shellCache, ct => builder.BuildFeatureAssembliesAsync(sp, ct), rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, logger);
+            return new DefaultShellHost(shellCache, ct => builder.BuildFeatureAssembliesAsync(sp, ct), rootProvider: sp, rootServicesAccessor, featureFactory, exclusionRegistry, seedDesiredStateFromCache: true, runtimeFeatureCatalog, runtimeStateStore, notificationPublisher, logger);
         });
         services.AddSingleton<IShellHost>(sp => sp.GetRequiredService<DefaultShellHost>());
         services.AddSingleton<IShellHostInitializer>(sp => sp.GetRequiredService<DefaultShellHost>());
@@ -80,7 +93,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IShellContextScopeFactory, DefaultShellContextScopeFactory>();
 
         // Register the shell manager for runtime shell lifecycle management
-        services.TryAddSingleton<IShellManager, DefaultShellManager>();
+        services.TryAddSingleton<DefaultShellManager>(sp => new DefaultShellManager(
+            sp.GetRequiredService<DefaultShellHost>(),
+            sp.GetRequiredService<ShellSettingsCache>(),
+            sp.GetRequiredService<IShellSettingsProvider>(),
+            sp.GetRequiredService<Notifications.INotificationPublisher>(),
+            sp.GetService<ILogger<DefaultShellManager>>()));
+        services.TryAddSingleton<IShellManager>(sp => sp.GetRequiredService<DefaultShellManager>());
 
         // Register hosted services for feature discovery and shell lifecycle coordination.
         services.AddHostedService<ShellFeatureInitializationHostedService>();

--- a/src/CShells/Features/RuntimeFeatureCatalog.cs
+++ b/src/CShells/Features/RuntimeFeatureCatalog.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Features;
+
+internal sealed class RuntimeFeatureCatalog(
+    Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver,
+    ILogger<RuntimeFeatureCatalog>? logger = null)
+{
+    private readonly Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver = Guard.Against.Null(assemblyResolver);
+    private readonly ILogger<RuntimeFeatureCatalog> logger = logger ?? NullLogger<RuntimeFeatureCatalog>.Instance;
+    private readonly SemaphoreSlim refreshLock = new(1, 1);
+
+    private RuntimeFeatureCatalogSnapshot? currentSnapshot;
+    private long nextGeneration;
+
+    public RuntimeFeatureCatalogSnapshot CurrentSnapshot => currentSnapshot
+        ?? throw new InvalidOperationException("The runtime feature catalog has not been initialized.");
+
+    public async Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+    {
+        if (currentSnapshot is not null)
+            return;
+
+        await RefreshAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RuntimeFeatureCatalogSnapshot> RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        await refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var assemblies = await assemblyResolver(cancellationToken).ConfigureAwait(false);
+            var descriptors = FeatureDiscovery
+                .DiscoverFeatures(
+                    assemblies,
+                    (assembly, ex) => logger.LogWarning(ex, "Failed to load types from assembly {AssemblyName}. Features in this assembly will not be available.", assembly.GetName().Name))
+                .ToList()
+                .AsReadOnly();
+
+            var featureMap = descriptors.ToDictionary(descriptor => descriptor.Id, descriptor => descriptor, StringComparer.OrdinalIgnoreCase);
+            var snapshot = new RuntimeFeatureCatalogSnapshot(
+                Interlocked.Increment(ref nextGeneration),
+                assemblies.ToList().AsReadOnly(),
+                descriptors,
+                featureMap,
+                DateTimeOffset.UtcNow);
+
+            currentSnapshot = snapshot;
+
+            logger.LogInformation(
+                "Committed runtime feature catalog generation {Generation} with {FeatureCount} feature(s): {FeatureNames}",
+                snapshot.Generation,
+                snapshot.FeatureDescriptors.Count,
+                string.Join(", ", snapshot.FeatureDescriptors.Select(feature => feature.Id)));
+
+            return snapshot;
+        }
+        finally
+        {
+            refreshLock.Release();
+        }
+    }
+}
+
+internal sealed record RuntimeFeatureCatalogSnapshot(
+    long Generation,
+    IReadOnlyCollection<Assembly> Assemblies,
+    IReadOnlyCollection<ShellFeatureDescriptor> FeatureDescriptors,
+    IReadOnlyDictionary<string, ShellFeatureDescriptor> FeatureMap,
+    DateTimeOffset RefreshedAt);
+

--- a/src/CShells/Hosting/DefaultShellHost.cs
+++ b/src/CShells/Hosting/DefaultShellHost.cs
@@ -1,9 +1,10 @@
-using System.Collections.Concurrent;
 using System.Reflection;
 using CShells.Configuration;
 using CShells.DependencyInjection;
 using CShells.Features;
 using CShells.Features.Validation;
+using CShells.Management;
+using CShells.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -35,20 +36,17 @@ namespace CShells.Hosting;
 /// </remarks>
 public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposable
 {
-    private readonly Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>>? _assemblyResolver;
-    private readonly IShellSettingsCache _shellSettingsCache;
     private readonly IServiceProvider _rootProvider;
     private readonly IServiceCollection _rootServices;
     private readonly IShellFeatureFactory _featureFactory;
     private readonly IShellServiceExclusionRegistry _exclusionRegistry;
-    private readonly ConcurrentDictionary<ShellId, ShellContext> _shellContexts = new();
+    private readonly ShellRuntimeStateStore _runtimeStateStore;
+    private readonly RuntimeFeatureCatalog _runtimeFeatureCatalog;
+    private readonly INotificationPublisher _notificationPublisher;
     private readonly FeatureDependencyResolver _dependencyResolver = new();
     private readonly ILogger<DefaultShellHost> _logger;
     private readonly object _buildLock = new();
-    private readonly object _featureInitializationLock = new();
     private bool _disposed;
-    private IReadOnlyDictionary<string, ShellFeatureDescriptor>? _featureMap;
-    private Task? _featureInitializationTask;
 
     // Cached copy of root service descriptors for efficient bulk-copy to shell service collections.
     // This avoids re-enumerating the root IServiceCollection for each shell.
@@ -79,15 +77,43 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
         IShellFeatureFactory featureFactory,
         IShellServiceExclusionRegistry exclusionRegistry,
         ILogger<DefaultShellHost>? logger = null)
+        : this(shellSettingsCache, assemblies, rootProvider, rootServicesAccessor, featureFactory, exclusionRegistry, activateExistingShells: true, runtimeFeatureCatalog: null, runtimeStateStore: null, notificationPublisher: null, logger)
     {
-        _shellSettingsCache = Guard.Against.Null(shellSettingsCache);
+    }
+
+    internal DefaultShellHost(
+        IShellSettingsCache shellSettingsCache,
+        IEnumerable<Assembly> assemblies,
+        IServiceProvider rootProvider,
+        IRootServiceCollectionAccessor rootServicesAccessor,
+        IShellFeatureFactory featureFactory,
+        IShellServiceExclusionRegistry exclusionRegistry,
+        bool activateExistingShells,
+        RuntimeFeatureCatalog? runtimeFeatureCatalog = null,
+        ShellRuntimeStateStore? runtimeStateStore = null,
+        INotificationPublisher? notificationPublisher = null,
+        ILogger<DefaultShellHost>? logger = null)
+    {
+        var cache = Guard.Against.Null(shellSettingsCache);
         _rootProvider = Guard.Against.Null(rootProvider);
         _rootServices = Guard.Against.Null(rootServicesAccessor).Services;
         _featureFactory = Guard.Against.Null(featureFactory);
         _exclusionRegistry = Guard.Against.Null(exclusionRegistry);
+        _runtimeStateStore = runtimeStateStore ?? new ShellRuntimeStateStore();
+        _notificationPublisher = notificationPublisher ?? new DefaultNotificationPublisher(rootProvider);
         _logger = logger ?? NullLogger<DefaultShellHost>.Instance;
 
-        InitializeFeatureMap(Guard.Against.Null(assemblies));
+        var fixedAssemblies = Guard.Against.Null(assemblies).ToList().AsReadOnly();
+        _runtimeFeatureCatalog = runtimeFeatureCatalog ?? new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>(fixedAssemblies),
+            rootProvider.GetService<ILogger<RuntimeFeatureCatalog>>());
+
+        SeedDesiredState(cache.GetAll());
+        if (activateExistingShells)
+        {
+            _runtimeFeatureCatalog.EnsureInitializedAsync().GetAwaiter().GetResult();
+            InitializeAppliedRuntimes(cache.GetAll());
+        }
     }
 
     /// <summary>
@@ -108,15 +134,40 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
         IShellFeatureFactory featureFactory,
         IShellServiceExclusionRegistry exclusionRegistry,
         ILogger<DefaultShellHost>? logger = null)
+        : this(shellSettingsCache, assemblyResolver, rootProvider, rootServicesAccessor, featureFactory, exclusionRegistry, seedDesiredStateFromCache: true, runtimeFeatureCatalog: null, runtimeStateStore: null, notificationPublisher: null, logger)
     {
-        _shellSettingsCache = Guard.Against.Null(shellSettingsCache);
-        _assemblyResolver = Guard.Against.Null(assemblyResolver);
+    }
+
+    internal DefaultShellHost(
+        IShellSettingsCache shellSettingsCache,
+        Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver,
+        IServiceProvider rootProvider,
+        IRootServiceCollectionAccessor rootServicesAccessor,
+        IShellFeatureFactory featureFactory,
+        IShellServiceExclusionRegistry exclusionRegistry,
+        bool seedDesiredStateFromCache,
+        RuntimeFeatureCatalog? runtimeFeatureCatalog = null,
+        ShellRuntimeStateStore? runtimeStateStore = null,
+        INotificationPublisher? notificationPublisher = null,
+        ILogger<DefaultShellHost>? logger = null)
+    {
+        var cache = Guard.Against.Null(shellSettingsCache);
         _rootProvider = Guard.Against.Null(rootProvider);
         _rootServices = Guard.Against.Null(rootServicesAccessor).Services;
         _featureFactory = Guard.Against.Null(featureFactory);
         _exclusionRegistry = Guard.Against.Null(exclusionRegistry);
+        _runtimeStateStore = runtimeStateStore ?? new ShellRuntimeStateStore();
+        _runtimeFeatureCatalog = runtimeFeatureCatalog ?? new RuntimeFeatureCatalog(Guard.Against.Null(assemblyResolver), rootProvider.GetService<ILogger<RuntimeFeatureCatalog>>());
+        _notificationPublisher = notificationPublisher ?? new DefaultNotificationPublisher(rootProvider);
         _logger = logger ?? NullLogger<DefaultShellHost>.Instance;
+
+        if (seedDesiredStateFromCache)
+            SeedDesiredState(cache.GetAll());
     }
+
+    internal ShellRuntimeStateStore RuntimeStateStore => _runtimeStateStore;
+
+    internal RuntimeFeatureCatalog RuntimeFeatureCatalog => _runtimeFeatureCatalog;
 
     /// <summary>
     /// Ensures that feature discovery has completed for this shell host.
@@ -129,57 +180,8 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     {
         ThrowIfDisposed();
 
-        if (_featureMap is not null)
-            return Task.CompletedTask;
-
-        if (_assemblyResolver is null)
-            throw new InvalidOperationException("No deferred feature assembly resolver was configured for this shell host.");
-
-        lock (_featureInitializationLock)
-        {
-            if (_featureMap is not null)
-                return Task.CompletedTask;
-
-            _featureInitializationTask ??= InitializeFeatureMapAsync(cancellationToken);
-            return _featureInitializationTask;
-        }
+        return _runtimeFeatureCatalog.EnsureInitializedAsync(cancellationToken);
     }
-
-    private async Task InitializeFeatureMapAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            var assemblies = await _assemblyResolver!(cancellationToken).ConfigureAwait(false);
-            InitializeFeatureMap(assemblies);
-        }
-        catch
-        {
-            lock (_featureInitializationLock)
-            {
-                _featureInitializationTask = null;
-            }
-
-            throw;
-        }
-    }
-
-    private void InitializeFeatureMap(IEnumerable<Assembly> assemblies)
-    {
-        var features = FeatureDiscovery.DiscoverFeatures(
-                Guard.Against.Null(assemblies),
-                (assembly, ex) => _logger.LogWarning(ex, "Failed to load types from assembly {AssemblyName}. Features in this assembly will not be available.", assembly.GetName().Name))
-            .ToList();
-
-        _logger.LogInformation("Discovered {FeatureCount} features: {FeatureNames}",
-            features.Count,
-            string.Join(", ", features.Select(f => f.Id)));
-
-        _featureMap = features.ToDictionary(f => f.Id, f => f, StringComparer.OrdinalIgnoreCase);
-    }
-
-    private IReadOnlyDictionary<string, ShellFeatureDescriptor> FeatureMap =>
-        _featureMap ?? throw new InvalidOperationException(
-            "Shell feature discovery has not completed yet. Start the application or ensure the shell host is initialized before accessing shells.");
 
     /// <inheritdoc />
     public ShellContext DefaultShell
@@ -188,30 +190,12 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
         {
             ThrowIfDisposed();
 
-            // Try to find shell with Id "Default"
             var defaultId = new ShellId(ShellConstants.DefaultShellName);
-            if (_shellContexts.TryGetValue(defaultId, out var context))
-            {
-                return context;
-            }
+            if (_runtimeStateStore.HasDesiredShell(defaultId))
+                return GetShell(defaultId);
 
-            // Check if there's a settings entry for "Default"
-            var defaultSettings = _shellSettingsCache.GetById(defaultId);
-
-            if (defaultSettings != null)
-            {
-                return GetShell(defaultSettings.Id);
-            }
-
-            // Otherwise, return the first shell
-            var allSettings = _shellSettingsCache.GetAll();
-            var firstSettings = allSettings.FirstOrDefault();
-            if (firstSettings == null)
-            {
-                throw new InvalidOperationException("No shells have been configured.");
-            }
-
-            return GetShell(firstSettings.Id);
+            var firstAppliedShell = AllShells.FirstOrDefault();
+            return firstAppliedShell ?? throw new InvalidOperationException("No applied shells are currently available.");
         }
     }
 
@@ -220,14 +204,31 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     {
         ThrowIfDisposed();
 
-        // Try to get from cache first
-        if (_shellContexts.TryGetValue(id, out var context))
+        var record = _runtimeStateStore.Get(id);
+        if (record is null || !record.HasAppliedRuntime)
         {
-            return context;
+            throw new KeyNotFoundException($"Shell with Id '{id}' does not have a committed applied runtime.");
         }
 
-        // Build the shell context
-        return BuildShellContext(id);
+        if (record.AppliedContext is not null)
+            return record.AppliedContext;
+
+        lock (_buildLock)
+        {
+            record = _runtimeStateStore.Get(id);
+            if (record is null || !record.HasAppliedRuntime)
+            {
+                throw new KeyNotFoundException($"Shell with Id '{id}' does not have a committed applied runtime.");
+            }
+
+            if (record.AppliedContext is not null)
+                return record.AppliedContext;
+
+            var orderedFeatures = ResolveFeatureDependencies(record.AppliedSettings!, record.AppliedCatalog!.FeatureMap);
+            var context = CreateShellContext(record.AppliedSettings!, orderedFeatures, record.AppliedCatalog.FeatureDescriptors);
+            _runtimeStateStore.SetAppliedContext(id, context);
+            return context;
+        }
     }
 
     /// <inheritdoc />
@@ -237,68 +238,114 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
         {
             ThrowIfDisposed();
 
-            // Build all shells that haven't been built yet
-            var allSettings = _shellSettingsCache.GetAll();
-            foreach (var settings in allSettings)
-            {
-                // Use GetOrAdd pattern to build each shell only once
-                _shellContexts.GetOrAdd(settings.Id, _ => BuildShellContextInternal(settings));
-            }
-
-            return _shellContexts.Values.ToList().AsReadOnly();
+            return _runtimeStateStore
+                .GetAll()
+                .Where(record => record.HasAppliedRuntime)
+                .Select(record => GetShell(record.ShellId))
+                .ToList()
+                .AsReadOnly();
         }
     }
 
-    /// <summary>
-    /// Builds a shell context for the specified shell ID.
-    /// </summary>
-    private ShellContext BuildShellContext(ShellId id)
+    internal ShellCandidateBuildResult BuildCandidate(ShellRuntimeRecord record, RuntimeFeatureCatalogSnapshot catalogSnapshot)
     {
-        // Find the settings for this shell
-        var settings = _shellSettingsCache.GetById(id);
-        if (settings == null)
-        {
-            throw new KeyNotFoundException($"Shell with Id '{id}' was not found in the configured shell settings.");
-        }
+        Guard.Against.Null(record);
+        Guard.Against.Null(catalogSnapshot);
 
-        return _shellContexts.GetOrAdd(id, _ => BuildShellContextInternal(settings));
-    }
-
-    /// <summary>
-    /// Internal method to build a shell context for the given settings.
-    /// This method is called within GetOrAdd and ensures thread-safe initialization.
-    /// </summary>
-    private ShellContext BuildShellContextInternal(ShellSettings settings)
-    {
-        // Double-check locking for thread safety during initialization
-        lock (_buildLock)
+        try
         {
-            // Check again after acquiring lock in case another thread already built it
-            if (_shellContexts.TryGetValue(settings.Id, out var existingContext))
+            var missingFeatures = record.DesiredSettings.EnabledFeatures
+                .Where(featureName => !catalogSnapshot.FeatureMap.ContainsKey(featureName))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (missingFeatures.Length > 0)
             {
-                return existingContext;
+                var blockingReason = $"Feature(s) '{string.Join(", ", missingFeatures)}' required by shell '{record.ShellId}' are not available in the current runtime feature catalog.";
+                return new ShellCandidateBuildResult(record.ShellId, record.DesiredGeneration, record.DesiredSettings, catalogSnapshot, null, blockingReason, missingFeatures);
             }
 
-            _logger.LogInformation("Building shell context for '{ShellId}'", settings.Id);
+            var orderedFeatures = ResolveFeatureDependencies(record.DesiredSettings, catalogSnapshot.FeatureMap);
+            var context = CreateShellContext(record.DesiredSettings, orderedFeatures, catalogSnapshot.FeatureDescriptors);
+            return new ShellCandidateBuildResult(record.ShellId, record.DesiredGeneration, record.DesiredSettings, catalogSnapshot, context, null, []);
+        }
+        catch (FeatureNotFoundException ex)
+        {
+            return new ShellCandidateBuildResult(record.ShellId, record.DesiredGeneration, record.DesiredSettings, catalogSnapshot, null, ex.Message, [ex.FeatureName]);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to build candidate runtime for shell '{ShellId}'", record.ShellId);
+            return new ShellCandidateBuildResult(record.ShellId, record.DesiredGeneration, record.DesiredSettings, catalogSnapshot, null, ex.Message, []);
+        }
+    }
 
-            ValidateEnabledFeatures(settings);
-            var orderedFeatures = ResolveFeatureDependencies(settings);
+    internal async Task CommitCandidateAsync(
+        ShellCandidateBuildResult candidate,
+        bool publishLifecycleNotifications = true,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.Against.Null(candidate);
 
-            _logger.LogInformation("Shell '{ShellId}' will use features (in order): {Features}",
-                settings.Id, string.Join(", ", orderedFeatures));
+        if (!candidate.IsReadyToCommit)
+        {
+            throw new InvalidOperationException($"Shell '{candidate.ShellId}' does not have a ready-to-commit runtime candidate.");
+        }
 
-            return CreateShellContext(settings, orderedFeatures);
+        var previousRecord = _runtimeStateStore.Get(candidate.ShellId);
+        var previousContext = previousRecord?.AppliedContext;
+
+        if (publishLifecycleNotifications && previousContext is not null)
+        {
+            await _notificationPublisher.PublishAsync(new ShellDeactivating(previousContext), strategy: null, cancellationToken).ConfigureAwait(false);
+        }
+
+        var commit = _runtimeStateStore.CommitAppliedRuntime(
+            candidate.ShellId,
+            candidate.DesiredSettings,
+            candidate.CatalogSnapshot,
+            candidate.CandidateContext!);
+
+        if (publishLifecycleNotifications)
+        {
+            await _notificationPublisher.PublishAsync(new ShellActivated(candidate.CandidateContext!), strategy: null, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (commit.PreviousContext is not null && !ReferenceEquals(commit.PreviousContext, candidate.CandidateContext))
+        {
+            await DisposeShellContextAsync(commit.PreviousContext).ConfigureAwait(false);
+        }
+    }
+
+    internal async Task RemoveAppliedRuntimeAsync(
+        ShellId shellId,
+        bool removeDesiredState = false,
+        bool publishLifecycleNotifications = true,
+        CancellationToken cancellationToken = default)
+    {
+        var result = removeDesiredState
+            ? _runtimeStateStore.RemoveShell(shellId)
+            : _runtimeStateStore.ClearAppliedRuntime(shellId);
+
+        if (result.PreviousContext is not null && publishLifecycleNotifications)
+        {
+            await _notificationPublisher.PublishAsync(new ShellDeactivating(result.PreviousContext), strategy: null, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (result.PreviousContext is not null)
+        {
+            await DisposeShellContextAsync(result.PreviousContext).ConfigureAwait(false);
         }
     }
 
     /// <summary>
     /// Resolves feature dependencies and returns an ordered list of features for the shell.
     /// </summary>
-    private List<string> ResolveFeatureDependencies(ShellSettings settings)
+    private List<string> ResolveFeatureDependencies(ShellSettings settings, IReadOnlyDictionary<string, ShellFeatureDescriptor> featureMap)
     {
         try
         {
-            return _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, FeatureMap);
+            return _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, featureMap);
         }
         catch (InvalidOperationException ex)
         {
@@ -311,40 +358,19 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// Creates a shell context with its service provider and configured features.
     /// Uses the holder pattern to allow ShellContext to be resolved from DI.
     /// </summary>
-    private ShellContext CreateShellContext(ShellSettings settings, List<string> orderedFeatures)
+    private ShellContext CreateShellContext(
+        ShellSettings settings,
+        List<string> orderedFeatures,
+        IReadOnlyCollection<ShellFeatureDescriptor> featureDescriptors)
     {
         var contextHolder = new ShellContextHolder();
-        var serviceProvider = BuildServiceProvider(settings, orderedFeatures, contextHolder);
+        var serviceProvider = BuildServiceProvider(settings, orderedFeatures, contextHolder, featureDescriptors);
         var context = new ShellContext(settings, serviceProvider, orderedFeatures.AsReadOnly());
 
         // Populate the holder so ShellContext can be resolved from DI
         contextHolder.Context = context;
 
         return context;
-    }
-
-    /// <summary>
-    /// Validates that all enabled features in the shell settings are known/discovered features.
-    /// </summary>
-    /// <param name="settings">The shell settings to validate.</param>
-    /// <exception cref="InvalidOperationException">Thrown when an unknown feature is configured.</exception>
-    private void ValidateEnabledFeatures(ShellSettings settings)
-    {
-        var unknownFeatures = settings.EnabledFeatures
-            .Where(featureName => !FeatureMap.ContainsKey(featureName))
-            .ToList();
-
-        foreach (var featureName in unknownFeatures)
-        {
-            _logger.LogWarning("Unknown feature '{FeatureName}' configured for shell '{ShellId}'",
-                featureName, settings.Id);
-        }
-
-        if (unknownFeatures.Count > 0)
-        {
-            throw new InvalidOperationException(
-                $"Feature(s) '{string.Join(", ", unknownFeatures)}' configured for shell '{settings.Id}' were not found in discovered features. Make sure to add the necessary package/project references that contain the feature implementations.");
-        }
     }
 
     /// <summary>
@@ -370,7 +396,11 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// registrations override root registrations for the same service type.
     /// </para>
     /// </remarks>
-    private IServiceProvider BuildServiceProvider(ShellSettings settings, List<string> orderedFeatures, ShellContextHolder contextHolder)
+    private IServiceProvider BuildServiceProvider(
+        ShellSettings settings,
+        List<string> orderedFeatures,
+        ShellContextHolder contextHolder,
+        IReadOnlyCollection<ShellFeatureDescriptor> featureDescriptors)
     {
         var shellServices = new ServiceCollection();
 
@@ -380,17 +410,17 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
 
         // Step 2: Register shell-specific core services (ShellSettings, ShellId, ShellContext, IConfiguration).
         // These are added after root services, so they override any root registrations.
-        RegisterCoreServices(shellServices, settings, contextHolder, _rootProvider, FeatureMap.Values);
+        RegisterCoreServices(shellServices, settings, contextHolder, _rootProvider, featureDescriptors);
 
         // Step 3: Configure feature services in dependency order.
         // Features can override root services by registering the same service type.
         // A single ShellFeatureContext is shared across all features so they can
         // exchange data through its Properties bag during construction.
-        var featureContext = new ShellFeatureContext(settings, FeatureMap.Values);
+        var featureContext = new ShellFeatureContext(settings, featureDescriptors);
         var postConfigureFeatures = new List<IPostConfigureShellServices>();
         if (orderedFeatures.Count > 0)
         {
-            ConfigureFeatureServices(shellServices, orderedFeatures, settings, featureContext, postConfigureFeatures);
+            ConfigureFeatureServices(shellServices, orderedFeatures, settings, featureContext, postConfigureFeatures, featureDescriptors.ToDictionary(descriptor => descriptor.Id, descriptor => descriptor, StringComparer.OrdinalIgnoreCase));
         }
 
         // Step 3b: Post-configure — called after ALL features have registered their services
@@ -508,10 +538,16 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// as an explicit parameter. No temporary shell ServiceProviders are created during configuration.
     /// This ensures features can only depend on root-level services in their constructors.
     /// </remarks>
-    private void ConfigureFeatureServices(ServiceCollection services, List<string> orderedFeatures, ShellSettings settings, ShellFeatureContext featureContext, List<IPostConfigureShellServices> postConfigureFeatures)
+    private void ConfigureFeatureServices(
+        ServiceCollection services,
+        List<string> orderedFeatures,
+        ShellSettings settings,
+        ShellFeatureContext featureContext,
+        List<IPostConfigureShellServices> postConfigureFeatures,
+        IReadOnlyDictionary<string, ShellFeatureDescriptor> featureMap)
     {
         var featuresWithStartups = orderedFeatures
-            .Select(name => (Name: name, Descriptor: FeatureMap[name]))
+            .Select(name => (Name: name, Descriptor: featureMap[name]))
             .Where(f => f.Descriptor.StartupType != null);
 
         foreach (var (featureName, descriptor) in featuresWithStartups)
@@ -620,23 +656,23 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// <inheritdoc />
     public async ValueTask EvictShellAsync(ShellId shellId)
     {
-        if (_shellContexts.TryRemove(shellId, out var context))
+        var context = _runtimeStateStore.EvictAppliedContext(shellId);
+        if (context is not null)
         {
             _logger.LogDebug("Evicting cached shell context for '{ShellId}'", shellId);
-            await DisposeShellContextAsync(context);
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
         }
     }
 
     /// <inheritdoc />
     public async ValueTask EvictAllShellsAsync()
     {
-        var contexts = _shellContexts.Values.ToList();
-        _shellContexts.Clear();
+        var contexts = _runtimeStateStore.EvictAllAppliedContexts();
 
         foreach (var context in contexts)
         {
             _logger.LogDebug("Evicting cached shell context for '{ShellId}'", context.Settings.Id);
-            await DisposeShellContextAsync(context);
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
         }
     }
 
@@ -691,15 +727,46 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
             return;
         }
 
-        // Dispose all service providers asynchronously
-        foreach (var context in _shellContexts.Values)
+        foreach (var context in _runtimeStateStore.EvictAllAppliedContexts())
         {
-            await DisposeShellContextAsync(context);
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
         }
 
-        _shellContexts.Clear();
         _disposed = true;
 
         GC.SuppressFinalize(this);
+    }
+
+    private void SeedDesiredState(IEnumerable<ShellSettings> settings)
+    {
+        foreach (var shell in settings)
+        {
+            _runtimeStateStore.RecordDesired(shell);
+        }
+    }
+
+    private void InitializeAppliedRuntimes(IEnumerable<ShellSettings> settings)
+    {
+        var snapshot = _runtimeFeatureCatalog.CurrentSnapshot;
+
+        foreach (var shell in settings)
+        {
+            var record = _runtimeStateStore.Get(shell.Id) ?? _runtimeStateStore.RecordDesired(shell);
+            var candidate = BuildCandidate(record, snapshot);
+
+            if (candidate.IsReadyToCommit)
+            {
+                _runtimeStateStore.CommitAppliedRuntime(candidate.ShellId, candidate.DesiredSettings, candidate.CatalogSnapshot, candidate.CandidateContext!);
+                continue;
+            }
+
+            if (candidate.IsDeferred)
+            {
+                _runtimeStateStore.MarkDeferred(candidate.ShellId, candidate.MissingFeatures, candidate.FailureReason);
+                continue;
+            }
+
+            _runtimeStateStore.MarkFailed(candidate.ShellId, candidate.FailureReason);
+        }
     }
 }

--- a/src/CShells/Hosting/IShellHost.cs
+++ b/src/CShells/Hosting/IShellHost.cs
@@ -1,13 +1,14 @@
 namespace CShells.Hosting;
 
 /// <summary>
-/// Provides access to shell contexts and their configurations.
+/// Provides access to committed applied shell runtimes.
 /// </summary>
 public interface IShellHost
 {
     /// <summary>
-    /// Gets the default shell context. Returns the shell with Id "Default" if present,
-    /// otherwise returns the first shell.
+    /// Gets the default applied shell context.
+    /// Returns the shell with Id "Default" when it is explicitly configured and currently applied;
+    /// otherwise returns the first applied shell when no explicit default exists.
     /// </summary>
     ShellContext DefaultShell { get; }
 
@@ -15,12 +16,12 @@ public interface IShellHost
     /// Gets a shell context by its identifier.
     /// </summary>
     /// <param name="id">The shell identifier.</param>
-    /// <returns>The shell context for the specified identifier.</returns>
-    /// <exception cref="KeyNotFoundException">Thrown when no shell with the specified identifier exists.</exception>
+    /// <returns>The applied shell context for the specified identifier.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when no committed applied runtime exists for the specified shell.</exception>
     ShellContext GetShell(ShellId id);
 
     /// <summary>
-    /// Gets all available shell contexts.
+    /// Gets all committed applied shell contexts.
     /// </summary>
     IReadOnlyCollection<ShellContext> AllShells { get; }
 

--- a/src/CShells/Hosting/ShellCandidateBuildResult.cs
+++ b/src/CShells/Hosting/ShellCandidateBuildResult.cs
@@ -1,0 +1,18 @@
+using CShells.Features;
+
+namespace CShells.Hosting;
+
+internal sealed record ShellCandidateBuildResult(
+    ShellId ShellId,
+    long DesiredGeneration,
+    ShellSettings DesiredSettings,
+    RuntimeFeatureCatalogSnapshot CatalogSnapshot,
+    ShellContext? CandidateContext,
+    string? FailureReason,
+    IReadOnlyCollection<string> MissingFeatures)
+{
+    public bool IsReadyToCommit => CandidateContext is not null;
+
+    public bool IsDeferred => MissingFeatures.Count > 0;
+}
+

--- a/src/CShells/Hosting/ShellStartupHostedService.cs
+++ b/src/CShells/Hosting/ShellStartupHostedService.cs
@@ -1,3 +1,4 @@
+using CShells.Management;
 using CShells.Notifications;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -6,115 +7,85 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace CShells.Hosting;
 
 /// <summary>
-/// Ensures all shells are activated during application startup and deactivated during shutdown.
+/// Ensures shells are reconciled into applied runtimes during application startup and deactivated during shutdown.
 /// </summary>
-/// <remarks>
-/// This hosted service coordinates shell lifecycle with the application lifecycle by:
-/// <list type="bullet">
-///   <item><description>Publishing <see cref="ShellActivated"/> notifications for all configured shells on startup</description></item>
-///   <item><description>Publishing <see cref="ShellsReloaded"/> after startup activation so shell-dependent projections can synchronize once</description></item>
-///   <item><description>Publishing <see cref="ShellDeactivating"/> notifications for all shells on shutdown</description></item>
-/// </list>
-/// </remarks>
 public class ShellStartupHostedService : IHostedService
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellHostInitializer _shellHostInitializer;
-    private readonly INotificationPublisher _notificationPublisher;
-    private readonly ILogger<ShellStartupHostedService> _logger;
-    private readonly object _lifecycleLock = new();
-    private Task? _startTask;
-    private Task? _stopTask;
+    private readonly IShellHost shellHost;
+    private readonly DefaultShellManager shellManager;
+    private readonly IShellRuntimeStateAccessor runtimeStateAccessor;
+    private readonly INotificationPublisher notificationPublisher;
+    private readonly ILogger<ShellStartupHostedService> logger;
+    private readonly object lifecycleLock = new();
+    private Task? startTask;
+    private Task? stopTask;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ShellStartupHostedService"/> class.
     /// </summary>
-    /// <param name="shellHost">The shell host containing all configured shells.</param>
-    /// <param name="shellHostInitializer">Ensures deferred shell host initialization completes before startup activation runs.</param>
-    /// <param name="notificationPublisher">The notification publisher for shell lifecycle events.</param>
-    /// <param name="logger">Optional logger for diagnostic output.</param>
     public ShellStartupHostedService(
         IShellHost shellHost,
-        IShellHostInitializer shellHostInitializer,
+        DefaultShellManager shellManager,
+        IShellRuntimeStateAccessor runtimeStateAccessor,
         INotificationPublisher notificationPublisher,
         ILogger<ShellStartupHostedService>? logger = null)
     {
-        _shellHost = Guard.Against.Null(shellHost);
-        _shellHostInitializer = Guard.Against.Null(shellHostInitializer);
-        _notificationPublisher = Guard.Against.Null(notificationPublisher);
-        _logger = logger ?? NullLogger<ShellStartupHostedService>.Instance;
+        this.shellHost = Guard.Against.Null(shellHost);
+        this.shellManager = Guard.Against.Null(shellManager);
+        this.runtimeStateAccessor = Guard.Against.Null(runtimeStateAccessor);
+        this.notificationPublisher = Guard.Against.Null(notificationPublisher);
+        this.logger = logger ?? NullLogger<ShellStartupHostedService>.Instance;
     }
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        lock (_lifecycleLock)
+        lock (lifecycleLock)
         {
-            _startTask ??= StartCoreAsync(cancellationToken);
-            return _startTask;
+            startTask ??= StartCoreAsync(cancellationToken);
+            return startTask;
         }
     }
 
     private async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Activating all shells on application startup");
+        logger.LogInformation("Reconciling shells on application startup");
 
-        await _shellHostInitializer.EnsureInitializedAsync(cancellationToken);
+        await shellManager.InitializeRuntimeAsync(cancellationToken).ConfigureAwait(false);
+        var statuses = runtimeStateAccessor.GetAllShells();
 
-        var shells = _shellHost.AllShells;
-        _logger.LogInformation("Found {ShellCount} shell(s) to activate", shells.Count);
+        await notificationPublisher.PublishAsync(new ShellsReloaded(statuses), strategy: null, cancellationToken).ConfigureAwait(false);
 
-        foreach (var shell in shells)
-        {
-            try
-            {
-                _logger.LogDebug("Publishing ShellActivated notification for shell '{ShellId}'", shell.Id);
-                await _notificationPublisher.PublishAsync(
-                    new ShellActivated(shell),
-                    strategy: null,
-                    cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to activate shell '{ShellId}' during application startup", shell.Id);
-                throw;
-            }
-        }
-
-        await _notificationPublisher.PublishAsync(
-            new ShellsReloaded(shells.Select(shell => shell.Settings).ToList().AsReadOnly()),
-            strategy: null,
-            cancellationToken);
-
-        _logger.LogInformation("Successfully activated {ShellCount} shell(s)", shells.Count);
+        logger.LogInformation(
+            "Startup reconciliation completed for {ShellCount} configured shell(s); {ActiveCount} shell(s) are currently applied",
+            statuses.Count,
+            statuses.Count(status => status.IsRoutable));
     }
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        lock (_lifecycleLock)
+        lock (lifecycleLock)
         {
-            _stopTask ??= StopCoreAsync(cancellationToken);
-            return _stopTask;
+            stopTask ??= StopCoreAsync(cancellationToken);
+            return stopTask;
         }
     }
 
     private async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Deactivating all shells on application shutdown");
+        logger.LogInformation("Deactivating applied shells on application shutdown");
 
         IReadOnlyCollection<ShellContext> shells;
         try
         {
-            shells = _shellHost.AllShells;
+            shells = shellHost.AllShells;
         }
         catch (ObjectDisposedException)
         {
-            _logger.LogDebug("Shell host already disposed, skipping deactivation");
+            logger.LogDebug("Shell host already disposed, skipping deactivation");
             return;
         }
-
-        _logger.LogInformation("Found {ShellCount} shell(s) to deactivate", shells.Count);
 
         var failedCount = 0;
 
@@ -122,28 +93,26 @@ public class ShellStartupHostedService : IHostedService
         {
             try
             {
-                _logger.LogDebug("Publishing ShellDeactivating notification for shell '{ShellId}'", shell.Id);
-                await _notificationPublisher.PublishAsync(
-                    new ShellDeactivating(shell),
-                    strategy: null,
-                    cancellationToken);
+                await notificationPublisher.PublishAsync(new ShellDeactivating(shell), strategy: null, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 failedCount++;
-                // Log but don't throw during shutdown - attempt to deactivate all shells
-                _logger.LogError(ex, "Failed to deactivate shell '{ShellId}' during application shutdown", shell.Id);
+                logger.LogError(ex, "Failed to deactivate shell '{ShellId}' during application shutdown", shell.Id);
             }
         }
 
         if (failedCount > 0)
         {
-            _logger.LogWarning("Deactivated {SuccessCount}/{TotalCount} shell(s) ({FailedCount} failed)",
-                shells.Count - failedCount, shells.Count, failedCount);
+            logger.LogWarning(
+                "Deactivated {SuccessCount}/{TotalCount} shell(s) ({FailedCount} failed)",
+                shells.Count - failedCount,
+                shells.Count,
+                failedCount);
         }
         else
         {
-            _logger.LogInformation("Successfully deactivated {ShellCount} shell(s)", shells.Count);
+            logger.LogInformation("Successfully deactivated {ShellCount} shell(s)", shells.Count);
         }
     }
 }

--- a/src/CShells/Management/DefaultShellManager.cs
+++ b/src/CShells/Management/DefaultShellManager.cs
@@ -1,24 +1,28 @@
 using CShells.Configuration;
+using CShells.Features;
 using CShells.Hosting;
 using CShells.Notifications;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CShells.Management;
 
 /// <summary>
-/// Default implementation of <see cref="IShellManager"/> that manages shell lifecycle
-/// and publishes notifications for shell state changes.
+/// Default implementation of <see cref="IShellManager"/> that manages desired shell definitions
+/// and reconciles them into committed applied runtimes.
 /// </summary>
 public class DefaultShellManager : IShellManager
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellHostInitializer _shellHostInitializer;
-    private readonly IShellSettingsCache _cache;
-    private readonly IShellSettingsProvider _provider;
-    private readonly INotificationPublisher _notificationPublisher;
-    private readonly ILogger<DefaultShellManager> _logger;
-    private readonly object _lock = new();
+    private readonly DefaultShellHost shellHost;
+    private readonly IShellSettingsCache cache;
+    private readonly IShellSettingsProvider provider;
+    private readonly ShellRuntimeStateStore runtimeStateStore;
+    private readonly RuntimeFeatureCatalog runtimeFeatureCatalog;
+    private readonly IShellRuntimeStateAccessor runtimeStateAccessor;
+    private readonly INotificationPublisher notificationPublisher;
+    private readonly ILogger<DefaultShellManager> logger;
+    private readonly SemaphoreSlim operationLock = new(1, 1);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultShellManager"/> class.
@@ -30,13 +34,79 @@ public class DefaultShellManager : IShellManager
         IShellSettingsProvider provider,
         INotificationPublisher notificationPublisher,
         ILogger<DefaultShellManager>? logger = null)
+        : this(
+            shellHost as DefaultShellHost ?? throw new ArgumentException("DefaultShellManager requires DefaultShellHost for reconciliation operations.", nameof(shellHost)),
+            cache,
+            provider,
+            notificationPublisher,
+            logger)
     {
-        _shellHost = shellHost;
-        _shellHostInitializer = shellHostInitializer;
-        _cache = cache;
-        _provider = provider;
-        _notificationPublisher = notificationPublisher;
-        _logger = logger ?? NullLogger<DefaultShellManager>.Instance;
+        Guard.Against.Null(shellHostInitializer);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultShellManager"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DefaultShellManager(
+        DefaultShellHost shellHost,
+        IShellSettingsCache cache,
+        IShellSettingsProvider provider,
+        INotificationPublisher notificationPublisher,
+        ILogger<DefaultShellManager>? logger = null)
+        : this(
+            shellHost,
+            cache,
+            provider,
+            shellHost.RuntimeStateStore,
+            shellHost.RuntimeFeatureCatalog,
+            new ShellRuntimeStateAccessor(shellHost.RuntimeStateStore),
+            notificationPublisher,
+            logger)
+    {
+    }
+
+    internal DefaultShellManager(
+        DefaultShellHost shellHost,
+        IShellSettingsCache cache,
+        IShellSettingsProvider provider,
+        ShellRuntimeStateStore runtimeStateStore,
+        RuntimeFeatureCatalog runtimeFeatureCatalog,
+        IShellRuntimeStateAccessor runtimeStateAccessor,
+        INotificationPublisher notificationPublisher,
+        ILogger<DefaultShellManager>? logger = null)
+    {
+        this.shellHost = Guard.Against.Null(shellHost);
+        this.cache = Guard.Against.Null(cache);
+        this.provider = Guard.Against.Null(provider);
+        this.runtimeStateStore = Guard.Against.Null(runtimeStateStore);
+        this.runtimeFeatureCatalog = Guard.Against.Null(runtimeFeatureCatalog);
+        this.runtimeStateAccessor = Guard.Against.Null(runtimeStateAccessor);
+        this.notificationPublisher = Guard.Against.Null(notificationPublisher);
+        this.logger = logger ?? NullLogger<DefaultShellManager>.Instance;
+    }
+
+    internal async Task InitializeRuntimeAsync(CancellationToken cancellationToken = default)
+    {
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            logger.LogInformation("Reconciling configured shells during application startup");
+
+            var desiredShells = cache.GetAll().ToList();
+            foreach (var settings in desiredShells)
+            {
+                runtimeStateStore.RecordDesired(settings);
+            }
+
+            var snapshot = await runtimeFeatureCatalog.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            await ReconcileShellsAsync(desiredShells.Select(settings => settings.Id), snapshot, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            operationLock.Release();
+        }
     }
 
     /// <inheritdoc />
@@ -44,66 +114,53 @@ public class DefaultShellManager : IShellManager
     {
         Guard.Against.Null(settings);
 
-        await _shellHostInitializer.EnsureInitializedAsync(cancellationToken);
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        ShellContext shellContext;
-
-        lock (_lock)
+        try
         {
-            _logger.LogInformation("Adding shell '{ShellId}'", settings.Id);
+            logger.LogInformation("Adding desired shell '{ShellId}'", settings.Id);
 
-            // Add to cache
-            _cache.Load(_cache.GetAll().Append(settings));
+            ReplaceShellInCache(settings);
+            runtimeStateStore.RecordDesired(settings);
 
-            // Build shell context (this triggers feature service registration)
-            shellContext = _shellHost.GetShell(settings.Id);
+            await notificationPublisher.PublishAsync(new ShellAdded(settings), strategy: null, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Shell '{ShellId}' added successfully", settings.Id);
+            RuntimeFeatureCatalogSnapshot snapshot;
+            try
+            {
+                snapshot = await runtimeFeatureCatalog.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                runtimeStateStore.MarkFailed(settings.Id, ex.Message);
+                throw;
+            }
+
+            await ReconcileShellAsync(settings.Id, snapshot, cancellationToken).ConfigureAwait(false);
         }
-
-        // Publish notifications (outside lock to avoid deadlocks)
-        // Activate shell first, then notify that it was added
-        await _notificationPublisher.PublishAsync(new ShellActivated(shellContext), strategy: null, cancellationToken);
-        await _notificationPublisher.PublishAsync(new ShellAdded(settings), strategy: null, cancellationToken);
+        finally
+        {
+            operationLock.Release();
+        }
     }
 
     /// <inheritdoc />
     public async Task RemoveShellAsync(ShellId shellId, CancellationToken cancellationToken = default)
     {
-        await _shellHostInitializer.EnsureInitializedAsync(cancellationToken);
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        ShellContext? shellContext = null;
-
-        // Get shell context BEFORE removing from cache so handlers can access it during deactivation
         try
         {
-            shellContext = _shellHost.GetShell(shellId);
+            logger.LogInformation("Removing desired shell '{ShellId}'", shellId);
+
+            RemoveShellFromCache(shellId);
+            await shellHost.RemoveAppliedRuntimeAsync(shellId, removeDesiredState: true, publishLifecycleNotifications: true, cancellationToken).ConfigureAwait(false);
+            await notificationPublisher.PublishAsync(new ShellRemoved(shellId), strategy: null, cancellationToken).ConfigureAwait(false);
         }
-        catch (KeyNotFoundException)
+        finally
         {
-            _logger.LogWarning("Shell '{ShellId}' not found, skipping deactivation", shellId);
+            operationLock.Release();
         }
-
-        // Publish deactivation notification BEFORE removal (outside lock to avoid deadlocks)
-        if (shellContext != null)
-        {
-            await _notificationPublisher.PublishAsync(new ShellDeactivating(shellContext), strategy: null, cancellationToken);
-        }
-
-        lock (_lock)
-        {
-            _logger.LogInformation("Removing shell '{ShellId}'", shellId);
-
-            // Remove from cache
-            var remainingShells = _cache.GetAll().Where(s => !s.Id.Equals(shellId));
-            _cache.Clear();
-            _cache.Load(remainingShells);
-
-            _logger.LogInformation("Shell '{ShellId}' removed successfully", shellId);
-        }
-
-        // Publish removal notification AFTER removal (outside lock to avoid deadlocks)
-        await _notificationPublisher.PublishAsync(new ShellRemoved(shellId), strategy: null, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -111,220 +168,250 @@ public class DefaultShellManager : IShellManager
     {
         Guard.Against.Null(settings);
 
-        _logger.LogInformation("Updating shell '{ShellId}'", settings.Id);
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        // Remove existing shell
-        await RemoveShellAsync(settings.Id, cancellationToken);
+        try
+        {
+            logger.LogInformation("Updating desired shell '{ShellId}'", settings.Id);
 
-        // Add updated shell
-        await AddShellAsync(settings, cancellationToken);
+            ReplaceShellInCache(settings);
+            runtimeStateStore.RecordDesired(settings);
 
-        _logger.LogInformation("Shell '{ShellId}' updated successfully", settings.Id);
+            await notificationPublisher.PublishAsync(new ShellUpdated(settings), strategy: null, cancellationToken).ConfigureAwait(false);
+
+            RuntimeFeatureCatalogSnapshot snapshot;
+            try
+            {
+                snapshot = await runtimeFeatureCatalog.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                runtimeStateStore.MarkFailed(settings.Id, ex.Message);
+                throw;
+            }
+
+            await ReconcileShellAsync(settings.Id, snapshot, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            operationLock.Release();
+        }
     }
 
     /// <inheritdoc />
     public async Task ReloadShellAsync(ShellId shellId, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Reloading shell '{ShellId}' from provider", shellId);
+        await notificationPublisher.PublishAsync(new ShellReloading(shellId), strategy: null, cancellationToken).ConfigureAwait(false);
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        await _shellHostInitializer.EnsureInitializedAsync(cancellationToken);
-
-        // Emit ShellReloading before any state mutation
-        await _notificationPublisher.PublishAsync(new ShellReloading(shellId), strategy: null, cancellationToken);
-
-        // Query the provider for the targeted shell
-        var freshSettings = await _provider.GetShellSettingsAsync(shellId, cancellationToken);
-
-        if (freshSettings is null)
-        {
-            _logger.LogWarning("Provider does not define shell '{ShellId}'; reload aborted without state mutation", shellId);
-            throw new InvalidOperationException($"Shell '{shellId}' is not defined by the provider. Reload aborted without modifying runtime state.");
-        }
-
-        // Capture the old shell context (if it was previously built) so we can
-        // publish ShellDeactivating before disposing its service provider.
-        ShellContext? oldContext = null;
         try
         {
-            oldContext = _shellHost.GetShell(shellId);
-        }
-        catch (KeyNotFoundException)
-        {
-            // Shell was never built — no deactivation needed
-        }
+            logger.LogInformation("Reloading shell '{ShellId}' from provider", shellId);
 
-        // Deactivate the old shell before eviction (service provider is still alive)
-        if (oldContext is not null)
-        {
-            _logger.LogDebug("Publishing ShellDeactivating for shell '{ShellId}' before reload eviction", shellId);
-            await _notificationPublisher.PublishAsync(new ShellDeactivating(oldContext), strategy: null, cancellationToken);
-        }
+            var snapshot = await runtimeFeatureCatalog.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            var freshSettings = await provider.GetShellSettingsAsync(shellId, cancellationToken).ConfigureAwait(false);
 
-        lock (_lock)
-        {
-            // Replace the targeted shell in-place to preserve insertion order;
-            // only append when the shell is genuinely new.
-            var existing = _cache.GetAll().ToList();
-            var index = existing.FindIndex(s => s.Id.Equals(shellId));
-
-            if (index >= 0)
+            if (freshSettings is null)
             {
-                existing[index] = freshSettings;
-            }
-            else
-            {
-                existing.Add(freshSettings);
+                logger.LogWarning("Provider does not define shell '{ShellId}'; reload aborted without state mutation", shellId);
+                throw new InvalidOperationException($"Shell '{shellId}' is not defined by the provider. Reload aborted without modifying runtime state.");
             }
 
-            _cache.Load(existing);
+            ReplaceShellInCache(freshSettings);
+            runtimeStateStore.RecordDesired(freshSettings);
+            await ReconcileShellAsync(shellId, snapshot, cancellationToken).ConfigureAwait(false);
+
+            await notificationPublisher.PublishAsync(
+                new ShellReloaded(shellId, [shellId], runtimeStateAccessor.GetAllShells()),
+                strategy: null,
+                cancellationToken).ConfigureAwait(false);
         }
-
-        // Evict the cached runtime context so next access rebuilds from fresh settings
-        await _shellHost.EvictShellAsync(shellId);
-
-        // Eagerly rebuild the shell and publish ShellActivated so lifecycle handlers run
-        var newContext = _shellHost.GetShell(shellId);
-        _logger.LogDebug("Publishing ShellActivated for shell '{ShellId}' after reload rebuild", shellId);
-        await _notificationPublisher.PublishAsync(new ShellActivated(newContext), strategy: null, cancellationToken);
-
-        _logger.LogInformation("Shell '{ShellId}' reloaded successfully", shellId);
-
-        // Emit ShellReloaded on success (always last)
-        await _notificationPublisher.PublishAsync(
-            new ShellReloaded(shellId, [shellId]), strategy: null, cancellationToken);
+        finally
+        {
+            operationLock.Release();
+        }
     }
 
     /// <inheritdoc />
     public async Task ReloadAllShellsAsync(CancellationToken cancellationToken = default)
     {
-        await _shellHostInitializer.EnsureInitializedAsync(cancellationToken);
+        await notificationPublisher.PublishAsync(new ShellReloading(null), strategy: null, cancellationToken).ConfigureAwait(false);
+        await operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        _logger.LogInformation("Reloading all shells from provider");
-
-        // Emit aggregate ShellReloading (null ShellId = full reload)
-        await _notificationPublisher.PublishAsync(new ShellReloading(null), strategy: null, cancellationToken);
-
-        // Load fresh shell settings from provider
-        var settings = await _provider.GetShellSettingsAsync(cancellationToken);
-        var settingsList = settings.ToList();
-
-        // Capture current shells before updating cache for reconciliation
-        IReadOnlyCollection<ShellSettings> previousShells;
-
-        lock (_lock)
+        try
         {
-            previousShells = _cache.GetAll();
-        }
+            logger.LogInformation("Reloading all shells from provider");
 
-        // Determine changed shells (added, removed, or updated)
-        var previousIds = previousShells.Select(s => s.Id).ToHashSet();
-        var currentIds = settingsList.Select(s => s.Id).ToHashSet();
+            var previousStatuses = runtimeStateAccessor.GetAllShells().ToDictionary(status => status.ShellId);
+            var previousSettings = cache.GetAll().ToList();
+            var snapshot = await runtimeFeatureCatalog.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            var desiredShells = (await provider.GetShellSettingsAsync(cancellationToken).ConfigureAwait(false)).ToList();
 
-        var addedIds = currentIds.Except(previousIds);
-        var removedIds = previousIds.Except(currentIds);
-        var potentiallyUpdatedIds = currentIds.Intersect(previousIds);
-
-        // Build lookup dictionaries using last-wins to handle duplicate IDs consistently
-        // with ShellSettingsCache.Load() which also uses last-wins semantics.
-        var previousByKey = new Dictionary<ShellId, ShellSettings>();
-        foreach (var s in previousShells)
-            previousByKey[s.Id] = s;
-
-        var currentByKey = new Dictionary<ShellId, ShellSettings>();
-        foreach (var s in settingsList)
-            currentByKey[s.Id] = s;
-
-        // For "updated", compare settings structurally to detect meaningful changes
-        var updatedIds = potentiallyUpdatedIds.Where(id =>
-            !ShellSettingsEqual(previousByKey[id], currentByKey[id]));
-
-        var changedShells = addedIds.Concat(removedIds).Concat(updatedIds).ToList();
-
-        // Emit per-shell ShellReloading for each changed shell (before mutation)
-        foreach (var id in changedShells)
-        {
-            await _notificationPublisher.PublishAsync(new ShellReloading(id), strategy: null, cancellationToken);
-        }
-
-        // Capture all existing shell contexts before eviction so we can publish
-        // ShellDeactivating while their service providers are still alive.
-        // EvictAllShellsAsync disposes ALL contexts, not just changed ones.
-        var existingContexts = new List<ShellContext>();
-        foreach (var shell in previousShells)
-        {
-            try
+            cache.Load(desiredShells);
+            foreach (var settings in desiredShells)
             {
-                existingContexts.Add(_shellHost.GetShell(shell.Id));
+                runtimeStateStore.RecordDesired(settings);
             }
-            catch (KeyNotFoundException)
+
+            var desiredIds = desiredShells.Select(settings => settings.Id).ToHashSet();
+            var removedIds = previousSettings
+                .Select(settings => settings.Id)
+                .Where(shellId => !desiredIds.Contains(shellId))
+                .Distinct()
+                .ToList();
+
+            foreach (var shellId in removedIds)
             {
-                // Shell was never built — no deactivation needed
+                await shellHost.RemoveAppliedRuntimeAsync(shellId, removeDesiredState: true, publishLifecycleNotifications: true, cancellationToken).ConfigureAwait(false);
             }
-        }
 
-        // Deactivate all existing shells before eviction
-        foreach (var context in existingContexts)
+            await ReconcileShellsAsync(desiredIds, snapshot, cancellationToken).ConfigureAwait(false);
+
+            var statuses = runtimeStateAccessor.GetAllShells();
+            var changedShells = DetermineChangedShells(previousStatuses, statuses, previousSettings, desiredShells, removedIds);
+
+            foreach (var shellId in changedShells)
+            {
+                await notificationPublisher.PublishAsync(
+                    new ShellReloaded(shellId, [shellId], statuses),
+                    strategy: null,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            await notificationPublisher.PublishAsync(new ShellsReloaded(statuses), strategy: null, cancellationToken).ConfigureAwait(false);
+            await notificationPublisher.PublishAsync(new ShellReloaded(null, changedShells, statuses), strategy: null, cancellationToken).ConfigureAwait(false);
+        }
+        finally
         {
-            _logger.LogDebug("Publishing ShellDeactivating for shell '{ShellId}' before reload eviction", context.Id);
-            await _notificationPublisher.PublishAsync(new ShellDeactivating(context), strategy: null, cancellationToken);
+            operationLock.Release();
         }
-
-        // Update cache - reconciles to provider state
-        lock (_lock)
-        {
-            _cache.Clear();
-            _cache.Load(settingsList);
-        }
-
-        // Evict all cached runtime contexts so next access rebuilds from fresh settings
-        await _shellHost.EvictAllShellsAsync();
-
-        // Eagerly rebuild all shells and publish ShellActivated for each
-        var allShells = _shellHost.AllShells;
-        foreach (var context in allShells)
-        {
-            _logger.LogDebug("Publishing ShellActivated for shell '{ShellId}' after reload rebuild", context.Id);
-            await _notificationPublisher.PublishAsync(new ShellActivated(context), strategy: null, cancellationToken);
-        }
-
-        _logger.LogInformation("Reloaded {Count} shell(s)", settingsList.Count);
-
-        // Emit per-shell ShellReloaded for each changed shell (after mutation)
-        foreach (var id in changedShells)
-        {
-            await _notificationPublisher.PublishAsync(
-                new ShellReloaded(id, [id]), strategy: null, cancellationToken);
-        }
-
-        // Publish ShellsReloaded (existing aggregate notification, preserved)
-        await _notificationPublisher.PublishAsync(new ShellsReloaded(settingsList), strategy: null, cancellationToken);
-
-        // Publish aggregate ShellReloaded last (null ShellId, with all changed shells)
-        await _notificationPublisher.PublishAsync(
-            new ShellReloaded(null, changedShells.AsReadOnly()), strategy: null, cancellationToken);
     }
 
-    /// <summary>
-    /// Compares two <see cref="ShellSettings"/> by value (Id, EnabledFeatures, ConfigurationData)
-    /// to determine whether they represent the same logical configuration.
-    /// </summary>
-    private static bool ShellSettingsEqual(ShellSettings a, ShellSettings b)
+    private async Task ReconcileShellsAsync(
+        IEnumerable<ShellId> shellIds,
+        RuntimeFeatureCatalogSnapshot snapshot,
+        CancellationToken cancellationToken)
     {
-        if (!a.Id.Equals(b.Id))
-            return false;
-
-        if (!a.EnabledFeatures.SequenceEqual(b.EnabledFeatures, StringComparer.OrdinalIgnoreCase))
-            return false;
-
-        if (a.ConfigurationData.Count != b.ConfigurationData.Count)
-            return false;
-
-        foreach (var kvp in a.ConfigurationData)
+        foreach (var shellId in shellIds.Distinct())
         {
-            if (!b.ConfigurationData.TryGetValue(kvp.Key, out var otherValue))
-                return false;
+            await ReconcileShellAsync(shellId, snapshot, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
-            if (!Equals(kvp.Value, otherValue))
+    private async Task ReconcileShellAsync(
+        ShellId shellId,
+        RuntimeFeatureCatalogSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        var record = runtimeStateStore.Get(shellId);
+        if (record is null)
+            return;
+
+        var candidate = shellHost.BuildCandidate(record, snapshot);
+        if (candidate.IsReadyToCommit)
+        {
+            await shellHost.CommitCandidateAsync(candidate, publishLifecycleNotifications: true, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (candidate.IsDeferred)
+        {
+            runtimeStateStore.MarkDeferred(shellId, candidate.MissingFeatures, candidate.FailureReason);
+            logger.LogInformation(
+                "Deferred shell '{ShellId}' at desired generation {DesiredGeneration}: {Reason}",
+                shellId,
+                record.DesiredGeneration,
+                candidate.FailureReason);
+            return;
+        }
+
+        runtimeStateStore.MarkFailed(shellId, candidate.FailureReason);
+        logger.LogWarning(
+            "Failed to reconcile shell '{ShellId}' at desired generation {DesiredGeneration}: {Reason}",
+            shellId,
+            record.DesiredGeneration,
+            candidate.FailureReason);
+    }
+
+    private void ReplaceShellInCache(ShellSettings settings)
+    {
+        var existing = cache.GetAll().ToList();
+        var index = existing.FindIndex(current => current.Id.Equals(settings.Id));
+
+        if (index >= 0)
+        {
+            existing[index] = settings;
+        }
+        else
+        {
+            existing.Add(settings);
+        }
+
+        cache.Load(existing);
+    }
+
+    private void RemoveShellFromCache(ShellId shellId)
+    {
+        var remainingShells = cache.GetAll()
+            .Where(settings => !settings.Id.Equals(shellId))
+            .ToList();
+
+        cache.Load(remainingShells);
+    }
+
+    private static IReadOnlyCollection<ShellId> DetermineChangedShells(
+        IReadOnlyDictionary<ShellId, ShellRuntimeStatus> previousStatuses,
+        IReadOnlyCollection<ShellRuntimeStatus> currentStatuses,
+        IReadOnlyCollection<ShellSettings> previousSettings,
+        IReadOnlyCollection<ShellSettings> currentSettings,
+        IReadOnlyCollection<ShellId> removedIds)
+    {
+        var changedShells = new HashSet<ShellId>(removedIds);
+        var previousSettingsById = previousSettings.ToDictionary(settings => settings.Id);
+        var currentSettingsById = currentSettings.ToDictionary(settings => settings.Id);
+
+        foreach (var shellId in previousSettingsById.Keys.Union(currentSettingsById.Keys))
+        {
+            var hadPreviousSettings = previousSettingsById.TryGetValue(shellId, out var previousSetting);
+            var hasCurrentSettings = currentSettingsById.TryGetValue(shellId, out var currentSetting);
+
+            if (!hadPreviousSettings || !hasCurrentSettings)
+            {
+                changedShells.Add(shellId);
+                continue;
+            }
+
+            if (!ShellSettingsEqual(previousSetting!, currentSetting!))
+            {
+                changedShells.Add(shellId);
+            }
+        }
+
+        foreach (var status in currentStatuses)
+        {
+            if (!previousStatuses.TryGetValue(status.ShellId, out var previousStatus) || previousStatus != status)
+            {
+                changedShells.Add(status.ShellId);
+            }
+        }
+
+        return changedShells.ToList().AsReadOnly();
+    }
+
+    private static bool ShellSettingsEqual(ShellSettings left, ShellSettings right)
+    {
+        if (!left.Id.Equals(right.Id))
+            return false;
+
+        if (!left.EnabledFeatures.SequenceEqual(right.EnabledFeatures, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        if (left.ConfigurationData.Count != right.ConfigurationData.Count)
+            return false;
+
+        foreach (var pair in left.ConfigurationData)
+        {
+            if (!right.ConfigurationData.TryGetValue(pair.Key, out var otherValue) || !Equals(pair.Value, otherValue))
                 return false;
         }
 

--- a/src/CShells/Management/ShellRuntimeRecord.cs
+++ b/src/CShells/Management/ShellRuntimeRecord.cs
@@ -1,0 +1,23 @@
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+
+namespace CShells.Management;
+
+internal sealed record ShellRuntimeRecord(
+    ShellId ShellId,
+    long DesiredGeneration,
+    ShellSettings DesiredSettings,
+    long? AppliedGeneration,
+    ShellSettings? AppliedSettings,
+    RuntimeFeatureCatalogSnapshot? AppliedCatalog,
+    ShellContext? AppliedContext,
+    ShellReconciliationOutcome LatestDesiredOutcome,
+    string? BlockingReason,
+    IReadOnlyCollection<string> MissingFeatures)
+{
+    public bool HasAppliedRuntime => AppliedGeneration.HasValue && AppliedSettings is not null && AppliedCatalog is not null;
+
+    public bool HasAppliedContext => AppliedContext is not null;
+}
+

--- a/src/CShells/Management/ShellRuntimeStateAccessor.cs
+++ b/src/CShells/Management/ShellRuntimeStateAccessor.cs
@@ -1,0 +1,39 @@
+namespace CShells.Management;
+
+internal sealed class ShellRuntimeStateAccessor(ShellRuntimeStateStore stateStore) : IShellRuntimeStateAccessor
+{
+    private readonly ShellRuntimeStateStore stateStore = Guard.Against.Null(stateStore);
+
+    public IReadOnlyCollection<ShellRuntimeStatus> GetAllShells() =>
+        stateStore
+            .GetAll()
+            .Select(Project)
+            .OrderBy(status => status.ShellId.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList()
+            .AsReadOnly();
+
+    public ShellRuntimeStatus? GetShell(ShellId shellId)
+    {
+        var record = stateStore.Get(shellId);
+        return record is null ? null : Project(record);
+    }
+
+    private static ShellRuntimeStatus Project(ShellRuntimeRecord record)
+    {
+        var isRoutable = record.HasAppliedRuntime;
+        var isInSync = record.AppliedGeneration.HasValue && record.AppliedGeneration.Value == record.DesiredGeneration;
+        var blockingReason = isInSync ? null : record.BlockingReason;
+        var outcome = isRoutable ? ShellReconciliationOutcome.Active : record.LatestDesiredOutcome;
+
+        return new ShellRuntimeStatus(
+            record.ShellId,
+            record.DesiredGeneration,
+            record.AppliedGeneration,
+            outcome,
+            isInSync,
+            isRoutable,
+            blockingReason,
+            [.. record.MissingFeatures]);
+    }
+}
+

--- a/src/CShells/Management/ShellRuntimeStateStore.cs
+++ b/src/CShells/Management/ShellRuntimeStateStore.cs
@@ -47,6 +47,7 @@ internal sealed class ShellRuntimeStateStore
                     ? existing.DesiredGeneration
                     : existing.DesiredGeneration + 1;
 
+            var isGenerationAdvanced = existing is not null && desiredGeneration > existing.DesiredGeneration;
             var record = existing is null
                 ? new ShellRuntimeRecord(
                     clonedSettings.Id,
@@ -63,8 +64,8 @@ internal sealed class ShellRuntimeStateStore
                 {
                     DesiredGeneration = desiredGeneration,
                     DesiredSettings = clonedSettings,
-                    BlockingReason = existing.HasAppliedRuntime ? "Awaiting reconciliation." : existing.BlockingReason,
-                    MissingFeatures = existing.HasAppliedRuntime ? [] : existing.MissingFeatures
+                    BlockingReason = isGenerationAdvanced ? "Awaiting reconciliation." : existing.BlockingReason,
+                    MissingFeatures = isGenerationAdvanced ? [] : existing.MissingFeatures
                 };
 
             records[settings.Id] = record;

--- a/src/CShells/Management/ShellRuntimeStateStore.cs
+++ b/src/CShells/Management/ShellRuntimeStateStore.cs
@@ -1,0 +1,267 @@
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+
+namespace CShells.Management;
+
+internal sealed class ShellRuntimeStateStore
+{
+    private readonly Dictionary<ShellId, ShellRuntimeRecord> records = [];
+    private readonly object syncRoot = new();
+
+    public IReadOnlyCollection<ShellRuntimeRecord> GetAll()
+    {
+        lock (syncRoot)
+        {
+            return [.. records.Values];
+        }
+    }
+
+    public ShellRuntimeRecord? Get(ShellId shellId)
+    {
+        lock (syncRoot)
+        {
+            return records.GetValueOrDefault(shellId);
+        }
+    }
+
+    public bool HasDesiredShell(ShellId shellId)
+    {
+        lock (syncRoot)
+        {
+            return records.ContainsKey(shellId);
+        }
+    }
+
+    public ShellRuntimeRecord RecordDesired(ShellSettings settings)
+    {
+        Guard.Against.Null(settings);
+
+        lock (syncRoot)
+        {
+            var clonedSettings = CloneShellSettings(settings);
+            var existing = records.GetValueOrDefault(settings.Id);
+            var desiredGeneration = existing is null
+                ? 1
+                : ShellSettingsEqual(existing.DesiredSettings, clonedSettings)
+                    ? existing.DesiredGeneration
+                    : existing.DesiredGeneration + 1;
+
+            var record = existing is null
+                ? new ShellRuntimeRecord(
+                    clonedSettings.Id,
+                    desiredGeneration,
+                    clonedSettings,
+                    null,
+                    null,
+                    null,
+                    null,
+                    ShellReconciliationOutcome.Failed,
+                    "Shell has not been reconciled yet.",
+                    [])
+                : existing with
+                {
+                    DesiredGeneration = desiredGeneration,
+                    DesiredSettings = clonedSettings,
+                    BlockingReason = existing.HasAppliedRuntime ? "Awaiting reconciliation." : existing.BlockingReason,
+                    MissingFeatures = existing.HasAppliedRuntime ? [] : existing.MissingFeatures
+                };
+
+            records[settings.Id] = record;
+            return record;
+        }
+    }
+
+    public ShellRuntimeRecord MarkDeferred(ShellId shellId, IReadOnlyCollection<string> missingFeatures, string? blockingReason)
+    {
+        lock (syncRoot)
+        {
+            var existing = GetRequiredRecord(shellId);
+            var normalizedMissingFeatures = missingFeatures
+                .Where(feature => !string.IsNullOrWhiteSpace(feature))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var record = existing with
+            {
+                LatestDesiredOutcome = ShellReconciliationOutcome.DeferredDueToMissingFeatures,
+                BlockingReason = blockingReason,
+                MissingFeatures = normalizedMissingFeatures
+            };
+
+            records[shellId] = record;
+            return record;
+        }
+    }
+
+    public ShellRuntimeRecord MarkFailed(ShellId shellId, string? blockingReason)
+    {
+        lock (syncRoot)
+        {
+            var existing = GetRequiredRecord(shellId);
+            var record = existing with
+            {
+                LatestDesiredOutcome = ShellReconciliationOutcome.Failed,
+                BlockingReason = blockingReason,
+                MissingFeatures = []
+            };
+
+            records[shellId] = record;
+            return record;
+        }
+    }
+
+    public ShellCommitResult CommitAppliedRuntime(
+        ShellId shellId,
+        ShellSettings appliedSettings,
+        RuntimeFeatureCatalogSnapshot appliedCatalog,
+        ShellContext appliedContext)
+    {
+        Guard.Against.Null(appliedSettings);
+        Guard.Against.Null(appliedCatalog);
+        Guard.Against.Null(appliedContext);
+
+        lock (syncRoot)
+        {
+            var existing = GetRequiredRecord(shellId);
+            var previousContext = existing.AppliedContext;
+            var record = existing with
+            {
+                AppliedGeneration = existing.DesiredGeneration,
+                AppliedSettings = CloneShellSettings(appliedSettings),
+                AppliedCatalog = appliedCatalog,
+                AppliedContext = appliedContext,
+                LatestDesiredOutcome = ShellReconciliationOutcome.Active,
+                BlockingReason = null,
+                MissingFeatures = []
+            };
+
+            records[shellId] = record;
+            return new(record, previousContext);
+        }
+    }
+
+    public ShellContext? EvictAppliedContext(ShellId shellId)
+    {
+        lock (syncRoot)
+        {
+            if (!records.TryGetValue(shellId, out var record) || record.AppliedContext is null)
+                return null;
+
+            var previousContext = record.AppliedContext;
+            records[shellId] = record with { AppliedContext = null };
+            return previousContext;
+        }
+    }
+
+    public IReadOnlyCollection<ShellContext> EvictAllAppliedContexts()
+    {
+        lock (syncRoot)
+        {
+            var contexts = records.Values
+                .Where(record => record.AppliedContext is not null)
+                .Select(record => record.AppliedContext!)
+                .ToList();
+
+            foreach (var record in records.Values.ToList())
+            {
+                if (record.AppliedContext is null)
+                    continue;
+
+                records[record.ShellId] = record with { AppliedContext = null };
+            }
+
+            return contexts;
+        }
+    }
+
+    public ShellRuntimeRecord SetAppliedContext(ShellId shellId, ShellContext context)
+    {
+        Guard.Against.Null(context);
+
+        lock (syncRoot)
+        {
+            var existing = GetRequiredRecord(shellId);
+            var record = existing with { AppliedContext = context };
+            records[shellId] = record;
+            return record;
+        }
+    }
+
+    public ShellRemovalResult RemoveShell(ShellId shellId)
+    {
+        lock (syncRoot)
+        {
+            if (!records.Remove(shellId, out var record))
+                return new(null, null);
+
+            return new(record, record.AppliedContext);
+        }
+    }
+
+    public ShellRemovalResult ClearAppliedRuntime(ShellId shellId)
+    {
+        lock (syncRoot)
+        {
+            if (!records.TryGetValue(shellId, out var existing))
+                return new(null, null);
+
+            var record = existing with
+            {
+                AppliedGeneration = null,
+                AppliedSettings = null,
+                AppliedCatalog = null,
+                AppliedContext = null
+            };
+
+            records[shellId] = record;
+            return new(record, existing.AppliedContext);
+        }
+    }
+
+    private ShellRuntimeRecord GetRequiredRecord(ShellId shellId) =>
+        records.GetValueOrDefault(shellId)
+        ?? throw new KeyNotFoundException($"Shell '{shellId}' is not present in the runtime state store.");
+
+    private static ShellSettings CloneShellSettings(ShellSettings settings)
+    {
+        var clone = new ShellSettings
+        {
+            Id = settings.Id,
+            EnabledFeatures = [.. settings.EnabledFeatures],
+            ConfigurationData = settings.ConfigurationData.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase)
+        };
+
+        foreach (var configurator in settings.FeatureConfigurators)
+        {
+            clone.FeatureConfigurators[configurator.Key] = configurator.Value;
+        }
+
+        return clone;
+    }
+
+    private static bool ShellSettingsEqual(ShellSettings left, ShellSettings right)
+    {
+        if (!left.Id.Equals(right.Id))
+            return false;
+
+        if (!left.EnabledFeatures.SequenceEqual(right.EnabledFeatures, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        if (left.ConfigurationData.Count != right.ConfigurationData.Count)
+            return false;
+
+        foreach (var pair in left.ConfigurationData)
+        {
+            if (!right.ConfigurationData.TryGetValue(pair.Key, out var otherValue) || !Equals(pair.Value, otherValue))
+                return false;
+        }
+
+        return true;
+    }
+}
+
+internal sealed record ShellCommitResult(ShellRuntimeRecord Record, ShellContext? PreviousContext);
+
+internal sealed record ShellRemovalResult(ShellRuntimeRecord? Record, ShellContext? PreviousContext);
+

--- a/src/CShells/Notifications/ShellReloaded.cs
+++ b/src/CShells/Notifications/ShellReloaded.cs
@@ -21,6 +21,6 @@ namespace CShells.Notifications;
 /// before this notification.</para>
 /// </remarks>
 public record ShellReloaded(
-	ShellId? ShellId,
-	IReadOnlyCollection<ShellId> ChangedShells,
-	IReadOnlyCollection<ShellRuntimeStatus> Statuses) : INotification;
+    ShellId? ShellId,
+    IReadOnlyCollection<ShellId> ChangedShells,
+    IReadOnlyCollection<ShellRuntimeStatus> Statuses) : INotification;

--- a/src/CShells/Notifications/ShellReloaded.cs
+++ b/src/CShells/Notifications/ShellReloaded.cs
@@ -1,3 +1,5 @@
+using CShells.Management;
+
 namespace CShells.Notifications;
 
 /// <summary>
@@ -11,10 +13,14 @@ namespace CShells.Notifications;
 /// For single-shell reload, this contains only the reloaded shell.
 /// For full reload, this contains all shells that changed during reconciliation.
 /// </param>
+/// <param name="Statuses">The current runtime status projection after the reconciliation pass completes.</param>
 /// <remarks>
 /// <para>This notification is always emitted last, only on successful completion.</para>
 /// <para>Failed reload operations do not emit this notification.</para>
 /// <para>For full reload: the existing aggregate <see cref="ShellsReloaded"/> notification is emitted
 /// before this notification.</para>
 /// </remarks>
-public record ShellReloaded(ShellId? ShellId, IReadOnlyCollection<ShellId> ChangedShells) : INotification;
+public record ShellReloaded(
+	ShellId? ShellId,
+	IReadOnlyCollection<ShellId> ChangedShells,
+	IReadOnlyCollection<ShellRuntimeStatus> Statuses) : INotification;

--- a/src/CShells/Notifications/ShellsReloaded.cs
+++ b/src/CShells/Notifications/ShellsReloaded.cs
@@ -1,8 +1,10 @@
+using CShells.Management;
+
 namespace CShells.Notifications;
 
 /// <summary>
 /// Notification published when the full shell set has been synchronized,
 /// such as after a full reload or after startup activation completes.
 /// </summary>
-/// <param name="AllShells">All shell settings after synchronization.</param>
-public record ShellsReloaded(IReadOnlyCollection<ShellSettings> AllShells) : INotification;
+/// <param name="Statuses">The runtime status projection for all configured shells after synchronization.</param>
+public record ShellsReloaded(IReadOnlyCollection<ShellRuntimeStatus> Statuses) : INotification;

--- a/src/CShells/Properties/InternalsVisibleTo.cs
+++ b/src/CShells/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CShells.Tests")]
+

--- a/src/CShells/Resolution/DefaultShellResolverStrategy.cs
+++ b/src/CShells/Resolution/DefaultShellResolverStrategy.cs
@@ -1,12 +1,33 @@
+using CShells.Hosting;
+using CShells.Management;
+
 namespace CShells.Resolution;
 
 /// <summary>
-/// A fallback strategy that always resolves to a shell with Id "Default".
-/// This strategy is typically registered last to ensure there's always a shell resolved.
+/// A fallback strategy that prefers the explicit <c>Default</c> shell when it is configured and applied,
+/// and otherwise falls back only to applied runtimes.
 /// </summary>
 [ResolverOrder(1000)]
-public class DefaultShellResolverStrategy : IShellResolverStrategy
+public class DefaultShellResolverStrategy(IShellHost shellHost, IShellRuntimeStateAccessor runtimeStateAccessor) : IShellResolverStrategy
 {
+    private readonly IShellHost shellHost = Guard.Against.Null(shellHost);
+    private readonly IShellRuntimeStateAccessor runtimeStateAccessor = Guard.Against.Null(runtimeStateAccessor);
+
     /// <inheritdoc />
-    public ShellId? Resolve(ShellResolutionContext context) => new ShellId(ShellConstants.DefaultShellName);
+    public ShellId? Resolve(ShellResolutionContext context)
+    {
+        Guard.Against.Null(context);
+
+        var defaultId = new ShellId(ShellConstants.DefaultShellName);
+        var explicitDefault = runtimeStateAccessor.GetShell(defaultId);
+
+        if (explicitDefault is not null)
+            return explicitDefault.IsRoutable ? defaultId : (ShellId?)null;
+
+        var fallback = shellHost.AllShells.FirstOrDefault();
+        if (fallback is null)
+            return null;
+
+        return fallback.Id;
+    }
 }

--- a/tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs
+++ b/tests/CShells.Tests.EndToEnd/WebRoutingShellResolutionTests.cs
@@ -1,5 +1,9 @@
 using System.Net;
 using System.Text.Json;
+using CShells.Management;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CShells.Tests.EndToEnd;
 
@@ -13,6 +17,30 @@ public class WebRoutingShellResolutionTests(WorkbenchApplicationFactory factory)
 {
     private readonly WorkbenchApplicationFactory _factory = factory;
     private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact(DisplayName = "Explicit Default that is configured but unapplied does not fall back at root while other applied shells remain active")]
+    public async Task ExplicitDefault_Unapplied_DoesNotFallbackAtRoot()
+    {
+        await using var customFactory = CreateFactoryWithUnappliedDefault();
+        using var client = customFactory.CreateClient();
+
+        var accessor = customFactory.Services.GetRequiredService<IShellRuntimeStateAccessor>();
+        var statuses = accessor.GetAllShells().ToDictionary(status => status.ShellId.Name, StringComparer.OrdinalIgnoreCase);
+
+        Assert.False(statuses["Default"].IsRoutable);
+        Assert.False(statuses["Default"].IsInSync);
+        Assert.Equal(["MissingFeature", "StillMissingFeature"], statuses["Default"].MissingFeatures.OrderBy(feature => feature, StringComparer.OrdinalIgnoreCase).ToArray());
+        Assert.True(statuses["Acme"].IsRoutable);
+        Assert.True(statuses["Contoso"].IsRoutable);
+
+        var rootResponse = await client.GetAsync("/");
+        Assert.Equal(HttpStatusCode.NotFound, rootResponse.StatusCode);
+
+        var acmeResponse = await client.GetAsync("/acme/");
+        acmeResponse.EnsureSuccessStatusCode();
+        var acmePayload = JsonDocument.Parse(await acmeResponse.Content.ReadAsStringAsync());
+        Assert.Equal("Acme", acmePayload.RootElement.GetProperty("tenant").GetString());
+    }
 
     [Fact(DisplayName = "Shell with WebRouting path configuration resolves correctly")]
     public async Task Shell_WithWebRoutingPath_ResolvesCorrectly()
@@ -215,5 +243,20 @@ public class WebRoutingShellResolutionTests(WorkbenchApplicationFactory factory)
                 Assert.True(json.RootElement.TryGetProperty("tenant", out _));
             }
         }
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithUnappliedDefault()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+            {
+                configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["CShells:Shells:0:Features:0"] = "MissingFeature",
+                    ["CShells:Shells:0:Features:1"] = "StillMissingFeature"
+                });
+            });
+        });
     }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs
@@ -1,11 +1,21 @@
+using System.Reflection;
+using CShells.AspNetCore.Features;
+using CShells.AspNetCore.Notifications;
 using CShells.AspNetCore.Routing;
+using CShells.Configuration;
+using CShells.Features;
 using CShells.Hosting;
+using CShells.Management;
+using CShells.Notifications;
 using CShells.Resolution;
+using CShells.Tests.Integration.ShellHost;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Hosting;
 
 namespace CShells.Tests.Integration.AspNetCore;
 
@@ -33,7 +43,7 @@ public class ApplicationBuilderExtensionsTests
         // Arrange
         var services = new ServiceCollection();
         services.AddSingleton<IShellResolver, NullShellResolver>();
-        services.AddSingleton<CShells.Features.IShellFeatureFactory, CShells.Features.DefaultShellFeatureFactory>();
+        services.AddSingleton<IShellFeatureFactory, DefaultShellFeatureFactory>();
         services.AddSingleton<IShellHost, EmptyShellHost>();
         services.AddSingleton<EndpointRouteBuilderAccessor>();
         services.AddSingleton<DynamicShellEndpointDataSource>();
@@ -46,6 +56,85 @@ public class ApplicationBuilderExtensionsTests
 
         // Assert
         Assert.NotNull(result);
+    }
+
+    [Fact(DisplayName = "Shell endpoint registration only exposes endpoints for committed applied runtimes")]
+    public async Task ShellEndpointRegistration_OnlyAppliedShellsExposeEndpoints()
+    {
+        // Arrange
+        var appliedShell = CreateShell("Applied", "applied", ["TestWeb"]);
+        var deferredShell = CreateShell("Deferred", "deferred", ["TestWeb", "MissingFeature"]);
+        var cache = new ShellSettingsCache();
+        cache.Load([appliedShell, deferredShell]);
+
+        var (rootServices, rootProvider) = TestFixtures.CreateRootServices();
+        var rootAccessor = TestFixtures.CreateRootServicesAccessor(rootServices);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var stateStore = new ShellRuntimeStateStore();
+        var notifications = new RecordingNotificationPublisher();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(ApplicationBuilderExtensionsTests).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        await using var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(ApplicationBuilderExtensionsTests).Assembly]),
+            rootProvider,
+            rootAccessor,
+            featureFactory,
+            new ShellServiceExclusionRegistry([]),
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var runtimeAccessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(
+            host,
+            cache,
+            new MutableInMemoryShellSettingsProvider([appliedShell, deferredShell]),
+            stateStore,
+            runtimeCatalog,
+            runtimeAccessor,
+            notifications,
+            NullLogger<DefaultShellManager>.Instance);
+
+        await manager.InitializeRuntimeAsync();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IShellResolver, NullShellResolver>();
+        services.AddSingleton<IShellFeatureFactory>(featureFactory);
+        services.AddSingleton<IShellHost>(host);
+        services.AddSingleton<EndpointRouteBuilderAccessor>();
+        services.AddSingleton<DynamicShellEndpointDataSource>();
+        services.AddSingleton<ApplicationBuilderAccessor>();
+        var serviceProvider = services.BuildServiceProvider();
+        var app = new TestApplicationBuilder(serviceProvider);
+
+        _ = CShells.AspNetCore.Extensions.ApplicationBuilderExtensions.MapShells(app);
+
+        var dataSource = serviceProvider.GetRequiredService<DynamicShellEndpointDataSource>();
+        var handler = new ShellEndpointRegistrationHandler(
+            dataSource,
+            featureFactory,
+            host,
+            serviceProvider.GetRequiredService<EndpointRouteBuilderAccessor>(),
+            serviceProvider.GetRequiredService<ApplicationBuilderAccessor>());
+
+        // Act
+        await handler.HandleAsync(new ShellsReloaded(runtimeAccessor.GetAllShells()));
+
+        // Assert
+        var routedEndpoints = dataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => (
+                endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId,
+                Pattern: endpoint.RoutePattern.RawText))
+            .ToList();
+
+        Assert.Contains(routedEndpoints, endpoint => endpoint.ShellId == new ShellId("Applied") && endpoint.Pattern == "/applied/ping");
+        Assert.DoesNotContain(routedEndpoints, endpoint => endpoint.ShellId == new ShellId("Deferred"));
+        Assert.DoesNotContain(routedEndpoints, endpoint => string.Equals(endpoint.Pattern, "/deferred/ping", StringComparison.OrdinalIgnoreCase));
     }
 
     // Test helpers
@@ -63,6 +152,40 @@ public class ApplicationBuilderExtensionsTests
         public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
     }
 
+    [ShellFeature("TestWeb")]
+    public sealed class TestWebFeature : IWebShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment)
+        {
+            endpoints.MapGet("/ping", () => Results.Ok(new { ok = true }));
+        }
+    }
+
+    private static ShellSettings CreateShell(string name, string path, IReadOnlyCollection<string> features)
+    {
+        return new ShellSettings
+        {
+            Id = new(name),
+            EnabledFeatures = [.. features],
+            ConfigurationData = new Dictionary<string, object>
+            {
+                ["WebRouting:Path"] = path
+            }
+        };
+    }
+
+    private sealed class RecordingNotificationPublisher : INotificationPublisher
+    {
+        public Task PublishAsync<TNotification>(
+            TNotification notification,
+            INotificationStrategy? strategy = null,
+            CancellationToken cancellationToken = default) where TNotification : class, INotification => Task.CompletedTask;
+    }
+
     private class TestApplicationBuilder(IServiceProvider serviceProvider) : IApplicationBuilder, IEndpointRouteBuilder
     {
         private readonly List<Func<RequestDelegate, RequestDelegate>> _components = [];
@@ -78,7 +201,7 @@ public class ApplicationBuilderExtensionsTests
 
         public RequestDelegate Build()
         {
-            RequestDelegate app = context => Task.CompletedTask;
+            RequestDelegate app = _ => Task.CompletedTask;
             for (var i = _components.Count - 1; i >= 0; i--)
             {
                 app = _components[i](app);

--- a/tests/CShells.Tests/Integration/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -25,8 +25,8 @@ public class ServiceCollectionExtensionsTests
         Assert.NotNull(resolver);
     }
 
-    [Fact(DisplayName = "AddCShellsAspNetCore default resolver returns Default ShellId")]
-    public void AddCShellsAspNetCore_DefaultResolver_ReturnsDefaultShellId()
+    [Fact(DisplayName = "AddCShellsAspNetCore default resolver returns null when no applied shells exist")]
+    public void AddCShellsAspNetCore_DefaultResolver_ReturnsNullWithoutAppliedShells()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -40,8 +40,7 @@ public class ServiceCollectionExtensionsTests
         var result = resolver.Resolve(context);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(new("Default"), result.Value);
+        Assert.Null(result);
     }
 
     [Fact(DisplayName = "AddCShellsAspNetCore does not override custom IShellResolver")]

--- a/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/WebRoutingShellResolverTests.cs
@@ -1,7 +1,11 @@
 using CShells.AspNetCore;
 using CShells.AspNetCore.Resolution;
 using CShells.Configuration;
+using CShells.DependencyInjection;
+using CShells.Features;
+using CShells.Hosting;
 using CShells.Resolution;
+using CShells.Tests.Integration.ShellHost;
 
 namespace CShells.Tests.Integration.AspNetCore;
 
@@ -50,6 +54,20 @@ public class WebRoutingShellResolverTests
 
         // Assert
         Assert.Equal(new ShellId(Tenant1Name), result);
+    }
+
+    [Fact(DisplayName = "WebRoutingShellResolver only resolves path-routed shells that currently have an applied runtime")]
+    public async Task WebRoutingShellResolver_PathRouting_OnlyUsesAppliedShells()
+    {
+        // Arrange
+        var defaultSettings = CreateShell("Default", new WebRoutingShellOptions { Path = string.Empty }, ["Core"]);
+        var deferredSettings = CreateShell("Deferred", new WebRoutingShellOptions { Path = "deferred" }, ["MissingFeature"]);
+        await using var host = CreateAppliedHost(defaultSettings, deferredSettings);
+        var resolver = new WebRoutingShellResolver(host, new WebRoutingShellResolverOptions());
+
+        // Act & Assert
+        Assert.Equal(new ShellId("Default"), resolver.Resolve(CreateContext(path: "/deferred/api")));
+        Assert.Equal(new ShellId("Default"), resolver.Resolve(CreateContext(path: "/")));
     }
 
     [Fact(DisplayName = "WebRoutingShellResolver respects excluded paths")]
@@ -249,6 +267,20 @@ public class WebRoutingShellResolverTests
         Assert.Null(result);
     }
 
+    [Fact(DisplayName = "WebRoutingShellResolver does not use an unapplied explicit Default shell as the root-path fallback")]
+    public async Task WebRoutingShellResolver_ExplicitDefaultUnapplied_DoesNotResolveRootFallback()
+    {
+        // Arrange
+        var defaultSettings = CreateShell("Default", new WebRoutingShellOptions { Path = string.Empty }, ["MissingFeature"]);
+        var contosoSettings = CreateShell("Contoso", new WebRoutingShellOptions { Path = "contoso" }, ["Core"]);
+        await using var host = CreateAppliedHost(defaultSettings, contosoSettings);
+        var resolver = new WebRoutingShellResolver(host, new WebRoutingShellResolverOptions());
+
+        // Act & Assert
+        Assert.Null(resolver.Resolve(CreateContext(path: "/")));
+        Assert.Equal(new ShellId("Contoso"), resolver.Resolve(CreateContext(path: "/contoso/posts")));
+    }
+
     #endregion
 
     #region Multi-Method Tests
@@ -310,7 +342,7 @@ public class WebRoutingShellResolverTests
         var options = new WebRoutingShellResolverOptions();
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentNullException>(() => new WebRoutingShellResolver(null!, options));
+        var ex = Assert.Throws<ArgumentNullException>(() => new WebRoutingShellResolver((IShellSettingsCache)null!, options));
         Assert.Equal("cache", ex.ParamName);
     }
 
@@ -375,12 +407,12 @@ public class WebRoutingShellResolverTests
         return new TestShellSettingsCache([CreateShell(Tenant3Name, routingOptions)]);
     }
 
-    private static ShellSettings CreateShell(string name, WebRoutingShellOptions routingOptions)
+    private static ShellSettings CreateShell(string name, WebRoutingShellOptions routingOptions, IReadOnlyCollection<string>? enabledFeatures = null)
     {
         var settings = new ShellSettings
         {
             Id = new(name),
-            EnabledFeatures = [],
+            EnabledFeatures = [.. enabledFeatures ?? []],
             ConfigurationData = new Dictionary<string, object>()
         };
 
@@ -395,6 +427,19 @@ public class WebRoutingShellResolverTests
             settings.ConfigurationData["WebRouting:ClaimKey"] = routingOptions.ClaimKey;
 
         return settings;
+    }
+
+    private static Hosting.DefaultShellHost CreateAppliedHost(params ShellSettings[] shells)
+    {
+        var cache = new ShellSettingsCache();
+        cache.Load(shells);
+
+        var (services, provider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(provider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+
+        return new Hosting.DefaultShellHost(cache, [typeof(TestFixtures).Assembly], provider, accessor, featureFactory, exclusionRegistry);
     }
 
     private class TestShellSettingsCache(List<ShellSettings> shells) : IShellSettingsCache

--- a/tests/CShells.Tests/Integration/DefaultShellHost/ConstructorTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/ConstructorTests.cs
@@ -66,8 +66,8 @@ public class ConstructorTests(DefaultShellHostFixture fixture)
         Assert.Equal(expectedParam, exception.ParamName);
     }
 
-    [Fact(DisplayName = "Deferred constructor requires async initialization before shell access")]
-    public void DeferredConstructor_BeforeInitialize_ThrowsInvalidOperationException()
+    [Fact(DisplayName = "Deferred constructor does not expose applied runtimes before reconciliation")]
+    public void DeferredConstructor_BeforeInitialize_ThrowsKeyNotFoundException()
     {
         var cache = new ShellSettingsCache();
         cache.Load([new(new("Default"), ["Weather"])]);
@@ -80,16 +80,17 @@ public class ConstructorTests(DefaultShellHostFixture fixture)
             fixture.FeatureFactory,
             exclusionRegistry);
 
-        var exception = Assert.Throws<InvalidOperationException>(() => host.GetShell(new("Default")));
+        var exception = Assert.Throws<KeyNotFoundException>(() => host.GetShell(new("Default")));
 
-        Assert.Contains("ensure the shell host is initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("does not have a committed applied runtime", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(DisplayName = "Deferred constructor builds shells after async initialization")]
-    public async Task DeferredConstructor_AfterInitialize_BuildsShells()
+    [Fact(DisplayName = "Deferred constructor builds shells after the runtime manager reconciles desired state")]
+    public async Task DeferredConstructor_AfterManagerInitialization_BuildsShells()
     {
         var cache = new ShellSettingsCache();
-        cache.Load([new(new("Default"), ["Weather"])]);
+        var settings = new ShellSettings(new("Default"), ["Weather"]);
+        cache.Load([settings]);
         var exclusionRegistry = new ShellServiceExclusionRegistry([]);
         var host = new Hosting.DefaultShellHost(
             cache,
@@ -98,8 +99,14 @@ public class ConstructorTests(DefaultShellHostFixture fixture)
             fixture.RootAccessor,
             fixture.FeatureFactory,
             exclusionRegistry);
+        var manager = new Management.DefaultShellManager(
+            host,
+            cache,
+            new InMemoryShellSettingsProvider([settings]),
+            new Notifications.DefaultNotificationPublisher(fixture.RootProvider));
 
         await host.InitializeAsync();
+        await manager.InitializeRuntimeAsync();
 
         var shell = host.GetShell(new("Default"));
 

--- a/tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/LifecycleTests.cs
@@ -1,6 +1,12 @@
+using System.Reflection;
+using CShells.Configuration;
+using CShells.Features;
 using CShells.Hosting;
+using CShells.Management;
+using CShells.Notifications;
 using CShells.Tests.Integration.ShellHost;
 using CShells.Tests.TestHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CShells.Tests.Integration.DefaultShellHost;
 
@@ -24,5 +30,103 @@ public class LifecycleTests(DefaultShellHostFixture fixture)
         Assert.Throws<ObjectDisposedException>(() => host.DefaultShell);
         Assert.Throws<ObjectDisposedException>(() => host.GetShell(new("TestShell")));
         Assert.Throws<ObjectDisposedException>(() => _ = host.AllShells);
+    }
+
+    [Fact(DisplayName = "ReloadAllShellsAsync only swaps shells whose candidates commit while preserving other applied runtimes")]
+    public async Task ReloadAllShellsAsync_MixedReconciliation_OnlyCommittedShellsAreReplaced()
+    {
+        // Arrange
+        var alphaId = new ShellId("Alpha");
+        var betaId = new ShellId("Beta");
+
+        var alphaInitial = new ShellSettings(alphaId, ["Core"]);
+        var betaInitial = new ShellSettings(betaId, ["Core"]);
+        var alphaUpdated = new ShellSettings(alphaId, ["Weather"]);
+        var betaDeferred = new ShellSettings(betaId, ["Core", "MissingFeature"]);
+
+        var cache = fixture.CreateCache([alphaInitial, betaInitial]);
+        var notifications = new RecordingNotificationPublisher();
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            fixture.RootProvider,
+            fixture.RootAccessor,
+            fixture.FeatureFactory,
+            new ShellServiceExclusionRegistry([]),
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var runtimeAccessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(
+            host,
+            cache,
+            new MutableInMemoryShellSettingsProvider([alphaUpdated, betaDeferred]),
+            stateStore,
+            runtimeCatalog,
+            runtimeAccessor,
+            notifications,
+            NullLogger<DefaultShellManager>.Instance);
+
+        await manager.InitializeRuntimeAsync();
+        var alphaBefore = host.GetShell(alphaId);
+        var betaBefore = host.GetShell(betaId);
+        notifications.Notifications.Clear();
+
+        // Act
+        await manager.ReloadAllShellsAsync();
+
+        // Assert
+        var alphaAfter = host.GetShell(alphaId);
+        var betaAfter = host.GetShell(betaId);
+        Assert.NotSame(alphaBefore, alphaAfter);
+        Assert.Same(betaBefore, betaAfter);
+
+        var statuses = runtimeAccessor.GetAllShells().OrderBy(status => status.ShellId.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.Collection(
+            statuses,
+            alphaStatus =>
+            {
+                Assert.Equal(alphaId, alphaStatus.ShellId);
+                Assert.True(alphaStatus.IsInSync);
+                Assert.True(alphaStatus.IsRoutable);
+                Assert.Equal(2, alphaStatus.AppliedGeneration);
+                Assert.Equal(ShellReconciliationOutcome.Active, alphaStatus.Outcome);
+            },
+            status =>
+            {
+                Assert.Equal(betaId, status.ShellId);
+                Assert.False(status.IsInSync);
+                Assert.True(status.IsRoutable);
+                Assert.Equal(2, status.DesiredGeneration);
+                Assert.Equal(1, status.AppliedGeneration);
+                Assert.Equal(ShellReconciliationOutcome.Active, status.Outcome);
+                Assert.Contains("MissingFeature", status.BlockingReason);
+                Assert.Equal(["MissingFeature"], status.MissingFeatures);
+            });
+
+        Assert.Contains(notifications.Notifications, notification => notification is ShellDeactivating deactivating && deactivating.Context.Id == alphaId);
+        Assert.Contains(notifications.Notifications, notification => notification is ShellActivated activated && activated.Context.Id == alphaId);
+        Assert.DoesNotContain(notifications.Notifications, notification => notification is ShellDeactivating deactivating && deactivating.Context.Id == betaId);
+        Assert.DoesNotContain(notifications.Notifications, notification => notification is ShellActivated activated && activated.Context.Id == betaId);
+    }
+
+    private sealed class RecordingNotificationPublisher : INotificationPublisher
+    {
+        public List<object> Notifications { get; } = [];
+
+        public Task PublishAsync<TNotification>(
+            TNotification notification,
+            INotificationStrategy? strategy = null,
+            CancellationToken cancellationToken = default) where TNotification : class, INotification
+        {
+            Notifications.Add(notification);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/ReloadBehaviorTests.cs
@@ -1,9 +1,12 @@
+using System.Reflection;
 using CShells.Configuration;
+using CShells.Features;
 using CShells.Hosting;
 using CShells.Management;
 using CShells.Notifications;
 using CShells.Tests.Integration.ShellHost;
 using CShells.Tests.TestHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CShells.Tests.Integration.DefaultShellHost;
 
@@ -59,7 +62,7 @@ public class ReloadBehaviorTests(DefaultShellHostFixture fixture)
         var host = fixture.CreateHost(cache, typeof(TestFixtures).Assembly);
 
         // Build both shells
-        var context1 = host.GetShell(tenant1);
+        _ = host.GetShell(tenant1);
         var context2Before = host.GetShell(tenant2);
 
         // Act - invalidate only Tenant1
@@ -139,99 +142,114 @@ public class ReloadBehaviorTests(DefaultShellHostFixture fixture)
         Assert.NotSame(context2Before, context2After);
     }
 
-    [Fact(DisplayName = "After invalidation of removed shell, GetShell throws KeyNotFoundException")]
-    public async Task AfterInvalidation_RemovedShell_ThrowsKeyNotFound()
+    [Fact(DisplayName = "After invalidation, an applied shell remains rebuildable even if it was removed from desired cache")]
+    public async Task AfterInvalidation_RemovedFromDesiredCache_AppliedRuntimeRemainsBuildable()
     {
         // Arrange
         var shellId = new ShellId("ToRemove");
-        var settings = new ShellSettings(shellId);
+        var settings = new ShellSettings(shellId, ["Core"]);
         var cache = fixture.CreateCache([settings]);
         var host = fixture.CreateHost(cache, typeof(TestFixtures).Assembly);
 
         // Build the shell
-        _ = host.GetShell(shellId);
+        var originalContext = host.GetShell(shellId);
 
-        // Remove from cache and invalidate context
+        // Remove from desired cache only and invalidate the materialized context.
+        // The applied runtime record should remain authoritative until explicit runtime removal.
         cache.Load([]); // empty cache
         await host.EvictShellAsync(shellId);
 
-        // Act & Assert - shell should no longer be accessible
-        Assert.Throws<KeyNotFoundException>(() => host.GetShell(shellId));
+        // Act
+        var rebuiltContext = host.GetShell(shellId);
+
+        // Assert
+        Assert.NotSame(originalContext, rebuiltContext);
+        Assert.Equal(shellId, rebuiltContext.Id);
+        Assert.Equal(["Core"], rebuiltContext.EnabledFeatures);
     }
 
     #endregion
 
     #region US3 - Notification Integration
 
-    [Fact(DisplayName = "ReloadShellAsync through manager emits ShellReloading and ShellReloaded with real host")]
-    public async Task ReloadShellAsync_ThroughManager_EmitsNotificationsWithRealHost()
+    [Fact(DisplayName = "ReloadShellAsync through manager emits reload plus applied-runtime lifecycle notifications when a successor commits")]
+    public async Task ReloadShellAsync_ThroughManager_EmitsNotificationsWithSharedHost()
     {
         // Arrange
         var shellId = new ShellId("Tenant1");
         var settings = new ShellSettings(shellId, ["Weather"]);
 
-        var cache = fixture.CreateCache([settings]);
-        var host = fixture.CreateHost(cache, typeof(TestFixtures).Assembly);
-        var provider = new InMemoryShellSettingsProvider([settings]);
-        var notifications = new RecordingNotificationPublisher();
-        var manager = new DefaultShellManager(host, host, cache, provider, notifications);
+        var runtime = CreateManagedRuntime([settings], new InMemoryShellSettingsProvider([settings]));
 
         // Build the shell initially
-        _ = host.GetShell(shellId);
+        await runtime.Manager.InitializeRuntimeAsync();
+        _ = runtime.Host.GetShell(shellId);
+        runtime.Notifications.Clear();
 
         // Act
-        await manager.ReloadShellAsync(shellId);
+        await runtime.Manager.ReloadShellAsync(shellId);
 
         // Assert - reload notifications
-        var reloading = notifications.Notifications.OfType<ShellReloading>().ToList();
-        var reloaded = notifications.Notifications.OfType<ShellReloaded>().ToList();
+        var reloading = runtime.Notifications.Notifications.OfType<ShellReloading>().ToList();
+        var reloaded = runtime.Notifications.Notifications.OfType<ShellReloaded>().ToList();
         Assert.Single(reloading);
         Assert.Single(reloaded);
         Assert.Equal(shellId, reloading[0].ShellId);
         Assert.Equal(shellId, reloaded[0].ShellId);
 
         // Assert - lifecycle notifications
-        Assert.Single(notifications.Notifications.OfType<ShellDeactivating>());
-        Assert.Single(notifications.Notifications.OfType<ShellActivated>());
+        Assert.Single(runtime.Notifications.Notifications.OfType<ShellDeactivating>());
+        Assert.Single(runtime.Notifications.Notifications.OfType<ShellActivated>());
     }
 
-    [Fact(DisplayName = "ReloadAllShellsAsync through manager emits aggregate notifications and rebuilds shells")]
-    public async Task ReloadAllShellsAsync_ThroughManager_EmitsAggregateNotificationsAndRebuilds()
+    [Fact(DisplayName = "ReloadAllShellsAsync through manager only publishes lifecycle notifications for committed mixed-shell successors")]
+    public async Task ReloadAllShellsAsync_ThroughManager_ReconcilesMixedShellsAtomically()
     {
         // Arrange
         var tenant1 = new ShellId("Tenant1");
         var tenant2 = new ShellId("Tenant2");
-        var settings1 = new ShellSettings(tenant1, ["Weather"]);
-        var settings2 = new ShellSettings(tenant2);
+        var initialSettings1 = new ShellSettings(tenant1, ["Core"]);
+        var initialSettings2 = new ShellSettings(tenant2, ["Core"]);
+        var updatedSettings1 = new ShellSettings(tenant1, ["Weather"]);
+        var deferredSettings2 = new ShellSettings(tenant2, ["Core", "MissingFeature"]);
 
-        var cache = fixture.CreateCache([settings1, settings2]);
-        var host = fixture.CreateHost(cache, typeof(TestFixtures).Assembly);
-        var provider = new InMemoryShellSettingsProvider([settings1, settings2]);
-        var notifications = new RecordingNotificationPublisher();
-        var manager = new DefaultShellManager(host, host, cache, provider, notifications);
+        var runtime = CreateManagedRuntime(
+            [initialSettings1, initialSettings2],
+            new InMemoryShellSettingsProvider([updatedSettings1, deferredSettings2]));
 
         // Build shells initially
-        var ctx1Before = host.GetShell(tenant1);
-        var ctx2Before = host.GetShell(tenant2);
+        await runtime.Manager.InitializeRuntimeAsync();
+        var ctx1Before = runtime.Host.GetShell(tenant1);
+        var ctx2Before = runtime.Host.GetShell(tenant2);
+        runtime.Notifications.Clear();
 
         // Act
-        await manager.ReloadAllShellsAsync();
+        await runtime.Manager.ReloadAllShellsAsync();
 
         // Assert - aggregate notifications
-        Assert.Contains(notifications.Notifications, n => n is ShellReloading r && r.ShellId is null);
-        Assert.Contains(notifications.Notifications, n => n is ShellReloaded r && r.ShellId is null);
+        Assert.Contains(runtime.Notifications.Notifications, n => n is ShellReloading r && r.ShellId is null);
+        Assert.Contains(runtime.Notifications.Notifications, n => n is ShellReloaded r && r.ShellId is null);
 
-        // Assert - lifecycle notifications for both shells
-        var deactivating = notifications.Notifications.OfType<ShellDeactivating>().ToList();
-        var activated = notifications.Notifications.OfType<ShellActivated>().ToList();
-        Assert.Equal(2, deactivating.Count);
-        Assert.Equal(2, activated.Count);
+        // Assert - lifecycle notifications only for the committed shell
+        var deactivating = runtime.Notifications.Notifications.OfType<ShellDeactivating>().ToList();
+        var activated = runtime.Notifications.Notifications.OfType<ShellActivated>().ToList();
+        Assert.Single(deactivating);
+        Assert.Single(activated);
+        Assert.Equal(tenant1, deactivating[0].Context.Id);
+        Assert.Equal(tenant1, activated[0].Context.Id);
 
-        // Assert - shells are rebuilt
-        var ctx1After = host.GetShell(tenant1);
-        var ctx2After = host.GetShell(tenant2);
+        // Assert - only the ready shell is rebuilt
+        var ctx1After = runtime.Host.GetShell(tenant1);
+        var ctx2After = runtime.Host.GetShell(tenant2);
         Assert.NotSame(ctx1Before, ctx1After);
-        Assert.NotSame(ctx2Before, ctx2After);
+        Assert.Same(ctx2Before, ctx2After);
+
+        var tenant2Status = runtime.Accessor.GetShell(tenant2);
+        Assert.NotNull(tenant2Status);
+        Assert.True(tenant2Status.IsRoutable);
+        Assert.False(tenant2Status.IsInSync);
+        Assert.Equal(1, tenant2Status.AppliedGeneration);
+        Assert.Equal(["MissingFeature"], tenant2Status.MissingFeatures);
     }
 
     [Fact(DisplayName = "Lifecycle notifications remain in expected sequence around reload notifications")]
@@ -241,20 +259,18 @@ public class ReloadBehaviorTests(DefaultShellHostFixture fixture)
         var shellId = new ShellId("Tenant1");
         var settings = new ShellSettings(shellId, ["Weather"]);
 
-        var cache = fixture.CreateCache([settings]);
-        var host = fixture.CreateHost(cache, typeof(TestFixtures).Assembly);
-        var provider = new InMemoryShellSettingsProvider([settings]);
-        var notifications = new RecordingNotificationPublisher();
-        var manager = new DefaultShellManager(host, host, cache, provider, notifications);
+        var runtime = CreateManagedRuntime([settings], new InMemoryShellSettingsProvider([settings]));
 
         // Build shell initially
-        _ = host.GetShell(shellId);
+        await runtime.Manager.InitializeRuntimeAsync();
+        _ = runtime.Host.GetShell(shellId);
+        runtime.Notifications.Clear();
 
         // Act
-        await manager.ReloadShellAsync(shellId);
+        await runtime.Manager.ReloadShellAsync(shellId);
 
         // Assert - full sequence: ShellReloading → ShellDeactivating → ShellActivated → ShellReloaded
-        var allNotifications = notifications.Notifications.ToList();
+        var allNotifications = runtime.Notifications.Notifications.ToList();
         var reloadingIdx = allNotifications.FindIndex(n => n is ShellReloading);
         var deactivatingIdx = allNotifications.FindIndex(n => n is ShellDeactivating);
         var activatedIdx = allNotifications.FindIndex(n => n is ShellActivated);
@@ -280,6 +296,8 @@ public class ReloadBehaviorTests(DefaultShellHostFixture fixture)
         private readonly List<object> _notifications = [];
         public IReadOnlyList<object> Notifications => _notifications;
 
+        public void Clear() => _notifications.Clear();
+
         public Task PublishAsync<TNotification>(
             TNotification notification,
             INotificationStrategy? strategy = null,
@@ -289,4 +307,46 @@ public class ReloadBehaviorTests(DefaultShellHostFixture fixture)
             return Task.CompletedTask;
         }
     }
+
+    private TestRuntime CreateManagedRuntime(
+        IEnumerable<ShellSettings> initialShells,
+        IShellSettingsProvider provider)
+    {
+        var cache = fixture.CreateCache(initialShells);
+        var notifications = new RecordingNotificationPublisher();
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            fixture.RootProvider,
+            fixture.RootAccessor,
+            fixture.FeatureFactory,
+            new ShellServiceExclusionRegistry([]),
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var accessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(
+            host,
+            cache,
+            provider,
+            stateStore,
+            runtimeCatalog,
+            accessor,
+            notifications,
+            NullLogger<DefaultShellManager>.Instance);
+
+        return new(host, manager, accessor, notifications);
+    }
+
+    private sealed record TestRuntime(
+        Hosting.DefaultShellHost Host,
+        DefaultShellManager Manager,
+        IShellRuntimeStateAccessor Accessor,
+        RecordingNotificationPublisher Notifications);
 }

--- a/tests/CShells.Tests/Integration/DefaultShellHost/ServiceResolutionTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/ServiceResolutionTests.cs
@@ -97,8 +97,8 @@ public class ServiceResolutionTests : IAsyncDisposable
         Assert.NotNull(settingsService);
     }
 
-    [Fact(DisplayName = "GetShell feature constructor with shell dependency throws")]
-    public void GetShell_FeatureConstructorWithShellDependency_Throws()
+    [Fact(DisplayName = "GetShell for a shell whose feature constructor depends on shell services reports no applied runtime")]
+    public void GetShell_FeatureConstructorWithShellDependency_ThrowsKeyNotFound()
     {
         // Arrange - Create a feature whose constructor depends on a shell-level service
         // According to the new design, this is NOT allowed
@@ -109,15 +109,9 @@ public class ServiceResolutionTests : IAsyncDisposable
         };
         var host = CreateHost(settings, [assembly]);
 
-        // Act & Assert - This should throw because IBaseService is not available from root provider
-        var ex = Assert.Throws<InvalidOperationException>(() => host.GetShell(new("TestShell")));
-        Assert.Contains("DependentFeature", ex.Message);
-        
-        // Verify the inner exception is from ActivatorUtilities indicating constructor dependency resolution failure
-        // The inner exception message indicates the service could not be resolved
-        Assert.NotNull(ex.InnerException);
-        Assert.IsType<InvalidOperationException>(ex.InnerException);
-        Assert.Contains("Unable to resolve service", ex.InnerException.Message);
+        // Act & Assert - failed candidate builds no longer become applied runtimes
+        var ex = Assert.Throws<KeyNotFoundException>(() => host.GetShell(new("TestShell")));
+        Assert.Contains("does not have a committed applied runtime", ex.Message);
     }
 
     [Fact(DisplayName = "GetShell returns ShellSettings from service provider")]

--- a/tests/CShells.Tests/Integration/DefaultShellHost/ShellRetrievalTests.cs
+++ b/tests/CShells.Tests/Integration/DefaultShellHost/ShellRetrievalTests.cs
@@ -18,7 +18,7 @@ public class ShellRetrievalTests(DefaultShellHostFixture fixture)
 
         // Act & Assert
         var ex = Assert.Throws<InvalidOperationException>(() => _ = host.DefaultShell);
-        Assert.Contains("No shells have been configured", ex.Message);
+        Assert.Contains("No applied shells are currently available", ex.Message);
     }
 
     [Theory(DisplayName = "DefaultShell resolves expected shell")]
@@ -98,15 +98,14 @@ public class ShellRetrievalTests(DefaultShellHostFixture fixture)
         Assert.Contains(allShells, s => s.Id.Name == "Shell3");
     }
 
-    [Fact(DisplayName = "GetShell with unknown feature throws InvalidOperationException")]
-    public void GetShell_WithUnknownFeature_ThrowsInvalidOperationException()
+    [Fact(DisplayName = "GetShell with an unapplied shell throws KeyNotFoundException")]
+    public void GetShell_WithUnknownFeature_ThrowsKeyNotFoundException()
     {
         // Arrange
         var host = fixture.CreateHost([new(new("TestShell"), ["UnknownFeature"])], typeof(TestFixtures).Assembly);
 
         // Act & Assert
-        var ex = Assert.Throws<InvalidOperationException>(() => host.GetShell(new("TestShell")));
-        Assert.Contains("UnknownFeature", ex.Message);
-        Assert.Contains("not found", ex.Message);
+        var ex = Assert.Throws<KeyNotFoundException>(() => host.GetShell(new("TestShell")));
+        Assert.Contains("does not have a committed applied runtime", ex.Message);
     }
 }

--- a/tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/DefaultShellFallbackIntegrationTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using CShells.Configuration;
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+using CShells.Notifications;
+using CShells.Resolution;
+using CShells.Tests.Integration.ShellHost;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Tests.Integration.ShellHost;
+
+public class DefaultShellFallbackIntegrationTests
+{
+    [Fact(DisplayName = "Explicit Default shell that is configured but unapplied does not silently fall back to another applied shell")]
+    public async Task ExplicitDefault_Unapplied_DoesNotSilentlyFallback()
+    {
+        // Arrange
+        var defaultSettings = new ShellSettings(new ShellId("Default"), ["MissingFeature"]);
+        var otherSettings = new ShellSettings(new ShellId("Contoso"), ["Core"]);
+        var cache = new ShellSettingsCache();
+        cache.Load([defaultSettings, otherSettings]);
+
+        var (services, rootProvider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var notifications = new RecordingNotificationPublisher();
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            rootProvider,
+            accessor,
+            featureFactory,
+            exclusionRegistry,
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var runtimeAccessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(host, cache, new MutableInMemoryShellSettingsProvider([defaultSettings, otherSettings]), stateStore, runtimeCatalog, runtimeAccessor, notifications, NullLogger<DefaultShellManager>.Instance);
+        var resolver = new DefaultShellResolverStrategy(host, runtimeAccessor);
+
+        await manager.InitializeRuntimeAsync();
+
+        // Act
+        var resolved = resolver.Resolve(new ShellResolutionContext());
+
+        // Assert
+        Assert.Null(resolved);
+        Assert.Single(host.AllShells);
+        Assert.Equal(new ShellId("Contoso"), host.AllShells.Single().Id);
+    }
+
+    private sealed class RecordingNotificationPublisher : INotificationPublisher
+    {
+        public Task PublishAsync<TNotification>(
+            TNotification notification,
+            INotificationStrategy? strategy = null,
+            CancellationToken cancellationToken = default) where TNotification : class, INotification => Task.CompletedTask;
+    }
+}
+

--- a/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/FeatureAssemblySelectionIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using CShells.DependencyInjection;
 using CShells.Features;
 using CShells.Hosting;
+using CShells.Management;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,11 +22,11 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         var explicitHostProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
-            CShellsBuilderExtensions.FromHostAssemblies(builder);
+            DependencyInjection.CShellsBuilderExtensions.FromHostAssemblies(builder);
         });
 
-        var defaultShell = GetShell(defaultProvider, new("Default"));
-        var explicitHostShell = GetShell(explicitHostProvider, new("Default"));
+        var defaultShell = GetShell(defaultProvider, new ShellId("Default"));
+        var explicitHostShell = GetShell(explicitHostProvider, new ShellId("Default"));
         var defaultFeatures = defaultShell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
         var explicitHostFeatures = explicitHostShell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
 
@@ -40,13 +41,13 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         var serviceProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
-            CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
+            DependencyInjection.CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
         });
 
         var shellHost = serviceProvider.GetRequiredService<IShellHost>();
-        var exception = Assert.Throws<InvalidOperationException>(() => shellHost.GetShell(new("Default")));
+        var exception = Assert.Throws<KeyNotFoundException>(() => shellHost.GetShell(new ShellId("Default")));
 
-        Assert.Contains("Weather", exception.Message);
+        Assert.Contains("does not have a committed applied runtime", exception.Message);
     }
 
     [Fact]
@@ -58,8 +59,8 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
             builder =>
             {
                 builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
-                CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
-                CShellsBuilderExtensions.WithAssemblyProvider(builder, sp =>
+                DependencyInjection.CShellsBuilderExtensions.FromAssemblies(builder, typeof(CShellsBuilder).Assembly);
+                DependencyInjection.CShellsBuilderExtensions.WithAssemblyProvider(builder, sp =>
                 {
                     var resolvedMarker = sp.GetRequiredService<RootMarkerService>();
                     return new TrackingFeatureAssemblyProvider([typeof(TestFixtures).Assembly], resolvedMarker);
@@ -67,7 +68,7 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
             },
             services => services.AddSingleton(marker));
 
-        var shell = GetShell(serviceProvider, new("Default"));
+        var shell = GetShell(serviceProvider, new ShellId("Default"));
         var features = shell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
 
         Assert.Contains(TrackingFeatureAssemblyProvider.CreatedProviders, provider => ReferenceEquals(provider.ResolvedMarker, marker));
@@ -82,11 +83,11 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         var serviceProvider = await BuildRootProviderAsync(builder =>
         {
             builder.AddShell("Default", shell => shell.WithFeatures("Weather"));
-            CShellsBuilderExtensions.FromAssemblies(builder, typeof(TestFixtures).Assembly);
-            CShellsBuilderExtensions.WithAssemblyProvider(builder, new TrackingFeatureAssemblyProvider([typeof(TestFixtures).Assembly]));
+            DependencyInjection.CShellsBuilderExtensions.FromAssemblies(builder, typeof(TestFixtures).Assembly);
+            DependencyInjection.CShellsBuilderExtensions.WithAssemblyProvider(builder, new TrackingFeatureAssemblyProvider([typeof(TestFixtures).Assembly]));
         });
 
-        var shell = GetShell(serviceProvider, new("Default"));
+        var shell = GetShell(serviceProvider, new ShellId("Default"));
         var features = shell.ServiceProvider.GetRequiredService<IReadOnlyCollection<ShellFeatureDescriptor>>();
 
         Assert.Contains(features, feature => feature.Id == "Core");
@@ -106,7 +107,7 @@ public class FeatureAssemblySelectionIntegrationTests : IAsyncDisposable
         var shellSettingsProvider = serviceProvider.GetRequiredService<CShells.Configuration.IShellSettingsProvider>();
         var shellSettingsCache = serviceProvider.GetRequiredService<CShells.Configuration.ShellSettingsCache>();
         shellSettingsCache.Load((await shellSettingsProvider.GetShellSettingsAsync()).ToList());
-        await serviceProvider.GetRequiredService<CShells.Hosting.DefaultShellHost>().InitializeAsync();
+        await serviceProvider.GetRequiredService<DefaultShellManager>().InitializeRuntimeAsync();
         _disposables.Add(serviceProvider);
         return serviceProvider;
     }

--- a/tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs
+++ b/tests/CShells.Tests/Integration/ShellHost/ShellRuntimeStatusIntegrationTests.cs
@@ -1,0 +1,149 @@
+using System.Reflection;
+using CShells.Configuration;
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+using CShells.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Tests.Integration.ShellHost;
+
+public class ShellRuntimeStatusIntegrationTests
+{
+    [Fact(DisplayName = "Runtime status exposes mixed desired and applied shell states after reconciliation")]
+    public async Task RuntimeStatus_ExposesMixedDesiredAndAppliedStates()
+    {
+        // Arrange
+        var defaultSettings = new ShellSettings(new ShellId("Default"), ["Core"]);
+        var deferredSettings = new ShellSettings(new ShellId("Deferred"), ["MissingFeature"]);
+        var cache = new ShellSettingsCache();
+        cache.Load([defaultSettings, deferredSettings]);
+
+        var (services, rootProvider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var notifications = new RecordingNotificationPublisher();
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            rootProvider,
+            accessor,
+            featureFactory,
+            exclusionRegistry,
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var runtimeAccessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(host, cache, new MutableInMemoryShellSettingsProvider([defaultSettings, deferredSettings]), stateStore, runtimeCatalog, runtimeAccessor, notifications, NullLogger<DefaultShellManager>.Instance);
+
+        // Act
+        await manager.InitializeRuntimeAsync();
+        var statuses = runtimeAccessor.GetAllShells().OrderBy(status => status.ShellId.Name, StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Assert
+        Assert.Collection(
+            statuses,
+            status =>
+            {
+                Assert.Equal(new ShellId("Default"), status.ShellId);
+                Assert.Equal(ShellReconciliationOutcome.Active, status.Outcome);
+                Assert.True(status.IsInSync);
+                Assert.True(status.IsRoutable);
+                Assert.Equal(1, status.AppliedGeneration);
+            },
+            status =>
+            {
+                Assert.Equal(new ShellId("Deferred"), status.ShellId);
+                Assert.Equal(ShellReconciliationOutcome.DeferredDueToMissingFeatures, status.Outcome);
+                Assert.False(status.IsInSync);
+                Assert.False(status.IsRoutable);
+                Assert.Null(status.AppliedGeneration);
+                Assert.Contains("MissingFeature", status.BlockingReason);
+                Assert.Contains("MissingFeature", status.MissingFeatures);
+            });
+    }
+
+    [Fact(DisplayName = "Runtime status keeps an explicit Default shell visible as unapplied without falling back to another applied shell")]
+    public async Task RuntimeStatus_ExplicitDefaultUnapplied_RemainsVisibleAndUnavailable()
+    {
+        // Arrange
+        var defaultSettings = new ShellSettings(new ShellId("Default"), ["MissingFeature"]);
+        var contosoSettings = new ShellSettings(new ShellId("Contoso"), ["Core"]);
+        var runtime = CreateRuntime([defaultSettings, contosoSettings]);
+
+        // Act
+        await runtime.Manager.InitializeRuntimeAsync();
+        var defaultStatus = runtime.Accessor.GetShell(new ShellId("Default"));
+        var contosoStatus = runtime.Accessor.GetShell(new ShellId("Contoso"));
+
+        // Assert
+        Assert.NotNull(defaultStatus);
+        Assert.Equal(ShellReconciliationOutcome.DeferredDueToMissingFeatures, defaultStatus!.Outcome);
+        Assert.False(defaultStatus.IsRoutable);
+        Assert.False(defaultStatus.IsInSync);
+        Assert.Null(defaultStatus.AppliedGeneration);
+        Assert.Equal(["MissingFeature"], defaultStatus.MissingFeatures);
+
+        Assert.NotNull(contosoStatus);
+        Assert.True(contosoStatus!.IsRoutable);
+        Assert.True(contosoStatus.IsInSync);
+        Assert.Equal(1, contosoStatus.AppliedGeneration);
+
+        Assert.Throws<KeyNotFoundException>(() => runtime.Host.DefaultShell);
+        Assert.Equal(new ShellId("Contoso"), Assert.Single(runtime.Host.AllShells).Id);
+    }
+
+    private static TestRuntime CreateRuntime(IEnumerable<ShellSettings> settings)
+    {
+        var cache = new ShellSettingsCache();
+        var shells = settings.ToList();
+        cache.Load(shells);
+
+        var (services, rootProvider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var notifications = new RecordingNotificationPublisher();
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new Hosting.DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            rootProvider,
+            accessor,
+            featureFactory,
+            exclusionRegistry,
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<Hosting.DefaultShellHost>.Instance);
+        var runtimeAccessor = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(host, cache, new MutableInMemoryShellSettingsProvider(shells), stateStore, runtimeCatalog, runtimeAccessor, notifications, NullLogger<DefaultShellManager>.Instance);
+
+        return new(host, manager, runtimeAccessor);
+    }
+
+    private sealed class RecordingNotificationPublisher : INotificationPublisher
+    {
+        public Task PublishAsync<TNotification>(
+            TNotification notification,
+            INotificationStrategy? strategy = null,
+            CancellationToken cancellationToken = default) where TNotification : class, INotification => Task.CompletedTask;
+    }
+
+    private sealed record TestRuntime(
+        Hosting.DefaultShellHost Host,
+        DefaultShellManager Manager,
+        IShellRuntimeStateAccessor Accessor);
+}
+

--- a/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs
+++ b/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Tests.Unit.Features;
+
+public class RuntimeFeatureCatalogTests
+{
+    [Fact(DisplayName = "RefreshAsync re-evaluates providers on each reconciliation pass")]
+    public async Task RefreshAsync_ReevaluatesAssemblySourcesEveryTime()
+    {
+        // Arrange
+        var refreshCalls = 0;
+        var uniqueAssembly = CreateDynamicFeatureAssembly("RuntimeFeatureCatalogUnique", "UniqueFeature", "Unique");
+        var catalog = new RuntimeFeatureCatalog(
+            _ =>
+            {
+                refreshCalls++;
+                return Task.FromResult<IReadOnlyCollection<Assembly>>([uniqueAssembly]);
+            },
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+
+        // Act
+        var first = await catalog.RefreshAsync();
+        var second = await catalog.RefreshAsync();
+
+        // Assert
+        Assert.Equal(2, refreshCalls);
+        Assert.NotEqual(first.Generation, second.Generation);
+        Assert.True(second.Generation > first.Generation);
+        Assert.Contains(second.FeatureDescriptors, descriptor => descriptor.Id == "Unique");
+    }
+
+    [Fact(DisplayName = "RefreshAsync preserves the last committed catalog when duplicate feature IDs are discovered")]
+    public async Task RefreshAsync_DuplicateFeatureIds_DoesNotReplaceCommittedSnapshot()
+    {
+        // Arrange
+        var uniqueAssembly = CreateDynamicFeatureAssembly("RuntimeFeatureCatalogUniqueCommitted", "CommittedUniqueFeature", "Unique");
+        var duplicateAssemblyOne = CreateDynamicFeatureAssembly("RuntimeFeatureCatalogDuplicateOne", "DuplicateFeatureOne", "Duplicate");
+        var duplicateAssemblyTwo = CreateDynamicFeatureAssembly("RuntimeFeatureCatalogDuplicateTwo", "DuplicateFeatureTwo", "Duplicate");
+        var useDuplicateAssemblies = false;
+        var catalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>(
+                useDuplicateAssemblies
+                    ? [duplicateAssemblyOne, duplicateAssemblyTwo]
+                    : [uniqueAssembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+
+        var committed = await catalog.RefreshAsync();
+        useDuplicateAssemblies = true;
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => catalog.RefreshAsync());
+
+        // Assert
+        Assert.Contains("Duplicate feature name 'Duplicate'", exception.Message);
+        Assert.Same(committed, catalog.CurrentSnapshot);
+        Assert.Contains(catalog.CurrentSnapshot.FeatureDescriptors, descriptor => descriptor.Id == "Unique");
+    }
+
+    private static Assembly CreateDynamicFeatureAssembly(string assemblyName, string typeName, string featureName)
+    {
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName), AssemblyBuilderAccess.Run);
+        var module = dynamicAssembly.DefineDynamicModule(assemblyName);
+        var type = module.DefineType(typeName, TypeAttributes.Public | TypeAttributes.Class);
+        type.AddInterfaceImplementation(typeof(IShellFeature));
+
+        var attributeConstructor = typeof(ShellFeatureAttribute).GetConstructor([typeof(string)])
+            ?? throw new InvalidOperationException("ShellFeatureAttribute(string) constructor was not found.");
+        type.SetCustomAttribute(new CustomAttributeBuilder(attributeConstructor, [featureName]));
+        type.DefineDefaultConstructor(MethodAttributes.Public);
+
+        var configureServices = type.DefineMethod(
+            nameof(IShellFeature.ConfigureServices),
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(void),
+            [typeof(IServiceCollection)]);
+        configureServices.GetILGenerator().Emit(OpCodes.Ret);
+        type.DefineMethodOverride(configureServices, typeof(IShellFeature).GetMethod(nameof(IShellFeature.ConfigureServices))!);
+
+        _ = type.CreateType();
+        return dynamicAssembly;
+    }
+}

--- a/tests/CShells.Tests/Unit/Hosting/ShellStartupHostedServiceTests.cs
+++ b/tests/CShells.Tests/Unit/Hosting/ShellStartupHostedServiceTests.cs
@@ -1,6 +1,11 @@
+using CShells.Configuration;
+using CShells.DependencyInjection;
 using CShells.Hosting;
 using CShells.Notifications;
+using CShells.Tests.Integration.ShellHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CShells.Tests.Unit.Hosting;
@@ -10,36 +15,35 @@ namespace CShells.Tests.Unit.Hosting;
 /// </summary>
 public class ShellStartupHostedServiceTests
 {
-    [Fact(DisplayName = "StartAsync activates each shell once and then publishes ShellsReloaded")]
-    public async Task StartAsync_ActivatesShells_ThenPublishesShellsReloaded()
+    [Fact(DisplayName = "StartAsync reconciles configured shells and publishes runtime status")]
+    public async Task StartAsync_ReconcilesShells_ThenPublishesShellStatuses()
     {
         // Arrange
-        var defaultShell = CreateShellContext(new ShellSettings(new("Default"), ["Core"]));
-        var contosoShell = CreateShellContext(new ShellSettings(new("Contoso"), ["Posts"]));
-        var shellHost = new StubShellHost([defaultShell, contosoShell]);
         var notifications = new RecordingNotificationPublisher();
-        var hostedService = new ShellStartupHostedService(
-            shellHost,
-            shellHost,
+        await using var provider = CreateServiceProvider(
             notifications,
-            NullLogger<ShellStartupHostedService>.Instance);
+            new ShellSettings(new("Default"), ["Core"]),
+            new ShellSettings(new("Contoso"), ["Weather"]));
+        var hostedService = GetStartupHostedService(provider);
 
         // Act
         await hostedService.StartAsync(CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, shellHost.EnsureInitializedCalls);
+        var shellsReloaded = Assert.Single(notifications.Notifications.OfType<ShellsReloaded>());
         Assert.Collection(
-            notifications.Notifications,
-            notification => Assert.Equal(defaultShell, Assert.IsType<ShellActivated>(notification).Context),
-            notification => Assert.Equal(contosoShell, Assert.IsType<ShellActivated>(notification).Context),
-            notification =>
+            shellsReloaded.Statuses.OrderBy(status => status.ShellId.Name, StringComparer.OrdinalIgnoreCase),
+            status =>
             {
-                var shellsReloaded = Assert.IsType<ShellsReloaded>(notification);
-                Assert.Collection(
-                    shellsReloaded.AllShells,
-                    shell => Assert.Equal(defaultShell.Settings.Id, shell.Id),
-                    shell => Assert.Equal(contosoShell.Settings.Id, shell.Id));
+                Assert.Equal(new ShellId("Contoso"), status.ShellId);
+                Assert.True(status.IsRoutable);
+                Assert.True(status.IsInSync);
+            },
+            status =>
+            {
+                Assert.Equal(new ShellId("Default"), status.ShellId);
+                Assert.True(status.IsRoutable);
+                Assert.True(status.IsInSync);
             });
     }
 
@@ -47,22 +51,15 @@ public class ShellStartupHostedServiceTests
     public async Task StartAsync_WhenCalledMultipleTimes_PublishesStartupNotificationsOnce()
     {
         // Arrange
-        var defaultShell = CreateShellContext(new ShellSettings(new("Default"), ["Core"]));
-        var shellHost = new StubShellHost([defaultShell]);
         var notifications = new RecordingNotificationPublisher();
-        var hostedService = new ShellStartupHostedService(
-            shellHost,
-            shellHost,
-            notifications,
-            NullLogger<ShellStartupHostedService>.Instance);
+        await using var provider = CreateServiceProvider(notifications, new ShellSettings(new("Default"), ["Core"]));
+        var hostedService = GetStartupHostedService(provider);
 
         // Act
         await hostedService.StartAsync(CancellationToken.None);
         await hostedService.StartAsync(CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, shellHost.EnsureInitializedCalls);
-        Assert.Single(notifications.Notifications.OfType<ShellActivated>());
         Assert.Single(notifications.Notifications.OfType<ShellsReloaded>());
     }
 
@@ -70,15 +67,14 @@ public class ShellStartupHostedServiceTests
     public async Task StopAsync_WhenCalledMultipleTimes_PublishesDeactivationOncePerShell()
     {
         // Arrange
-        var defaultShell = CreateShellContext(new ShellSettings(new("Default"), ["Core"]));
-        var contosoShell = CreateShellContext(new ShellSettings(new("Contoso"), ["Posts"]));
-        var shellHost = new StubShellHost([defaultShell, contosoShell]);
         var notifications = new RecordingNotificationPublisher();
-        var hostedService = new ShellStartupHostedService(
-            shellHost,
-            shellHost,
+        await using var provider = CreateServiceProvider(
             notifications,
-            NullLogger<ShellStartupHostedService>.Instance);
+            new ShellSettings(new("Default"), ["Core"]),
+            new ShellSettings(new("Contoso"), ["Weather"]));
+        var hostedService = GetStartupHostedService(provider);
+        await hostedService.StartAsync(CancellationToken.None);
+        notifications.Notifications.Clear();
 
         // Act
         await hostedService.StopAsync(CancellationToken.None);
@@ -87,36 +83,30 @@ public class ShellStartupHostedServiceTests
         // Assert
         var deactivating = notifications.Notifications.OfType<ShellDeactivating>().ToList();
         Assert.Equal(2, deactivating.Count);
-        Assert.Equal(defaultShell, deactivating[0].Context);
-        Assert.Equal(contosoShell, deactivating[1].Context);
+        Assert.Contains(deactivating, notification => notification.Context.Id.Equals(new ShellId("Default")));
+        Assert.Contains(deactivating, notification => notification.Context.Id.Equals(new ShellId("Contoso")));
     }
 
-    private static ShellContext CreateShellContext(ShellSettings settings) =>
-        new(settings, new ServiceCollection().BuildServiceProvider(), settings.EnabledFeatures.ToList().AsReadOnly());
+    private static ShellStartupHostedService GetStartupHostedService(IServiceProvider provider) =>
+        provider.GetServices<IHostedService>().OfType<ShellStartupHostedService>().Single();
 
-    private sealed class StubShellHost(IReadOnlyCollection<ShellContext> shells) : IShellHost, IShellHostInitializer
+    private static ServiceProvider CreateServiceProvider(
+        RecordingNotificationPublisher notifications,
+        params ShellSettings[] shells)
     {
-        private IReadOnlyCollection<ShellContext> Shells { get; } = shells;
+        var services = new ServiceCollection();
+        services.AddSingleton<INotificationPublisher>(notifications);
+        services.AddLogging();
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShells(builder => builder
+            .FromAssemblies(typeof(TestFixtures).Assembly)
+            .WithProvider(new InMemoryShellSettingsProvider(shells)));
+        var provider = services.BuildServiceProvider();
+        var shellSettingsProvider = provider.GetRequiredService<IShellSettingsProvider>();
+        var shellSettingsCache = provider.GetRequiredService<ShellSettingsCache>();
+        shellSettingsCache.Load(shellSettingsProvider.GetShellSettingsAsync().GetAwaiter().GetResult().ToList());
 
-        public int EnsureInitializedCalls { get; private set; }
-
-        public ShellContext DefaultShell => Shells.First();
-
-        public IReadOnlyCollection<ShellContext> AllShells => Shells;
-
-        public ShellContext GetShell(ShellId id) =>
-            Shells.FirstOrDefault(shell => shell.Id.Equals(id))
-            ?? throw new KeyNotFoundException($"Shell '{id}' not found.");
-
-        public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
-        {
-            EnsureInitializedCalls++;
-            return Task.CompletedTask;
-        }
-
-        public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
-
-        public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
+        return provider;
     }
 
     private sealed class RecordingNotificationPublisher : INotificationPublisher
@@ -133,4 +123,3 @@ public class ShellStartupHostedServiceTests
         }
     }
 }
-

--- a/tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs
+++ b/tests/CShells.Tests/Unit/Management/DefaultShellManagerReloadTests.cs
@@ -1,876 +1,157 @@
+using System.Reflection;
 using CShells.Configuration;
+using CShells.Features;
 using CShells.Hosting;
 using CShells.Management;
 using CShells.Notifications;
+using CShells.Tests.Integration.ShellHost;
+using CShells.Tests.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CShells.Tests.Unit.Management;
 
-/// <summary>
-/// Unit tests for <see cref="DefaultShellManager"/> reload semantics.
-/// Tests use stub collaborators to verify manager behavior in isolation.
-/// </summary>
 public class DefaultShellManagerReloadTests
 {
-    #region US1 - Strict Targeted Reload
-
-    [Fact(DisplayName = "ReloadShellAsync refreshes active shell from provider")]
-    public async Task ReloadShellAsync_ActiveShell_RefreshesFromProvider()
+    [Fact(DisplayName = "ReloadShellAsync preserves last-known-good applied runtime when the new desired shell is deferred")]
+    public async Task ReloadShellAsync_DeferredDesiredGeneration_PreservesAppliedRuntime()
     {
         // Arrange
-        var shellId = new ShellId("Tenant1");
-        var originalSettings = CreateShell("Tenant1", ["FeatureA"]);
-        var updatedSettings = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, updatedSettings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([originalSettings]);
-
+        var shellId = new ShellId("Contoso");
+        var initialSettings = new ShellSettings(shellId, ["Core"]);
+        var deferredSettings = new ShellSettings(shellId, ["Core", "MissingFeature"]);
+        var provider = new MutableInMemoryShellSettingsProvider([deferredSettings]);
         var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
+        var runtime = CreateRuntime([initialSettings], provider, notifications);
+
+        await runtime.Manager.InitializeRuntimeAsync();
+        notifications.Notifications.Clear();
 
         // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert - cache should contain the updated settings
-        var cached = cache.GetById(shellId);
-        Assert.NotNull(cached);
-        Assert.Contains("FeatureB", cached.EnabledFeatures);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync with missing provider result throws and preserves state")]
-    public async Task ReloadShellAsync_MissingFromProvider_ThrowsAndPreservesState()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var originalSettings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider(); // returns null for any lookup
-        var cache = new ShellSettingsCache();
-        cache.Load([originalSettings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act & Assert - should throw InvalidOperationException
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            manager.ReloadShellAsync(shellId));
-
-        // State should be preserved - original shell still in cache
-        var cached = cache.GetById(shellId);
-        Assert.NotNull(cached);
-        Assert.Equal(["FeatureA"], cached.EnabledFeatures);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync does not affect unrelated shells in cache")]
-    public async Task ReloadShellAsync_DoesNotAffectUnrelatedShells()
-    {
-        // Arrange
-        var target = new ShellId("Tenant1");
-        var other = new ShellId("Tenant2");
-        var tenant1Settings = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2Settings = CreateShell("Tenant2", ["FeatureX"]);
-        var updatedTenant1 = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(target, updatedTenant1);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1Settings, tenant2Settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(target);
-
-        // Assert - Tenant2 should remain unchanged
-        var cachedTenant2 = cache.GetById(other);
-        Assert.NotNull(cachedTenant2);
-        Assert.Equal(["FeatureX"], cachedTenant2.EnabledFeatures);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync with new shell not yet in cache adds it")]
-    public async Task ReloadShellAsync_NewShell_AddsToCache()
-    {
-        // Arrange
-        var shellId = new ShellId("NewTenant");
-        var newSettings = CreateShell("NewTenant", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, newSettings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([]); // empty cache
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert - new shell should be in the cache
-        var cached = cache.GetById(shellId);
-        Assert.NotNull(cached);
-        Assert.Equal(["FeatureA"], cached.EnabledFeatures);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync with missing provider does not modify cache")]
-    public async Task ReloadShellAsync_MissingFromProvider_DoesNotModifyCache()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var otherShellId = new ShellId("Tenant2");
-        var tenant1Settings = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2Settings = CreateShell("Tenant2", ["FeatureX"]);
-
-        var provider = new StubShellSettingsProvider(); // returns null for any lookup
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1Settings, tenant2Settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act - ignore the expected exception
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            manager.ReloadShellAsync(shellId));
-
-        // Assert - both shells should remain in cache
-        Assert.NotNull(cache.GetById(shellId));
-        Assert.NotNull(cache.GetById(otherShellId));
-        Assert.Equal(2, cache.GetAll().Count);
-    }
-
-    #endregion
-
-    #region US2 - Full Reload Reconciliation
-
-    [Fact(DisplayName = "ReloadAllShellsAsync reconciles added shells")]
-    public async Task ReloadAllShellsAsync_Reconciles_AddedShells()
-    {
-        // Arrange
-        var existing = CreateShell("Tenant1", ["FeatureA"]);
-        var newShell = CreateShell("NewTenant", ["FeatureX"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), existing);
-        provider.SetShell(new("NewTenant"), newShell);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([existing]); // only Tenant1 initially
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - NewTenant should now be in the cache
-        Assert.NotNull(cache.GetById(new("NewTenant")));
-        Assert.Equal(2, cache.GetAll().Count);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync reconciles removed shells")]
-    public async Task ReloadAllShellsAsync_Reconciles_RemovedShells()
-    {
-        // Arrange
-        var tenant1 = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2 = CreateShell("Tenant2", ["FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), tenant1); // only Tenant1 in provider
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1, tenant2]); // both in cache
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - Tenant2 should no longer be in the cache
-        Assert.Null(cache.GetById(new("Tenant2")));
-        Assert.Single(cache.GetAll());
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync reconciles updated shell settings")]
-    public async Task ReloadAllShellsAsync_Reconciles_UpdatedShells()
-    {
-        // Arrange
-        var original = CreateShell("Tenant1", ["FeatureA"]);
-        var updated = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), updated);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([original]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - cache should have the updated settings
-        var cached = cache.GetById(new("Tenant1"));
-        Assert.NotNull(cached);
-        Assert.Contains("FeatureB", cached.EnabledFeatures);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync publishes ShellsReloaded notification")]
-    public async Task ReloadAllShellsAsync_PublishesShellsReloadedNotification()
-    {
-        // Arrange
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - ShellsReloaded should have been published
-        Assert.Contains(notifications.Notifications, n => n is ShellsReloaded);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync ensures shell host initialization before enumerating shells")]
-    public async Task ReloadAllShellsAsync_EnsuresShellHostInitialized()
-    {
-        // Arrange
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var host = new StubShellHost(cache);
-        var manager = new DefaultShellManager(host, host, cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
+        await runtime.Manager.ReloadShellAsync(shellId);
 
         // Assert
-        Assert.Equal(1, host.InitializeCalls);
+        var appliedContext = runtime.Host.GetShell(shellId);
+        Assert.Equal(["Core"], appliedContext.Settings.EnabledFeatures);
+
+        var status = runtime.Accessor.GetShell(shellId);
+        Assert.NotNull(status);
+        Assert.Equal(2, status!.DesiredGeneration);
+        Assert.Equal(1, status.AppliedGeneration);
+        Assert.Equal(ShellReconciliationOutcome.Active, status.Outcome);
+        Assert.False(status.IsInSync);
+        Assert.True(status.IsRoutable);
+        Assert.Contains("MissingFeature", status.BlockingReason);
+        Assert.Equal(["MissingFeature"], status.MissingFeatures);
+
+        Assert.DoesNotContain(notifications.Notifications, notification => notification is ShellActivated);
+        Assert.DoesNotContain(notifications.Notifications, notification => notification is ShellDeactivating);
+        Assert.Contains(notifications.Notifications, notification => notification is ShellReloaded reloaded && reloaded.ShellId == shellId);
     }
 
-    #endregion
-
-    #region US3 - Reload Notification Ordering and Scope
-
-    [Fact(DisplayName = "ReloadShellAsync emits ShellReloading before ShellReloaded")]
-    public async Task ReloadShellAsync_EmitsShellReloading_BeforeShellReloaded()
+    [Fact(DisplayName = "ReloadShellAsync with missing provider result throws and preserves the applied runtime")]
+    public async Task ReloadShellAsync_MissingProviderResult_ThrowsAndPreservesAppliedRuntime()
     {
         // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
+        var shellId = new ShellId("Contoso");
+        var initialSettings = new ShellSettings(shellId, ["Core"]);
+        var provider = new MutableInMemoryShellSettingsProvider();
         var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
+        var runtime = CreateRuntime([initialSettings], provider, notifications);
 
-        // Act
-        await manager.ReloadShellAsync(shellId);
+        await runtime.Manager.InitializeRuntimeAsync();
+        var originalContext = runtime.Host.GetShell(shellId);
+        notifications.Notifications.Clear();
 
-        // Assert - ShellReloading should come first, ShellReloaded last
-        var reloading = notifications.Notifications.OfType<ShellReloading>().ToList();
-        var reloaded = notifications.Notifications.OfType<ShellReloaded>().ToList();
-        Assert.Single(reloading);
-        Assert.Single(reloaded);
-        Assert.Equal(shellId, reloading[0].ShellId);
-        Assert.Equal(shellId, reloaded[0].ShellId);
-
-        var allNotifications = notifications.Notifications.ToList();
-        var reloadingIndex = allNotifications.IndexOf(reloading[0]);
-        var reloadedIndex = allNotifications.IndexOf(reloaded[0]);
-        Assert.True(reloadingIndex < reloadedIndex, "ShellReloading must be emitted before ShellReloaded");
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => runtime.Manager.ReloadShellAsync(shellId));
+        var preservedContext = runtime.Host.GetShell(shellId);
+        Assert.Same(originalContext, preservedContext);
+        Assert.DoesNotContain(notifications.Notifications, notification => notification is ShellReloaded);
     }
 
-    [Fact(DisplayName = "ReloadShellAsync failure does not emit ShellReloaded")]
-    public async Task ReloadShellAsync_Failure_DoesNotEmitShellReloaded()
+    [Fact(DisplayName = "ReloadAllShellsAsync commits a ready successor and publishes applied-runtime lifecycle notifications")]
+    public async Task ReloadAllShellsAsync_ReadyCandidate_CommitsAndPublishesLifecycleNotifications()
     {
         // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider(); // returns null
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
+        var shellId = new ShellId("Contoso");
+        var initialSettings = new ShellSettings(shellId, ["Core"]);
+        var updatedSettings = new ShellSettings(shellId, ["Weather"]);
+        var provider = new MutableInMemoryShellSettingsProvider([updatedSettings]);
         var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
+        var runtime = CreateRuntime([initialSettings], provider, notifications);
+
+        await runtime.Manager.InitializeRuntimeAsync();
+        var previousContext = runtime.Host.GetShell(shellId);
+        notifications.Notifications.Clear();
 
         // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            manager.ReloadShellAsync(shellId));
-
-        // Assert - ShellReloading may be emitted, but ShellReloaded must NOT be
-        Assert.DoesNotContain(notifications.Notifications, n => n is ShellReloaded);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync ShellReloaded contains the reloaded shell in ChangedShells")]
-    public async Task ReloadShellAsync_ShellReloaded_ContainsChangedShell()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
+        await runtime.Manager.ReloadAllShellsAsync();
 
         // Assert
-        var reloaded = notifications.Notifications.OfType<ShellReloaded>().Single();
-        Assert.Contains(shellId, reloaded.ChangedShells);
+        var currentContext = runtime.Host.GetShell(shellId);
+        Assert.NotSame(previousContext, currentContext);
+        Assert.Contains("Weather", currentContext.EnabledFeatures);
+
+        Assert.Contains(notifications.Notifications, notification => notification is ShellDeactivating deactivating && deactivating.Context.Id == shellId);
+        Assert.Contains(notifications.Notifications, notification => notification is ShellActivated activated && activated.Context.Id == shellId);
+
+        var aggregateReload = Assert.Single(notifications.Notifications.OfType<ShellReloaded>(), notification => notification.ShellId is null);
+        Assert.Contains(shellId, aggregateReload.ChangedShells);
+        Assert.Contains(aggregateReload.Statuses, status => status.ShellId == shellId && status.IsInSync && status.IsRoutable);
     }
 
-    [Fact(DisplayName = "ReloadAllShellsAsync emits aggregate ShellReloading and ShellReloaded")]
-    public async Task ReloadAllShellsAsync_EmitsAggregateNotifications()
-    {
-        // Arrange - use different settings instances so structural comparison detects a change
-        var original = CreateShell("Tenant1", ["FeatureA"]);
-        var updated = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), updated);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([original]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - aggregate notifications should have null ShellId
-        var reloading = notifications.Notifications.OfType<ShellReloading>().Where(n => n.ShellId is null).ToList();
-        var reloaded = notifications.Notifications.OfType<ShellReloaded>().Where(n => n.ShellId is null).ToList();
-        Assert.Single(reloading);
-        Assert.Single(reloaded);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync emits ShellsReloaded before aggregate ShellReloaded")]
-    public async Task ReloadAllShellsAsync_ShellsReloaded_BeforeAggregateShellReloaded()
-    {
-        // Arrange
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - ShellsReloaded should come before the aggregate ShellReloaded
-        var shellsReloaded = notifications.Notifications.OfType<ShellsReloaded>().Single();
-        var aggregateReloaded = notifications.Notifications.OfType<ShellReloaded>().Single(n => n.ShellId is null);
-
-        var allNotifications = notifications.Notifications.ToList();
-        var shellsReloadedIndex = allNotifications.IndexOf(shellsReloaded);
-        var aggregateReloadedIndex = allNotifications.IndexOf(aggregateReloaded);
-        Assert.True(shellsReloadedIndex < aggregateReloadedIndex,
-            "ShellsReloaded must be emitted before the aggregate ShellReloaded");
-    }
-
-    [Fact(DisplayName = "Existing lifecycle notifications are published during reload")]
-    public async Task ReloadShellAsync_PublishesLifecycleNotifications()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert - reload emits lifecycle notifications alongside reload-specific ones
-        var reloadNotifications = notifications.Notifications
-            .Where(n => n is ShellReloading or ShellReloaded)
-            .ToList();
-        Assert.Equal(2, reloadNotifications.Count); // exactly one ShellReloading + one ShellReloaded
-
-        var lifecycleNotifications = notifications.Notifications
-            .Where(n => n is ShellDeactivating or ShellActivated)
-            .ToList();
-        Assert.Equal(2, lifecycleNotifications.Count); // exactly one ShellDeactivating + one ShellActivated
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync emits per-shell notifications for changed shells")]
-    public async Task ReloadAllShellsAsync_EmitsPerShellNotifications()
-    {
-        // Arrange
-        var tenant1Original = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant1Updated = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-        var newTenant = CreateShell("NewTenant", ["FeatureX"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), tenant1Updated);
-        provider.SetShell(new("NewTenant"), newTenant);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1Original]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - per-shell notifications for each changed shell
-        var perShellReloading = notifications.Notifications.OfType<ShellReloading>()
-            .Where(n => n.ShellId is not null).ToList();
-        var perShellReloaded = notifications.Notifications.OfType<ShellReloaded>()
-            .Where(n => n.ShellId is not null).ToList();
-
-        Assert.Equal(2, perShellReloading.Count); // Tenant1 (updated) + NewTenant (added)
-        Assert.Equal(2, perShellReloaded.Count);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync per-shell notifications ordered before ShellsReloaded")]
-    public async Task ReloadAllShellsAsync_PerShellNotifications_BeforeShellsReloaded()
-    {
-        // Arrange
-        var original = CreateShell("Tenant1", ["FeatureA"]);
-        var updated = CreateShell("Tenant1", ["FeatureA", "FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), updated);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([original]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - ordering: per-shell ShellReloaded before ShellsReloaded before aggregate ShellReloaded
-        var all = notifications.Notifications.ToList();
-        var perShellReloaded = all.OfType<ShellReloaded>().First(n => n.ShellId is not null);
-        var shellsReloaded = all.OfType<ShellsReloaded>().Single();
-        var aggregateReloaded = all.OfType<ShellReloaded>().Single(n => n.ShellId is null);
-
-        Assert.True(all.IndexOf(perShellReloaded) < all.IndexOf(shellsReloaded),
-            "Per-shell ShellReloaded must be emitted before ShellsReloaded");
-        Assert.True(all.IndexOf(shellsReloaded) < all.IndexOf(aggregateReloaded),
-            "ShellsReloaded must be emitted before the aggregate ShellReloaded");
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync does not report unchanged shells in ChangedShells")]
-    public async Task ReloadAllShellsAsync_UnchangedShells_NotInChangedShells()
-    {
-        // Arrange - use the same settings instance for unchanged shell
-        var unchanged = CreateShell("Tenant1", ["FeatureA"]);
-        var updated = CreateShell("Tenant2", ["FeatureB", "FeatureC"]);
-
-        var provider = new StubShellSettingsProvider();
-        // Provider returns structurally identical settings for Tenant1
-        provider.SetShell(new("Tenant1"), CreateShell("Tenant1", ["FeatureA"]));
-        provider.SetShell(new("Tenant2"), updated);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([unchanged, CreateShell("Tenant2", ["FeatureB"])]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - only Tenant2 should be in changed shells (Tenant1 is structurally identical)
-        var aggregateReloaded = notifications.Notifications.OfType<ShellReloaded>().Single(n => n.ShellId is null);
-        Assert.DoesNotContain(new ShellId("Tenant1"), aggregateReloaded.ChangedShells);
-        Assert.Contains(new ShellId("Tenant2"), aggregateReloaded.ChangedShells);
-    }
-
-    #endregion
-
-    #region US4 - Lifecycle Notifications During Reload
-
-    [Fact(DisplayName = "ReloadShellAsync emits ShellDeactivating before ShellActivated")]
-    public async Task ReloadShellAsync_EmitsDeactivating_BeforeActivated()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert
-        var all = notifications.Notifications.ToList();
-        var deactivatingIdx = all.FindIndex(n => n is ShellDeactivating);
-        var activatedIdx = all.FindIndex(n => n is ShellActivated);
-        Assert.True(deactivatingIdx >= 0, "ShellDeactivating should be emitted");
-        Assert.True(activatedIdx >= 0, "ShellActivated should be emitted");
-        Assert.True(deactivatingIdx < activatedIdx, "ShellDeactivating must precede ShellActivated");
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync full notification sequence: Reloading → Deactivating → Activated → Reloaded")]
-    public async Task ReloadShellAsync_FullNotificationSequence()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert - exact ordering
-        var all = notifications.Notifications.ToList();
-        Assert.Equal(4, all.Count);
-        Assert.IsType<ShellReloading>(all[0]);
-        Assert.IsType<ShellDeactivating>(all[1]);
-        Assert.IsType<ShellActivated>(all[2]);
-        Assert.IsType<ShellReloaded>(all[3]);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync with new shell skips ShellDeactivating")]
-    public async Task ReloadShellAsync_NewShell_SkipsDeactivating()
-    {
-        // Arrange
-        var shellId = new ShellId("NewTenant");
-        var newSettings = CreateShell("NewTenant", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(shellId, newSettings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([]); // empty cache — shell was never built
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(shellId);
-
-        // Assert - no ShellDeactivating since there was no old context
-        Assert.DoesNotContain(notifications.Notifications, n => n is ShellDeactivating);
-        Assert.Contains(notifications.Notifications, n => n is ShellActivated);
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync failure does not emit ShellDeactivating or ShellActivated")]
-    public async Task ReloadShellAsync_Failure_DoesNotEmitLifecycleNotifications()
-    {
-        // Arrange
-        var shellId = new ShellId("Tenant1");
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider(); // returns null
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            manager.ReloadShellAsync(shellId));
-
-        // Assert - lifecycle notifications must NOT be emitted on failure
-        Assert.DoesNotContain(notifications.Notifications, n => n is ShellDeactivating);
-        Assert.DoesNotContain(notifications.Notifications, n => n is ShellActivated);
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync emits ShellDeactivating for all existing shells")]
-    public async Task ReloadAllShellsAsync_EmitsDeactivating_ForAllExistingShells()
-    {
-        // Arrange
-        var tenant1 = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2 = CreateShell("Tenant2", ["FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), tenant1);
-        provider.SetShell(new("Tenant2"), tenant2);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1, tenant2]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - ShellDeactivating for both existing shells
-        var deactivating = notifications.Notifications.OfType<ShellDeactivating>().ToList();
-        Assert.Equal(2, deactivating.Count);
-        Assert.Contains(deactivating, d => d.Context.Id.Equals(new ShellId("Tenant1")));
-        Assert.Contains(deactivating, d => d.Context.Id.Equals(new ShellId("Tenant2")));
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync emits ShellActivated for all shells after rebuild")]
-    public async Task ReloadAllShellsAsync_EmitsActivated_ForAllShells()
-    {
-        // Arrange
-        var tenant1 = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2 = CreateShell("Tenant2", ["FeatureB"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), tenant1);
-        provider.SetShell(new("Tenant2"), tenant2);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1, tenant2]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - ShellActivated for both shells
-        var activated = notifications.Notifications.OfType<ShellActivated>().ToList();
-        Assert.Equal(2, activated.Count);
-        Assert.Contains(activated, a => a.Context.Id.Equals(new ShellId("Tenant1")));
-        Assert.Contains(activated, a => a.Context.Id.Equals(new ShellId("Tenant2")));
-    }
-
-    [Fact(DisplayName = "ReloadAllShellsAsync lifecycle notifications ordered: Deactivating before Activated")]
-    public async Task ReloadAllShellsAsync_DeactivatingBeforeActivated()
-    {
-        // Arrange
-        var settings = CreateShell("Tenant1", ["FeatureA"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant1"), settings);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([settings]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadAllShellsAsync();
-
-        // Assert - all ShellDeactivating must come before any ShellActivated
-        var all = notifications.Notifications.ToList();
-        var lastDeactivating = all.FindLastIndex(n => n is ShellDeactivating);
-        var firstActivated = all.FindIndex(n => n is ShellActivated);
-        Assert.True(lastDeactivating >= 0, "ShellDeactivating should be emitted");
-        Assert.True(firstActivated >= 0, "ShellActivated should be emitted");
-        Assert.True(lastDeactivating < firstActivated, "All ShellDeactivating must precede ShellActivated");
-    }
-
-    [Fact(DisplayName = "ReloadShellAsync preserves insertion order of existing shells")]
-    public async Task ReloadShellAsync_PreservesInsertionOrder()
-    {
-        // Arrange
-        var tenant1 = CreateShell("Tenant1", ["FeatureA"]);
-        var tenant2 = CreateShell("Tenant2", ["FeatureB"]);
-        var tenant3 = CreateShell("Tenant3", ["FeatureC"]);
-        var updatedTenant2 = CreateShell("Tenant2", ["FeatureB", "FeatureD"]);
-
-        var provider = new StubShellSettingsProvider();
-        provider.SetShell(new("Tenant2"), updatedTenant2);
-
-        var cache = new ShellSettingsCache();
-        cache.Load([tenant1, tenant2, tenant3]);
-
-        var notifications = new RecordingNotificationPublisher();
-        var manager = CreateManager(cache, provider, notifications);
-
-        // Act
-        await manager.ReloadShellAsync(new ShellId("Tenant2"));
-
-        // Assert - order should be preserved: Tenant1, Tenant2, Tenant3
-        var allShells = cache.GetAll().ToList();
-        Assert.Equal(3, allShells.Count);
-        Assert.Equal(new ShellId("Tenant1"), allShells[0].Id);
-        Assert.Equal(new ShellId("Tenant2"), allShells[1].Id);
-        Assert.Equal(new ShellId("Tenant3"), allShells[2].Id);
-        Assert.Contains("FeatureD", allShells[1].EnabledFeatures);
-    }
-
-    #endregion
-
-    #region Helpers
-
-    private static DefaultShellManager CreateManager(
-        ShellSettingsCache cache,
-        StubShellSettingsProvider provider,
+    private static TestRuntime CreateRuntime(
+        IEnumerable<ShellSettings> initialShells,
+        IShellSettingsProvider provider,
         RecordingNotificationPublisher notifications)
     {
-        var host = new StubShellHost(cache);
-        return new DefaultShellManager(host, host, cache, provider, notifications);
+        var cache = new ShellSettingsCache();
+        cache.Load(initialShells.ToList());
+
+        var (services, rootProvider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+        var host = new DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            rootProvider,
+            accessor,
+            featureFactory,
+            exclusionRegistry,
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: notifications,
+            logger: NullLogger<DefaultShellHost>.Instance);
+        var accessorService = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(host, cache, provider, stateStore, runtimeCatalog, accessorService, notifications, NullLogger<DefaultShellManager>.Instance);
+
+        return new TestRuntime(cache, host, manager, accessorService);
     }
 
-    private static ShellSettings CreateShell(string id, string[] features) => new()
+    private sealed record TestRuntime(
+        ShellSettingsCache Cache,
+        DefaultShellHost Host,
+        DefaultShellManager Manager,
+        IShellRuntimeStateAccessor Accessor);
+
+    private sealed class RecordingNotificationPublisher : INotificationPublisher
     {
-        Id = new(id),
-        EnabledFeatures = features
-    };
-
-    /// <summary>
-    /// A minimal stub shell host for unit testing.
-    /// Creates lightweight <see cref="ShellContext"/> instances backed by the cache.
-    /// </summary>
-    private sealed class StubShellHost(ShellSettingsCache cache) : IShellHost, IShellHostInitializer
-    {
-        private readonly Dictionary<ShellId, ShellContext> _contexts = new();
-        private bool _initialized;
-
-        public List<ShellId> EvictedShells { get; } = [];
-        public bool AllShellsEvicted { get; private set; }
-        public int InitializeCalls { get; private set; }
-
-        public ShellContext DefaultShell => throw new NotImplementedException();
-
-        public IReadOnlyCollection<ShellContext> AllShells
-        {
-            get
-            {
-                EnsureInitialized();
-
-                foreach (var settings in cache.GetAll())
-                {
-                    if (!_contexts.ContainsKey(settings.Id))
-                        _contexts[settings.Id] = CreateContext(settings);
-                }
-
-                return _contexts.Values.ToList().AsReadOnly();
-            }
-        }
-
-        public ShellContext GetShell(ShellId id)
-        {
-            EnsureInitialized();
-
-            if (_contexts.TryGetValue(id, out var context))
-                return context;
-
-            var settings = cache.GetById(id)
-                ?? throw new KeyNotFoundException($"Shell '{id}' not found.");
-
-            var newContext = CreateContext(settings);
-            _contexts[id] = newContext;
-            return newContext;
-        }
-
-        public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
-        {
-            InitializeCalls++;
-            _initialized = true;
-            return Task.CompletedTask;
-        }
-
-        public ValueTask EvictShellAsync(ShellId shellId)
-        {
-            EvictedShells.Add(shellId);
-            _contexts.Remove(shellId);
-            return ValueTask.CompletedTask;
-        }
-
-        public ValueTask EvictAllShellsAsync()
-        {
-            AllShellsEvicted = true;
-            _contexts.Clear();
-            return ValueTask.CompletedTask;
-        }
-
-        private void EnsureInitialized()
-        {
-            if (!_initialized)
-                throw new InvalidOperationException("Shell host must be initialized before accessing shells.");
-        }
-
-        private static ShellContext CreateContext(ShellSettings settings) =>
-            new(settings, new ServiceCollection().BuildServiceProvider(), settings.EnabledFeatures.ToList().AsReadOnly());
-    }
-
-    /// <summary>
-    /// A stub provider that returns configured shells by ID.
-    /// </summary>
-    internal sealed class StubShellSettingsProvider : IShellSettingsProvider
-    {
-        private readonly Dictionary<ShellId, ShellSettings> _shells = new();
-
-        public void SetShell(ShellId id, ShellSettings settings) => _shells[id] = settings;
-
-        public Task<IEnumerable<ShellSettings>> GetShellSettingsAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult<IEnumerable<ShellSettings>>(_shells.Values.ToList());
-
-        public Task<ShellSettings?> GetShellSettingsAsync(ShellId shellId, CancellationToken cancellationToken = default) =>
-            Task.FromResult(_shells.GetValueOrDefault(shellId));
-    }
-
-    /// <summary>
-    /// A notification publisher that records all published notifications.
-    /// </summary>
-    internal sealed class RecordingNotificationPublisher : INotificationPublisher
-    {
-        private readonly List<object> _notifications = [];
-        public IReadOnlyList<object> Notifications => _notifications;
+        public List<object> Notifications { get; } = [];
 
         public Task PublishAsync<TNotification>(
             TNotification notification,
             INotificationStrategy? strategy = null,
             CancellationToken cancellationToken = default) where TNotification : class, INotification
         {
-            _notifications.Add(notification);
+            Notifications.Add(notification);
             return Task.CompletedTask;
         }
     }
-
-    #endregion
 }

--- a/tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs
+++ b/tests/CShells.Tests/Unit/Management/ShellRuntimeStateAccessorTests.cs
@@ -1,0 +1,67 @@
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Management;
+
+public class ShellRuntimeStateAccessorTests
+{
+    [Fact(DisplayName = "GetShell reports active last-known-good runtime with desired drift and blocking reason")]
+    public void GetShell_LastKnownGoodAppliedRuntime_RemainsActiveWhileDesiredDrifts()
+    {
+        // Arrange
+        var shellId = new ShellId("Contoso");
+        var store = new ShellRuntimeStateStore();
+        var accessor = new ShellRuntimeStateAccessor(store);
+        var appliedSettings = new ShellSettings(shellId, ["Core"]);
+        var desiredSettings = new ShellSettings(shellId, ["Core", "MissingFeature"]);
+        var snapshot = new RuntimeFeatureCatalogSnapshot(
+            1,
+            Array.Empty<System.Reflection.Assembly>(),
+            Array.Empty<ShellFeatureDescriptor>(),
+            new Dictionary<string, ShellFeatureDescriptor>(StringComparer.OrdinalIgnoreCase),
+            DateTimeOffset.UtcNow);
+        var appliedContext = new ShellContext(appliedSettings, new ServiceCollection().BuildServiceProvider(), ["Core"]);
+
+        store.RecordDesired(appliedSettings);
+        store.CommitAppliedRuntime(shellId, appliedSettings, snapshot, appliedContext);
+        store.RecordDesired(desiredSettings);
+        store.MarkDeferred(shellId, ["MissingFeature"], "Feature 'MissingFeature' is not available in the current runtime feature catalog.");
+
+        // Act
+        var status = accessor.GetShell(shellId);
+
+        // Assert
+        Assert.NotNull(status);
+        Assert.Equal(2, status!.DesiredGeneration);
+        Assert.Equal(1, status.AppliedGeneration);
+        Assert.Equal(ShellReconciliationOutcome.Active, status.Outcome);
+        Assert.False(status.IsInSync);
+        Assert.True(status.IsRoutable);
+        Assert.Equal("Feature 'MissingFeature' is not available in the current runtime feature catalog.", status.BlockingReason);
+        Assert.Equal(["MissingFeature"], status.MissingFeatures);
+    }
+
+    [Fact(DisplayName = "GetAllShells includes configured shells with no applied runtime")]
+    public void GetAllShells_IncludesDesiredOnlyShells()
+    {
+        // Arrange
+        var store = new ShellRuntimeStateStore();
+        var accessor = new ShellRuntimeStateAccessor(store);
+        store.RecordDesired(new ShellSettings(new ShellId("Deferred"), ["MissingFeature"]));
+        store.MarkDeferred(new ShellId("Deferred"), ["MissingFeature"], "Missing required feature.");
+
+        // Act
+        var statuses = accessor.GetAllShells();
+
+        // Assert
+        var status = Assert.Single(statuses);
+        Assert.Equal(new ShellId("Deferred"), status.ShellId);
+        Assert.Null(status.AppliedGeneration);
+        Assert.Equal(ShellReconciliationOutcome.DeferredDueToMissingFeatures, status.Outcome);
+        Assert.False(status.IsRoutable);
+        Assert.False(status.IsInSync);
+    }
+}
+

--- a/wiki/Runtime-Shell-Management.md
+++ b/wiki/Runtime-Shell-Management.md
@@ -1,6 +1,6 @@
 # Runtime Shell Management
 
-CShells supports adding, updating, and removing shells at runtime without restarting the application. Use `IShellManager` for programmatic shell lifecycle management.
+CShells supports adding, updating, removing, and reloading shells at runtime without restarting the application. Under the deferred-activation model, runtime management now records **desired** shell definitions immediately and reconciles them into **applied** runtimes only when a candidate runtime is fully ready.
 
 ---
 
@@ -11,11 +11,11 @@ CShells supports adding, updating, and removing shells at runtime without restar
 ```csharp
 public class TenantProvisioningService
 {
-    private readonly IShellManager _shellManager;
+    private readonly IShellManager shellManager;
 
     public TenantProvisioningService(IShellManager shellManager)
     {
-        _shellManager = shellManager;
+        this.shellManager = shellManager;
     }
 }
 ```
@@ -35,19 +35,17 @@ public async Task CreateTenantAsync(string tenantId, string tier)
     };
 
     var settings = new ShellSettings(new ShellId(tenantId), features);
-
-    // Optionally set routing and feature configuration
     settings.ConfigurationData["WebRouting:Path"] = tenantId;
 
-    await _shellManager.AddShellAsync(settings);
-    // Shell is now active and handling requests
+    await shellManager.AddShellAsync(settings);
 }
 ```
 
 When a shell is added:
-1. Its settings are stored in the cache.
-2. Its DI container is built from the enabled features.
-3. Its endpoints are registered with the routing system (for web features).
+1. Its settings are recorded as the new **desired** definition.
+2. CShells refreshes the runtime feature catalog.
+3. If the candidate runtime builds successfully, it is committed and becomes active.
+4. If the shell cannot be applied yet, the desired state remains recorded and visible through runtime status until a later reconciliation succeeds.
 
 ---
 
@@ -56,10 +54,11 @@ When a shell is added:
 ```csharp
 public async Task DeleteTenantAsync(string tenantId)
 {
-    await _shellManager.RemoveShellAsync(new ShellId(tenantId));
-    // Shell is immediately removed; its DI container is disposed
+    await shellManager.RemoveShellAsync(new ShellId(tenantId));
 }
 ```
+
+Removal is the explicit operation that deletes a shell from desired state and tears down its applied runtime.
 
 ---
 
@@ -75,186 +74,129 @@ public async Task UpgradeTenantAsync(string tenantId, string newTier)
     var settings = new ShellSettings(new ShellId(tenantId), features);
     settings.ConfigurationData["WebRouting:Path"] = tenantId;
 
-    await _shellManager.UpdateShellAsync(settings);
-    // Old shell is removed and new shell is added atomically
+    await shellManager.UpdateShellAsync(settings);
 }
 ```
 
-`UpdateShellAsync` removes the existing shell and adds the new one. There may be a brief period during which requests to the affected shell return 404.
+`UpdateShellAsync` no longer tears down the current runtime first. It records a newer desired generation and attempts to reconcile it into a successor runtime. If the new desired generation is deferred or fails, the last-known-good applied runtime stays routable.
 
 ---
 
 ## Reloading All Shells
 
-Reload all shells from the configured providers without restarting the application. Useful when shell configurations are stored externally (e.g., in a database or blob storage) and have changed.
-
 ```csharp
 public async Task RefreshAllTenantsAsync()
 {
-    await _shellManager.ReloadAllShellsAsync();
+    await shellManager.ReloadAllShellsAsync();
 }
 ```
 
-Shells that no longer exist in the providers are removed; new shells are added; changed shells are updated. All cached runtime contexts are invalidated and rebuilt on next access.
+Every full reload:
+- refreshes the runtime feature catalog first
+- reloads the latest desired shell set from providers
+- commits only shells whose successor runtimes are fully ready
+- preserves already applied shells when newer desired generations defer or fail
 
 ---
 
 ## Reloading a Single Shell
 
-Reload a specific shell from its provider without affecting other shells. The provider is queried by `ShellId`; if the provider no longer defines the shell, an `InvalidOperationException` is thrown and the runtime state is left unchanged.
-
 ```csharp
 public async Task RefreshTenantAsync(string tenantId)
 {
-    await _shellManager.ReloadShellAsync(new ShellId(tenantId));
-    // Shell's DI container will be rebuilt on next access
+    await shellManager.ReloadShellAsync(new ShellId(tenantId));
 }
 ```
 
-- The reloaded shell's cached runtime context is invalidated and rebuilt lazily.
-- Unrelated shells are not affected.
-- If the shell is unknown to the provider, the call throws without mutating cache or runtime state.
+- The shell records the latest desired definition from the provider before reconciliation.
+- The previous applied runtime remains available until a successor commits.
+- Unrelated applied shells are not affected.
+- If the shell is unknown to the provider, the call throws without mutating runtime state.
+
+---
+
+## Inspecting Desired vs. Applied State
+
+Inject `IShellRuntimeStateAccessor` when you need to distinguish configured intent from currently serving runtimes.
+
+```csharp
+public class ShellStatusService(IShellRuntimeStateAccessor runtimeState)
+{
+    public IReadOnlyCollection<ShellRuntimeStatus> GetShells() => runtimeState.GetAllShells();
+}
+```
+
+Each `ShellRuntimeStatus` reports:
+- the latest `DesiredGeneration`
+- the committed `AppliedGeneration` (if any)
+- whether the shell is currently `IsInSync`
+- whether it is currently `IsRoutable`
+- any `BlockingReason` / `MissingFeatures`
+
+This means operators can see configured-but-unapplied shells without those shells becoming routable or endpoint-visible.
 
 ---
 
 ## Shell Lifecycle Notifications
 
-CShells publishes notifications during shell lifecycle events. Register a handler to react to them.
+CShells publishes notifications during shell lifecycle events.
 
 ### Available Notifications
 
 | Notification | When |
 |---|---|
-| `ShellActivated` | A shell's DI container has been built and is ready |
-| `ShellDeactivating` | A shell is about to be shut down |
+| `ShellActivated` | A candidate runtime has been committed and is now applied |
+| `ShellDeactivating` | An applied runtime is about to be replaced or removed |
 | `ShellAdded` | A shell was added via `IShellManager.AddShellAsync` |
 | `ShellRemoved` | A shell was removed via `IShellManager.RemoveShellAsync` |
 | `ShellUpdated` | A shell was updated via `IShellManager.UpdateShellAsync` |
-| `ShellReloading` | A reload operation is starting (per-shell or aggregate) |
-| `ShellReloaded` | A reload operation completed successfully (per-shell or aggregate) |
-| `ShellsReloaded` | All shells were reloaded via `IShellManager.ReloadAllShellsAsync` |
+| `ShellReloading` | A reload operation is starting |
+| `ShellReloaded` | A reload operation completed successfully |
+| `ShellsReloaded` | A reconciliation pass produced a fresh runtime status snapshot |
 
 ### Reload Notification Ordering
 
 During a **single-shell reload** (`ReloadShellAsync`):
-
-1. `ShellReloading(shellId)` — reload is starting
-2. Cache update + context invalidation
-3. `ShellReloaded(shellId, [shellId])` — reload succeeded
-
-If the provider does not define the shell, `ShellReloading` may be emitted but `ShellReloaded` is **never** emitted on failure.
+1. `ShellReloading(shellId)`
+2. Desired state is refreshed from the provider
+3. The runtime feature catalog is refreshed
+4. If a successor commits, `ShellDeactivating` / `ShellActivated` are emitted around the applied runtime swap
+5. `ShellReloaded(shellId, [shellId], statuses)`
 
 During a **full reload** (`ReloadAllShellsAsync`):
-
-1. `ShellReloading(null)` — aggregate reload is starting
-2. Cache reconciliation + context invalidation
-3. `ShellsReloaded(allShells)` — existing aggregate notification
-4. `ShellReloaded(null, changedShells)` — aggregate reload succeeded
-
-The `ShellReloaded.ChangedShells` collection contains only shells whose reconciliation outcome was Added, Updated, or Removed. Unchanged shells are excluded.
-
-### Implementing a Notification Handler
-
-```csharp
-using CShells.Notifications;
-
-public class TenantActivatedHandler : INotificationHandler<ShellActivated>
-{
-    private readonly ILogger<TenantActivatedHandler> _logger;
-
-    public TenantActivatedHandler(ILogger<TenantActivatedHandler> logger)
-    {
-        _logger = logger;
-    }
-
-    public Task HandleAsync(ShellActivated notification, CancellationToken cancellationToken = default)
-    {
-        _logger.LogInformation("Shell '{ShellId}' activated with {FeatureCount} features",
-            notification.Context.Settings.Id.Value,
-            notification.Context.Settings.EnabledFeatures.Count);
-
-        return Task.CompletedTask;
-    }
-}
-```
-
-Register it in the DI container:
-
-```csharp
-builder.Services.AddSingleton<INotificationHandler<ShellActivated>, TenantActivatedHandler>();
-```
-
-### `IShellActivatedHandler` and `IShellDeactivatingHandler`
-
-Register these in a feature's `ConfigureServices` to react to shell lifecycle events from within the shell's own DI container:
-
-```csharp
-using CShells.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-
-public class AnalyticsActivationHandler : IShellActivatedHandler, IShellDeactivatingHandler
-{
-    private readonly IAnalyticsCollector _collector;
-
-    public AnalyticsActivationHandler(IAnalyticsCollector collector)
-    {
-        _collector = collector;
-    }
-
-    public Task OnActivatedAsync(CancellationToken cancellationToken = default)
-    {
-        _collector.StartTracking();
-        return Task.CompletedTask;
-    }
-
-    public Task OnDeactivatingAsync(CancellationToken cancellationToken = default)
-    {
-        _collector.Flush();
-        return Task.CompletedTask;
-    }
-}
-
-// Register in the feature:
-[ShellFeature("Analytics")]
-public class AnalyticsFeature : IShellFeature
-{
-    public void ConfigureServices(IServiceCollection services)
-    {
-        services.AddSingleton<IAnalyticsCollector, AnalyticsCollector>();
-        services.AddSingleton<IShellActivatedHandler, AnalyticsActivationHandler>();
-        services.AddSingleton<IShellDeactivatingHandler, AnalyticsActivationHandler>();
-    }
-}
-```
-
-Because these handlers are registered in the shell's DI container, they can depend on any shell-scoped service.
+1. `ShellReloading(null)`
+2. Desired state is refreshed from providers
+3. The runtime feature catalog is refreshed
+4. Ready candidates commit individually; deferred/failed generations remain unapplied
+5. `ShellsReloaded(statuses)`
+6. `ShellReloaded(null, changedShells, statuses)`
 
 ---
 
-## `IShellHost` — Accessing Shells
+## `IShellHost` — Accessing Applied Shells
 
-Inject `IShellHost` to enumerate or look up active shell contexts.
+Inject `IShellHost` to enumerate or look up applied shell contexts.
 
 ```csharp
 public class ShellDashboardService
 {
-    private readonly IShellHost _shellHost;
+    private readonly IShellHost shellHost;
 
     public ShellDashboardService(IShellHost shellHost)
     {
-        _shellHost = shellHost;
+        this.shellHost = shellHost;
     }
 
     public IEnumerable<string> GetActiveShellNames() =>
-        _shellHost.AllShells.Select(s => s.Settings.Id.Value);
+        shellHost.AllShells.Select(shell => shell.Settings.Id.Value);
 
     public ShellContext GetShell(string name) =>
-        _shellHost.GetShell(new ShellId(name));
+        shellHost.GetShell(new ShellId(name));
 }
 ```
 
 | Member | Description |
 |---|---|
-| `IShellHost.AllShells` | All currently active shell contexts |
-| `IShellHost.DefaultShell` | The shell named `"Default"`, or the first shell |
-| `IShellHost.GetShell(ShellId)` | Look up a shell by ID; throws `KeyNotFoundException` if not found |
+| `IShellHost.AllShells` | All currently applied shell contexts |
+| `IShellHost.DefaultShell` | The explicit `"Default"` shell only when it is applied; otherwise the first applied shell is used only when no explicit default exists |
+| `IShellHost.GetShell(ShellId)` | Looks up an applied shell by ID; throws `KeyNotFoundException` if no committed runtime exists |

--- a/wiki/Shell-Lifecycle.md
+++ b/wiki/Shell-Lifecycle.md
@@ -1,0 +1,61 @@
+# Shell Lifecycle
+
+CShells lifecycle handlers run against **applied** shell runtimes, not merely against configured intent.
+
+## Desired vs. Applied
+
+Deferred activation introduces two layers of truth per shell:
+
+- **Desired state** — the latest recorded `ShellSettings`
+- **Applied runtime** — the last committed shell runtime that is safe to serve
+
+A shell can be configured without currently being applied.
+
+## Lifecycle Handler Rules
+
+| Handler | Runs when |
+|---|---|
+| `IShellActivatedHandler` | A candidate runtime is committed and becomes applied |
+| `IShellDeactivatingHandler` | An applied runtime is about to be replaced or removed |
+
+That means:
+
+- recording a new desired generation does **not** trigger activation by itself
+- deferred / failed desired generations do **not** deactivate the last-known-good applied runtime
+- reload deactivation happens only when a successor runtime is ready to commit
+
+## Startup Behavior
+
+During application startup, CShells:
+1. records desired state for configured shells
+2. refreshes the runtime feature catalog
+3. reconciles shells into applied runtimes where possible
+4. publishes runtime status for all configured shells
+
+Only shells with applied runtimes become routable.
+
+## Runtime Notifications
+
+Framework notifications follow applied-runtime transitions:
+
+- `ShellActivated` — emitted when a candidate runtime commits
+- `ShellDeactivating` — emitted when an applied runtime is being replaced or removed
+- `ShellsReloaded` / `ShellReloaded` — emitted after reconciliation with runtime status snapshots
+
+## Inspecting State
+
+Use `IShellRuntimeStateAccessor` to inspect every configured shell, including shells that are deferred or failed:
+
+```csharp
+public class ShellStatusPage(IShellRuntimeStateAccessor runtimeState)
+{
+    public IReadOnlyCollection<ShellRuntimeStatus> GetShells() => runtimeState.GetAllShells();
+}
+```
+
+This lets operators distinguish:
+
+- shells that are configured and applied
+- shells that are configured but deferred
+- shells that are serving a last-known-good runtime while a newer desired generation is blocked
+

--- a/wiki/Shell-Resolution.md
+++ b/wiki/Shell-Resolution.md
@@ -1,12 +1,12 @@
 # Shell Resolution
 
-Shell resolution determines which shell handles an incoming HTTP request. CShells ships with a unified `WebRoutingShellResolver` that supports path, host, header, and claim-based routing out of the box.
+Shell resolution determines which shell handles an incoming HTTP request. CShells ships with a unified `WebRoutingShellResolver` that supports path, host, header, and claim-based routing out of the box — but only **applied** shells participate in routing.
 
 ---
 
 ## How Resolution Works
 
-For each incoming request, CShells runs through registered resolver strategies in order. The first strategy that returns a shell name wins. If no strategy matches, a configurable fallback (default: `"Default"` shell) is used.
+For each incoming request, CShells runs through registered resolver strategies in order. The first strategy that returns a shell name wins. Desired-only shells that are deferred or failed do not participate until a runtime has been committed.
 
 ```
 Request
@@ -15,7 +15,7 @@ Request
          ├── Host routing    (WebRouting:Host match)
          ├── Header routing  (X-Tenant-Id: header)
          └── Claim routing   (tenant_id claim)
-  └──> DefaultShellResolverStrategy  (returns "Default")
+  └──> DefaultShellResolverStrategy  (uses explicit `Default` only when it is applied)
 ```
 
 ---
@@ -49,7 +49,7 @@ A shell is resolved when the first URL path segment matches the shell's `WebRout
 }
 ```
 
-Requests to `/acme/*` → resolved to the `Acme` shell.
+Requests to `/acme/*` → resolved to the `Acme` shell, provided `Acme` currently has an applied runtime.
 
 Path routing is enabled by default (`EnablePathRouting = true`).
 
@@ -193,6 +193,24 @@ services.AddCShells(cshells =>
     cshells.WithDefaultResolver();
 });
 ```
+
+## Explicit `Default` Behavior
+
+If a shell named `Default` is explicitly configured, fallback is strict:
+
+- **Applied `Default`** → fallback can resolve to `Default`
+- **Configured but unapplied `Default`** → fallback returns no shell
+- **No explicit `Default` configured** → fallback may choose the first applied shell
+
+This prevents a deferred or failed explicit default shell from silently routing traffic to another tenant.
+
+## Applied-Only Endpoints
+
+Endpoint registration follows the same rule as routing:
+
+- applied shells expose endpoints
+- deferred / failed desired shells expose no shell-owned endpoints
+- runtime status remains inspectable through `IShellRuntimeStateAccessor`
 
 ---
 


### PR DESCRIPTION
## Summary
- separate configured desired state from applied runtime state for each shell
- add a refreshable runtime feature catalog and candidate-build/atomic-commit reconciliation flow
- preserve last-known-good applied runtimes during deferred or failed desired updates
- align routing, endpoint exposure, lifecycle semantics, docs, and samples to applied-active runtimes only
- add runtime status inspection contracts and coverage for mixed-state/default-shell behavior

## Validation
- `dotnet build`
- `dotnet test tests/CShells.Tests/`
- `dotnet test tests/CShells.Tests.EndToEnd/`

## Notes
- includes spec, plan, data model, contracts, tasks, docs, sample updates, and implementation/tests for feature `005-deferred-shell-activation`
- adds sample diagnostic endpoint: `GET /_shells/status`