### PR TITLE
Add ConfiguringShellSettingsProvider for global shell configuration

### DIFF
--- a/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
+++ b/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
@@ -8,6 +8,8 @@ internal sealed class ConfiguringShellSettingsProvider(
     IShellSettingsProvider inner,
     IReadOnlyList<Action<ShellBuilder>> configurators) : IShellSettingsProvider
 {
+    private readonly IShellSettingsProvider inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    private readonly Action<ShellBuilder>[] configurators = (configurators ?? throw new ArgumentNullException(nameof(configurators))).ToArray();
     public async Task<IEnumerable<ShellSettings>> GetShellSettingsAsync(CancellationToken cancellationToken = default)
     {
         var settings = await inner.GetShellSettingsAsync(cancellationToken);

--- a/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
+++ b/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
@@ -24,9 +24,24 @@ internal sealed class ConfiguringShellSettingsProvider(
 
     private ShellSettings ApplyConfigurators(ShellSettings settings)
     {
-        var builder = new ShellBuilder(settings);
+        var clone = CloneSettings(settings);
+        var builder = new ShellBuilder(clone);
         foreach (var configurator in configurators)
             configurator(builder);
-        return settings;
+        return clone;
+    }
+
+    private static ShellSettings CloneSettings(ShellSettings settings)
+    {
+        var clone = new ShellSettings(settings.Id)
+        {
+            EnabledFeatures = settings.EnabledFeatures,
+            ConfigurationData = new Dictionary<string, object>(settings.ConfigurationData),
+        };
+
+        foreach (var (key, value) in settings.FeatureConfigurators)
+            clone.FeatureConfigurators[key] = value;
+
+        return clone;
     }
 }

--- a/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
+++ b/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
@@ -1,0 +1,30 @@
+namespace CShells.Configuration;
+
+/// <summary>
+/// Decorator that applies <see cref="ShellBuilder"/>-based configurators to every
+/// <see cref="ShellSettings"/> returned by the inner provider.
+/// </summary>
+internal sealed class ConfiguringShellSettingsProvider(
+    IShellSettingsProvider inner,
+    IReadOnlyList<Action<ShellBuilder>> configurators) : IShellSettingsProvider
+{
+    public async Task<IEnumerable<ShellSettings>> GetShellSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await inner.GetShellSettingsAsync(cancellationToken);
+        return settings.Select(ApplyConfigurators);
+    }
+
+    public async Task<ShellSettings?> GetShellSettingsAsync(ShellId shellId, CancellationToken cancellationToken = default)
+    {
+        var settings = await inner.GetShellSettingsAsync(shellId, cancellationToken);
+        return settings is not null ? ApplyConfigurators(settings) : null;
+    }
+
+    private ShellSettings ApplyConfigurators(ShellSettings settings)
+    {
+        var builder = new ShellBuilder(settings);
+        foreach (var configurator in configurators)
+            configurator(builder);
+        return settings;
+    }
+}

--- a/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
+++ b/src/CShells/Configuration/ConfiguringShellSettingsProvider.cs
@@ -11,7 +11,7 @@ internal sealed class ConfiguringShellSettingsProvider(
     public async Task<IEnumerable<ShellSettings>> GetShellSettingsAsync(CancellationToken cancellationToken = default)
     {
         var settings = await inner.GetShellSettingsAsync(cancellationToken);
-        return settings.Select(ApplyConfigurators);
+        return settings.Select(ApplyConfigurators).ToArray();
     }
 
     public async Task<ShellSettings?> GetShellSettingsAsync(ShellId shellId, CancellationToken cancellationToken = default)

--- a/src/CShells/Configuration/ShellBuilder.cs
+++ b/src/CShells/Configuration/ShellBuilder.cs
@@ -29,6 +29,15 @@ public class ShellBuilder
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ShellBuilder"/> class that wraps an existing <see cref="ShellSettings"/>.
+    /// Mutations via the builder are applied directly to the provided settings instance.
+    /// </summary>
+    internal ShellBuilder(ShellSettings settings)
+    {
+        _settings = Guard.Against.Null(settings);
+    }
+
+    /// <summary>
     /// Adds features to the shell by string identifier.
     /// </summary>
     public ShellBuilder WithFeatures(params string[] featureIds)

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -14,6 +14,7 @@ public class CShellsBuilder
     private readonly List<ShellSettings> _codeFirstShells = new();
     private readonly List<Action<IServiceProvider, List<IShellSettingsProvider>>> _providerRegistrations = new();
     private readonly List<Func<IServiceProvider, IFeatureAssemblyProvider>> _featureAssemblyProviderRegistrations = [];
+    private readonly List<Action<ShellBuilder>> _shellConfigurators = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CShellsBuilder"/> class.
@@ -33,6 +34,11 @@ public class CShellsBuilder
     /// Gets all code-first shell settings configured via AddShell.
     /// </summary>
     internal IReadOnlyList<ShellSettings> CodeFirstShells => _codeFirstShells.AsReadOnly();
+
+    /// <summary>
+    /// Gets the configurators registered via <see cref="ConfigureAllShells"/>.
+    /// </summary>
+    internal IReadOnlyList<Action<ShellBuilder>> ShellConfigurators => _shellConfigurators.AsReadOnly();
 
     /// <summary>
     /// Gets a value indicating whether explicit feature assembly providers were configured.
@@ -103,6 +109,24 @@ public class CShellsBuilder
         return UsesExplicitFeatureAssemblyProviders
             ? await CShells.Features.FeatureAssemblyResolver.ResolveAssembliesAsync(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider, cancellationToken)
             : CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies();
+    }
+
+    /// <summary>
+    /// Registers a configurator that is applied to every shell — whether defined in code or loaded from configuration.
+    /// Configurators run in registration order before a shell's settings are finalized.
+    /// </summary>
+    /// <param name="configure">Configuration action applied to each shell's builder.</param>
+    /// <returns>This builder for method chaining.</returns>
+    /// <remarks>
+    /// Use this to define a base set of features or configuration that all shells should share.
+    /// Shell-specific features (from <see cref="AddShell(string,System.Action{CShells.Configuration.ShellBuilder})"/>
+    /// or configuration providers) are merged on top.
+    /// </remarks>
+    public CShellsBuilder ConfigureAllShells(Action<ShellBuilder> configure)
+    {
+        Guard.Against.Null(configure);
+        _shellConfigurators.Add(configure);
+        return this;
     }
 
     /// <summary>

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -118,9 +118,10 @@ public class CShellsBuilder
     /// <param name="configure">Configuration action applied to each shell's builder.</param>
     /// <returns>This builder for method chaining.</returns>
     /// <remarks>
-    /// Use this to define a base set of features or configuration that all shells should share.
-    /// Shell-specific features (from <see cref="AddShell(string,System.Action{CShells.Configuration.ShellBuilder})"/>
-    /// or configuration providers) are merged on top.
+    /// Use this to define a shared set of features or configuration that should be applied to all shells.
+    /// This configuration is applied as part of shell finalization and may override values already supplied by
+    /// shell-specific configuration (from <see cref="AddShell(string,System.Action{CShells.Configuration.ShellBuilder})"/>)
+    /// or configuration providers when they target the same settings.
     /// </remarks>
     public CShellsBuilder ConfigureAllShells(Action<ShellBuilder> configure)
     {

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -111,31 +111,32 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IShellSettingsProvider>(sp =>
         {
             var providers = new List<IShellSettingsProvider>();
-            
+
             // Add code-first shells provider if any shells were defined
             if (builder.CodeFirstShells.Count > 0)
             {
                 providers.Add(new InMemoryShellSettingsProvider(builder.CodeFirstShells));
             }
-            
+
             // Build and add all registered providers
             var registeredProviders = builder.BuildProviders(sp);
             providers.AddRange(registeredProviders);
-            
+
+            IShellSettingsProvider provider;
+
             // If no providers were registered, return an empty provider
             if (providers.Count == 0)
-            {
-                return new InMemoryShellSettingsProvider([]);
-            }
-            
-            // If only one provider, return it directly (optimization)
-            if (providers.Count == 1)
-            {
-                return providers[0];
-            }
-            
-            // Return composite provider for multiple providers
-            return new CompositeShellSettingsProvider(providers);
+                provider = new InMemoryShellSettingsProvider([]);
+            else if (providers.Count == 1)
+                provider = providers[0];
+            else
+                provider = new CompositeShellSettingsProvider(providers);
+
+            // Wrap with ConfigureAllShells configurators when registered
+            if (builder.ShellConfigurators.Count > 0)
+                provider = new ConfiguringShellSettingsProvider(provider, builder.ShellConfigurators);
+
+            return provider;
         });
         
         configure?.Invoke(builder);

--- a/tests/CShells.Tests/Unit/Configuration/ConfiguringShellSettingsProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/ConfiguringShellSettingsProviderTests.cs
@@ -1,0 +1,268 @@
+using CShells.Configuration;
+using CShells.DependencyInjection;
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Configuration;
+
+public class ConfiguringShellSettingsProviderTests
+{
+    [Fact]
+    public async Task ConfigureAllShells_AppliesFeaturesToCodeFirstShells()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.AddShell("Shell1", shell => shell.WithFeature("Feature1"));
+            shells.AddShell("Shell2", shell => shell.WithFeature("Feature2"));
+            shells.ConfigureAllShells(shell => shell.WithFeature("SharedFeature"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert
+        Assert.Equal(2, settings.Count);
+
+        var shell1 = settings.Single(s => s.Id.Name == "Shell1");
+        Assert.Contains("Feature1", shell1.EnabledFeatures);
+        Assert.Contains("SharedFeature", shell1.EnabledFeatures);
+
+        var shell2 = settings.Single(s => s.Id.Name == "Shell2");
+        Assert.Contains("Feature2", shell2.EnabledFeatures);
+        Assert.Contains("SharedFeature", shell2.EnabledFeatures);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_AppliesConfigurationToAllShells()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.AddShell("Shell1", shell => shell.WithFeature("Feature1"));
+            shells.AddShell("Shell2", shell => shell.WithFeature("Feature2"));
+            shells.ConfigureAllShells(shell => shell.WithConfiguration("Plan", "Enterprise"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert
+        foreach (var shell in settings)
+        {
+            Assert.Equal("Enterprise", shell.ConfigurationData["Plan"]);
+        }
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_AppliesFeaturesToProviderShells()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var providerShells = new List<ShellSettings>
+        {
+            new(new ShellId("ProviderShell"), ["ProviderFeature"])
+        };
+
+        services.AddCShells(shells =>
+        {
+            shells.WithProvider(new InMemoryShellSettingsProvider(providerShells));
+            shells.ConfigureAllShells(shell => shell.WithFeature("SharedFeature"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert
+        var shell = settings.Single();
+        Assert.Contains("ProviderFeature", shell.EnabledFeatures);
+        Assert.Contains("SharedFeature", shell.EnabledFeatures);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_DoesNotCompound_OnMultipleEnumerations()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var providerShells = new List<ShellSettings>
+        {
+            new(new ShellId("Shell1"), ["Feature1"])
+        };
+
+        services.AddCShells(shells =>
+        {
+            shells.WithProvider(new InMemoryShellSettingsProvider(providerShells));
+            shells.ConfigureAllShells(shell => shell.WithFeature("SharedFeature"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act - enumerate multiple times
+        var firstCall = (await provider.GetShellSettingsAsync()).ToList();
+        var secondCall = (await provider.GetShellSettingsAsync()).ToList();
+        var thirdCall = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert - features should be the same on every call, not compounded
+        Assert.Equal(firstCall.Single().EnabledFeatures, secondCall.Single().EnabledFeatures);
+        Assert.Equal(firstCall.Single().EnabledFeatures, thirdCall.Single().EnabledFeatures);
+        Assert.Equal(2, thirdCall.Single().EnabledFeatures.Count); // Feature1 + SharedFeature
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_DoesNotMutateOriginalProviderInstances()
+    {
+        // Arrange
+        var originalSettings = new ShellSettings(new ShellId("Shell1"), ["Feature1"]);
+        var providerShells = new List<ShellSettings> { originalSettings };
+
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.WithProvider(new InMemoryShellSettingsProvider(providerShells));
+            shells.ConfigureAllShells(shell => shell
+                .WithFeature("SharedFeature")
+                .WithConfiguration("Key", "Value"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        _ = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert - original instance should not be mutated
+        Assert.Equal(["Feature1"], originalSettings.EnabledFeatures);
+        Assert.Empty(originalSettings.ConfigurationData);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_FeatureConfiguratorsDoNotCompound()
+    {
+        // Arrange
+        var callCount = 0;
+        var services = new ServiceCollection();
+        var providerShells = new List<ShellSettings>
+        {
+            new(new ShellId("Shell1"), ["Feature1"])
+        };
+
+        services.AddCShells(shells =>
+        {
+            shells.WithProvider(new InMemoryShellSettingsProvider(providerShells));
+            shells.ConfigureAllShells(shell => shell.WithFeature<TestFeature>(f => callCount++));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act - call GetShellSettingsAsync multiple times
+        var firstResult = (await provider.GetShellSettingsAsync()).ToList();
+        var secondResult = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert - each call's settings should have exactly one configurator, not compounded
+        var firstConfigurator = firstResult.Single().FeatureConfigurators;
+        var secondConfigurator = secondResult.Single().FeatureConfigurators;
+
+        Assert.Single(firstConfigurator);
+        Assert.Single(secondConfigurator);
+
+        // Invoke both configurators to verify they each call once
+        callCount = 0;
+        firstConfigurator[nameof(TestFeature)].Invoke(new TestFeature());
+        Assert.Equal(1, callCount);
+
+        callCount = 0;
+        secondConfigurator[nameof(TestFeature)].Invoke(new TestFeature());
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_MultipleConfiguratorsApplyInOrder()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.AddShell("Shell1", shell => shell.WithFeature("Feature1"));
+            shells.ConfigureAllShells(shell => shell.WithConfiguration("Key", "First"));
+            shells.ConfigureAllShells(shell => shell.WithConfiguration("Key", "Second"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = (await provider.GetShellSettingsAsync()).ToList();
+
+        // Assert - last configurator wins
+        Assert.Equal("Second", settings.Single().ConfigurationData["Key"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_AppliesViaGetShellSettingsByIdToo()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.AddShell("Shell1", shell => shell.WithFeature("Feature1"));
+            shells.ConfigureAllShells(shell => shell.WithFeature("SharedFeature"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = await provider.GetShellSettingsAsync(new ShellId("Shell1"));
+
+        // Assert
+        Assert.NotNull(settings);
+        Assert.Contains("Feature1", settings.EnabledFeatures);
+        Assert.Contains("SharedFeature", settings.EnabledFeatures);
+    }
+
+    [Fact]
+    public async Task ConfigureAllShells_GetShellSettingsById_ReturnsNullForMissingShell()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddCShells(shells =>
+        {
+            shells.AddShell("Shell1", shell => shell.WithFeature("Feature1"));
+            shells.ConfigureAllShells(shell => shell.WithFeature("SharedFeature"));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetRequiredService<IShellSettingsProvider>();
+
+        // Act
+        var settings = await provider.GetShellSettingsAsync(new ShellId("NonExistent"));
+
+        // Assert
+        Assert.Null(settings);
+    }
+
+    [ShellFeature(nameof(TestFeature))]
+    private class TestFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+    }
+}


### PR DESCRIPTION
- Introduce `ConfiguringShellSettingsProvider` to apply configurators to all `ShellSettings` returned by inner providers.
- Enhance `CShellsBuilder` with `ConfigureAllShells` to allow base configuration for all shells.
- Update `ServiceCollectionExtensions` to utilize `ConfiguringShellSettingsProvider` when shell configurators are present.
- Add new constructor in `ShellBuilder` for direct mutations on existing `ShellSettings`.
