### PR TITLE
Defer shell context disposal until in-flight request scopes complete

### DIFF
--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -79,6 +79,12 @@ public class ShellMiddleware(
 
         var shellContext = _host.GetShell(shellId.Value);
 
+        // Acquire a scope handle so that DefaultShellHost can defer disposal of this shell
+        // context if it is replaced (e.g. via a reload) while this request is still in flight.
+        // The handle is released via `await using` after _next returns (i.e. after the response
+        // has been written), at which point the old provider can be safely disposed.
+        await using var scopeHandle = _host.AcquireContextScope(shellContext);
+
         var scope = shellContext.ServiceProvider.CreateScope();
         context.RequestServices = scope.ServiceProvider;
 

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -81,15 +81,22 @@ public class ShellMiddleware(
 
         // Acquire a scope handle so that DefaultShellHost can defer disposal of this shell
         // context if it is replaced (e.g. via a reload) while this request is still in flight.
-        // The handle is released via `await using` after _next returns (i.e. after the response
-        // has been written), at which point the old provider can be safely disposed.
-        await using var scopeHandle = _host.AcquireContextScope(shellContext);
+        //
+        // The handle is released via OnCompleted (not `await using`) so that it outlives
+        // InvokeAsync returning. This matters because upstream middleware may do post-processing
+        // after awaiting _next that still reads from context.RequestServices — releasing the
+        // handle at InvokeAsync return could dispose the root provider prematurely and cause
+        // ObjectDisposedException in that post-processing code or in OnCompleted callbacks.
+        var scopeHandle = _host.AcquireContextScope(shellContext);
+        context.Response.OnCompleted(() => scopeHandle.DisposeAsync().AsTask());
 
         var scope = shellContext.ServiceProvider.CreateScope();
         context.RequestServices = scope.ServiceProvider;
 
-        // Register the scope for disposal when the request completes
-        // This ensures the scope lives for the entire request, including endpoint execution
+        // Register the scope for disposal when the request completes.
+        // This ensures the scope lives for the entire request, including endpoint execution.
+        // Fires after OnCompleted, so the root provider disposal (triggered by the scope handle
+        // above) always precedes the request scope's own cleanup.
         context.Response.RegisterForDispose(scope);
 
         await _next(context);

--- a/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
+++ b/src/CShells.AspNetCore/Resolution/WebRoutingShellResolver.cs
@@ -204,6 +204,14 @@ public class WebRoutingShellResolver : IShellResolverStrategy
             return ValueTask.CompletedTask;
         }
 
+        public IAsyncDisposable AcquireContextScope(ShellContext context) => NoOpDisposable.Instance;
+
+        private sealed class NoOpDisposable : IAsyncDisposable
+        {
+            public static readonly NoOpDisposable Instance = new();
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+
         private IReadOnlyCollection<ShellContext> GetAllShells()
         {
             lock (allShellsLock)

--- a/src/CShells/Hosting/DefaultShellHost.cs
+++ b/src/CShells/Hosting/DefaultShellHost.cs
@@ -347,7 +347,7 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
 
         if (commit.PreviousContext is not null && !ReferenceEquals(commit.PreviousContext, candidate.CandidateContext))
         {
-            await DisposeShellContextAsync(commit.PreviousContext).ConfigureAwait(false);
+            await DisposeOrDeferContextAsync(commit.PreviousContext).ConfigureAwait(false);
         }
     }
 
@@ -368,7 +368,7 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
 
         if (result.PreviousContext is not null)
         {
-            await DisposeShellContextAsync(result.PreviousContext).ConfigureAwait(false);
+            await DisposeOrDeferContextAsync(result.PreviousContext).ConfigureAwait(false);
         }
     }
 
@@ -709,6 +709,41 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
             _logger.LogDebug("Evicting cached shell context for '{ShellId}'", context.Settings.Id);
             await DisposeShellContextAsync(context).ConfigureAwait(false);
         }
+    }
+
+    /// <inheritdoc/>
+    public IAsyncDisposable AcquireContextScope(ShellContext context)
+        => new ShellContextScopeHandle(context, this);
+
+    /// <summary>
+    /// Disposes <paramref name="context"/> immediately if no active request scopes are using it,
+    /// otherwise marks it for deferred disposal. The last scope handle to release will dispose it
+    /// via <see cref="TryDisposePendingContextAsync"/>.
+    /// </summary>
+    private async ValueTask DisposeOrDeferContextAsync(ShellContext context)
+    {
+        if (context.ActiveScopes == 0)
+        {
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        context.MarkPendingDisposal();
+
+        // Double-check: all scopes may have released between the ActiveScopes check above and
+        // MarkPendingDisposal(). If so, we must dispose now since no scope handle will do it.
+        if (context.ActiveScopes == 0)
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Disposes <paramref name="context"/> if it is pending disposal and has no active scopes.
+    /// Called by <see cref="ShellContextScopeHandle"/> when the last scope releases.
+    /// </summary>
+    internal async ValueTask TryDisposePendingContextAsync(ShellContext context)
+    {
+        if (context.IsPendingDisposal && context.ActiveScopes == 0)
+            await DisposeShellContextAsync(context).ConfigureAwait(false);
     }
 
     private async ValueTask DisposeShellContextAsync(ShellContext context)

--- a/src/CShells/Hosting/DefaultShellHost.cs
+++ b/src/CShells/Hosting/DefaultShellHost.cs
@@ -720,19 +720,39 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// otherwise marks it for deferred disposal. The last scope handle to release will dispose it
     /// via <see cref="TryDisposePendingContextAsync"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why deferred disposal?</b> When a shell is reloaded its new <see cref="IServiceProvider"/>
+    /// is committed while the HTTP request that triggered the reload is still executing inside the
+    /// old shell's DI scope. Disposing the old root provider synchronously would invalidate all
+    /// outstanding child scopes immediately, causing <see cref="ObjectDisposedException"/> when the
+    /// endpoint tries to serialize its response. We instead defer disposal until every in-flight
+    /// request scope (tracked by <see cref="ShellContextScopeHandle"/>) has released.
+    /// </para>
+    /// <para>
+    /// <b>Double-check pattern:</b> there is a narrow race between the initial
+    /// <c>ActiveScopes == 0</c> check and <see cref="ShellContext.MarkPendingDisposal"/>. If the
+    /// last scope releases in that window it would see <c>IsPendingDisposal == false</c> and skip
+    /// disposal; the second check below catches this. <see cref="ShellContext.TryBeginDispose"/>
+    /// ensures only one caller wins even if both paths fire concurrently.
+    /// </para>
+    /// </remarks>
     private async ValueTask DisposeOrDeferContextAsync(ShellContext context)
     {
         if (context.ActiveScopes == 0)
         {
-            await DisposeShellContextAsync(context).ConfigureAwait(false);
+            if (context.TryBeginDispose())
+                await DisposeShellContextAsync(context).ConfigureAwait(false);
             return;
         }
 
         context.MarkPendingDisposal();
 
         // Double-check: all scopes may have released between the ActiveScopes check above and
-        // MarkPendingDisposal(). If so, we must dispose now since no scope handle will do it.
-        if (context.ActiveScopes == 0)
+        // MarkPendingDisposal(). If so, we must dispose now — no scope handle will do it.
+        // TryBeginDispose() ensures we don't double-dispose if ShellContextScopeHandle wins the
+        // race and calls TryDisposePendingContextAsync at the same instant.
+        if (context.ActiveScopes == 0 && context.TryBeginDispose())
             await DisposeShellContextAsync(context).ConfigureAwait(false);
     }
 
@@ -742,7 +762,7 @@ public class DefaultShellHost : IShellHost, IShellHostInitializer, IAsyncDisposa
     /// </summary>
     internal async ValueTask TryDisposePendingContextAsync(ShellContext context)
     {
-        if (context.IsPendingDisposal && context.ActiveScopes == 0)
+        if (context.IsPendingDisposal && context.ActiveScopes == 0 && context.TryBeginDispose())
             await DisposeShellContextAsync(context).ConfigureAwait(false);
     }
 

--- a/src/CShells/Hosting/IShellHost.cs
+++ b/src/CShells/Hosting/IShellHost.cs
@@ -37,4 +37,22 @@ public interface IShellHost
     /// The next access to any shell will rebuild it from the latest shell settings.
     /// </summary>
     ValueTask EvictAllShellsAsync();
+
+    /// <summary>
+    /// Acquires a scope tracking handle for the specified shell context.
+    /// The handle must be disposed (via <c>await using</c>) when the scope ends so that the host
+    /// can safely defer disposal of shells that are replaced while request scopes are still active.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation is a no-op. <see cref="DefaultShellHost"/> overrides this to
+    /// implement deferred disposal: when a shell is reloaded, its old <see cref="IServiceProvider"/>
+    /// is not disposed until all outstanding scope handles have been released.
+    /// </remarks>
+    IAsyncDisposable AcquireContextScope(ShellContext context) => NoOpAsyncDisposable.Instance;
+
+    private sealed class NoOpAsyncDisposable : IAsyncDisposable
+    {
+        public static readonly NoOpAsyncDisposable Instance = new();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 }

--- a/src/CShells/Hosting/IShellHost.cs
+++ b/src/CShells/Hosting/IShellHost.cs
@@ -40,19 +40,8 @@ public interface IShellHost
 
     /// <summary>
     /// Acquires a scope tracking handle for the specified shell context.
-    /// The handle must be disposed (via <c>await using</c>) when the scope ends so that the host
-    /// can safely defer disposal of shells that are replaced while request scopes are still active.
+    /// The handle must be disposed when the scope ends so that the host can safely defer disposal
+    /// of shells that are replaced while request scopes are still active.
     /// </summary>
-    /// <remarks>
-    /// The default implementation is a no-op. <see cref="DefaultShellHost"/> overrides this to
-    /// implement deferred disposal: when a shell is reloaded, its old <see cref="IServiceProvider"/>
-    /// is not disposed until all outstanding scope handles have been released.
-    /// </remarks>
-    IAsyncDisposable AcquireContextScope(ShellContext context) => NoOpAsyncDisposable.Instance;
-
-    private sealed class NoOpAsyncDisposable : IAsyncDisposable
-    {
-        public static readonly NoOpAsyncDisposable Instance = new();
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-    }
+    IAsyncDisposable AcquireContextScope(ShellContext context);
 }

--- a/src/CShells/Hosting/ShellContext.cs
+++ b/src/CShells/Hosting/ShellContext.cs
@@ -8,6 +8,11 @@ public class ShellContext(ShellSettings settings, IServiceProvider serviceProvid
     private int _activeScopes;
     private volatile bool _pendingDisposal;
 
+    // CAS flag that ensures DisposeShellContextAsync is entered by at most one caller even when
+    // both DisposeOrDeferContextAsync (double-check path) and ShellContextScopeHandle.DisposeAsync
+    // race to trigger disposal in the same narrow window. 0 = not yet disposing, 1 = disposing.
+    private int _disposing;
+
     /// <summary>
     /// Gets the shell settings.
     /// </summary>
@@ -64,4 +69,19 @@ public class ShellContext(ShellSettings settings, IServiceProvider serviceProvid
     /// <see cref="ActiveScopes"/> reaches zero.
     /// </summary>
     internal void MarkPendingDisposal() => _pendingDisposal = true;
+
+    /// <summary>
+    /// Atomically claims the right to dispose this context. Returns <see langword="true"/> exactly
+    /// once across all concurrent callers; all subsequent calls return <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Used to prevent double-disposal in the race where both
+    /// <c>DisposeOrDeferContextAsync</c> (the double-check path) and
+    /// <c>ShellContextScopeHandle.DisposeAsync</c> determine simultaneously that
+    /// <see cref="ActiveScopes"/> has reached zero. <see cref="IServiceProvider"/> disposal is
+    /// idempotent in .NET, so double-disposal would not crash, but this keeps the code clean and
+    /// avoids spurious <see cref="ObjectDisposedException"/> log warnings.
+    /// </remarks>
+    internal bool TryBeginDispose() =>
+        Interlocked.CompareExchange(ref _disposing, 1, 0) == 0;
 }

--- a/src/CShells/Hosting/ShellContext.cs
+++ b/src/CShells/Hosting/ShellContext.cs
@@ -5,6 +5,9 @@ namespace CShells.Hosting;
 /// </summary>
 public class ShellContext(ShellSettings settings, IServiceProvider serviceProvider, IReadOnlyList<string> enabledFeatures, IReadOnlyCollection<string>? missingFeatures = null)
 {
+    private int _activeScopes;
+    private volatile bool _pendingDisposal;
+
     /// <summary>
     /// Gets the shell settings.
     /// </summary>
@@ -38,4 +41,27 @@ public class ShellContext(ShellSettings settings, IServiceProvider serviceProvid
     /// when this shell was built. Empty when all configured features were available.
     /// </summary>
     public IReadOnlyCollection<string> MissingFeatures { get; } = missingFeatures ?? [];
+
+    /// <summary>
+    /// Gets the number of active request scopes currently using this shell context.
+    /// </summary>
+    internal int ActiveScopes => Volatile.Read(ref _activeScopes);
+
+    /// <summary>
+    /// Gets whether this context has been marked for deferred disposal once all active scopes release.
+    /// </summary>
+    internal bool IsPendingDisposal => _pendingDisposal;
+
+    internal void IncrementActiveScopes() => Interlocked.Increment(ref _activeScopes);
+
+    /// <summary>
+    /// Decrements the active scope counter and returns the new count.
+    /// </summary>
+    internal int DecrementActiveScopes() => Interlocked.Decrement(ref _activeScopes);
+
+    /// <summary>
+    /// Marks this context for deferred disposal. The actual disposal will happen when
+    /// <see cref="ActiveScopes"/> reaches zero.
+    /// </summary>
+    internal void MarkPendingDisposal() => _pendingDisposal = true;
 }

--- a/src/CShells/Hosting/ShellContextScopeHandle.cs
+++ b/src/CShells/Hosting/ShellContextScopeHandle.cs
@@ -5,10 +5,26 @@ namespace CShells.Hosting;
 /// <see cref="DefaultShellHost"/> can defer disposal of replaced shell contexts until all
 /// in-flight request scopes have completed.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Lifecycle:</b> the constructor increments <see cref="ShellContext.ActiveScopes"/> and
+/// <see cref="DisposeAsync"/> decrements it. <see cref="DefaultShellHost"/> uses the counter to
+/// decide whether it can dispose a replaced shell context immediately or must defer until the
+/// last outstanding handle is released.
+/// </para>
+/// <para>
+/// <b>Usage:</b> always consumed via <c>await using</c> in <see cref="ShellMiddleware"/>, which
+/// guarantees <see cref="DisposeAsync"/> is called on every exit path (normal, exception, or
+/// cancellation). The <c>_released</c> guard below defends against the theoretical case of manual
+/// double-dispose, which would otherwise corrupt the counter and prevent the old context from ever
+/// being disposed.
+/// </para>
+/// </remarks>
 internal sealed class ShellContextScopeHandle : IAsyncDisposable
 {
     private readonly ShellContext _context;
     private readonly DefaultShellHost _host;
+    private int _released; // 0 = active, 1 = released; guards against double-dispose
 
     internal ShellContextScopeHandle(ShellContext context, DefaultShellHost host)
     {
@@ -19,6 +35,12 @@ internal sealed class ShellContextScopeHandle : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Guard against double-dispose: each handle must decrement the counter exactly once.
+        // With `await using` this never fires in practice, but protects the counter if the handle
+        // is ever disposed manually more than once.
+        if (Interlocked.Exchange(ref _released, 1) != 0)
+            return;
+
         var remaining = _context.DecrementActiveScopes();
         if (remaining == 0 && _context.IsPendingDisposal)
             await _host.TryDisposePendingContextAsync(_context).ConfigureAwait(false);

--- a/src/CShells/Hosting/ShellContextScopeHandle.cs
+++ b/src/CShells/Hosting/ShellContextScopeHandle.cs
@@ -1,0 +1,26 @@
+namespace CShells.Hosting;
+
+/// <summary>
+/// Tracks an active request scope against a <see cref="ShellContext"/> so that
+/// <see cref="DefaultShellHost"/> can defer disposal of replaced shell contexts until all
+/// in-flight request scopes have completed.
+/// </summary>
+internal sealed class ShellContextScopeHandle : IAsyncDisposable
+{
+    private readonly ShellContext _context;
+    private readonly DefaultShellHost _host;
+
+    internal ShellContextScopeHandle(ShellContext context, DefaultShellHost host)
+    {
+        _context = context;
+        _host = host;
+        _context.IncrementActiveScopes();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var remaining = _context.DecrementActiveScopes();
+        if (remaining == 0 && _context.IsPendingDisposal)
+            await _host.TryDisposePendingContextAsync(_context).ConfigureAwait(false);
+    }
+}

--- a/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ApplicationBuilderExtensionsTests.cs
@@ -151,6 +151,13 @@ public class ApplicationBuilderExtensionsTests
         public ShellContext GetShell(ShellId id) => throw new KeyNotFoundException();
         public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
         public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
+        public IAsyncDisposable AcquireContextScope(ShellContext context) => NoOpDisposable.Instance;
+
+        private sealed class NoOpDisposable : IAsyncDisposable
+        {
+            public static readonly NoOpDisposable Instance = new();
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
     }
 
     [ShellFeature("TestWeb")]

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -291,6 +291,13 @@ public class ShellMiddlewareTests
 
         public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
         public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
+        public virtual IAsyncDisposable AcquireContextScope(ShellContext context) => NoOpDisposable.Instance;
+
+        private sealed class NoOpDisposable : IAsyncDisposable
+        {
+            public static readonly NoOpDisposable Instance = new();
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
     }
 
     /// <summary>
@@ -298,9 +305,9 @@ public class ShellMiddlewareTests
     /// to use the real active-scope counter on <see cref="ShellContext"/>, letting tests observe
     /// when the scope handle is acquired and released.
     /// </summary>
-    private sealed class TrackingShellHost(ShellContext? shellContext = null) : TestShellHost(shellContext), IShellHost
+    private sealed class TrackingShellHost(ShellContext? shellContext = null) : TestShellHost(shellContext)
     {
-        IAsyncDisposable IShellHost.AcquireContextScope(ShellContext context)
+        public override IAsyncDisposable AcquireContextScope(ShellContext context)
         {
             context.IncrementActiveScopes();
             return new ScopeHandle(context);

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -2,6 +2,7 @@ using CShells.AspNetCore.Middleware;
 using CShells.Hosting;
 using CShells.Resolution;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -194,6 +195,54 @@ public class ShellMiddlewareTests
         // Note: We can't directly test disposal, but the test verifies the exception is properly propagated
     }
 
+    [Fact(DisplayName = "InvokeAsync acquires a context scope that is active during the request and released at response completion")]
+    public async Task InvokeAsync_AcquiresContextScope_HeldDuringRequestReleasedAtResponseCompletion()
+    {
+        // Arrange
+        var shellServices = new ServiceCollection();
+        var shellServiceProvider = shellServices.BuildServiceProvider();
+        var settings = new ShellSettings(new("TestShell"));
+        var shellContext = new ShellContext(settings, shellServiceProvider, Array.Empty<string>());
+
+        var host = new TrackingShellHost(shellContext);
+        int activeScopesDuringNext = -1;
+
+        // Inject a custom response feature that captures OnCompleted callbacks so we can
+        // fire them on demand, simulating what the ASP.NET Core server does after the
+        // response is sent. DefaultHttpContext has no built-in mechanism for this in tests.
+        var httpContext = new DefaultHttpContext();
+        var responseFeature = new FireableResponseFeature();
+        httpContext.Features.Set<IHttpResponseFeature>(responseFeature);
+
+        var middleware = CreateMiddleware(
+            ctx =>
+            {
+                // Capture the counter while inside _next — the scope must be active here.
+                activeScopesDuringNext = shellContext.ActiveScopes;
+                return Task.CompletedTask;
+            },
+            new FixedShellResolver(new("TestShell")),
+            host);
+
+        // Act
+        await middleware.InvokeAsync(httpContext);
+
+        // Assert — scope was held while _next executed.
+        Assert.Equal(1, activeScopesDuringNext);
+
+        // After InvokeAsync returns but before OnCompleted fires, the handle must still be active.
+        // (In a real server OnCompleted fires after all middleware return. In tests it does not
+        // fire automatically, so the counter stays at 1 here — proving the handle is NOT released
+        // at middleware return but deferred to request completion.)
+        Assert.Equal(1, shellContext.ActiveScopes);
+
+        // Simulate the server firing OnCompleted callbacks.
+        await responseFeature.FireOnCompletedAsync();
+
+        // Now the scope must be released.
+        Assert.Equal(0, shellContext.ActiveScopes);
+    }
+
     [Theory(DisplayName = "Constructor guard clauses throw ArgumentNullException")]
     [InlineData(true, false, false, false, false, "next")]
     [InlineData(false, true, false, false, false, "resolver")]
@@ -242,5 +291,52 @@ public class ShellMiddlewareTests
 
         public ValueTask EvictShellAsync(ShellId shellId) => ValueTask.CompletedTask;
         public ValueTask EvictAllShellsAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// A <see cref="TestShellHost"/> that overrides <see cref="IShellHost.AcquireContextScope"/>
+    /// to use the real active-scope counter on <see cref="ShellContext"/>, letting tests observe
+    /// when the scope handle is acquired and released.
+    /// </summary>
+    private sealed class TrackingShellHost(ShellContext? shellContext = null) : TestShellHost(shellContext), IShellHost
+    {
+        IAsyncDisposable IShellHost.AcquireContextScope(ShellContext context)
+        {
+            context.IncrementActiveScopes();
+            return new ScopeHandle(context);
+        }
+
+        private sealed class ScopeHandle(ShellContext context) : IAsyncDisposable
+        {
+            private int _released;
+
+            public ValueTask DisposeAsync()
+            {
+                if (Interlocked.Exchange(ref _released, 1) != 0)
+                    return ValueTask.CompletedTask;
+                context.DecrementActiveScopes();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A custom <see cref="IHttpResponseFeature"/> that captures <c>OnCompleted</c> callbacks
+    /// so tests can fire them on demand, simulating what the ASP.NET Core server does after
+    /// the response is sent. <see cref="DefaultHttpContext"/> has no built-in mechanism to
+    /// trigger these callbacks outside of a running server.
+    /// </summary>
+    private sealed class FireableResponseFeature : HttpResponseFeature
+    {
+        private readonly List<(Func<object, Task> Callback, object State)> _onCompleted = new();
+
+        public override void OnCompleted(Func<object, Task> callback, object state)
+            => _onCompleted.Add((callback, state));
+
+        public async Task FireOnCompletedAsync()
+        {
+            foreach (var (callback, state) in _onCompleted)
+                await callback(state);
+        }
     }
 }

--- a/tests/CShells.Tests/Unit/Hosting/DeferredShellContextDisposalTests.cs
+++ b/tests/CShells.Tests/Unit/Hosting/DeferredShellContextDisposalTests.cs
@@ -1,0 +1,214 @@
+using System.Reflection;
+using CShells.Configuration;
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Management;
+using CShells.Notifications;
+using CShells.Tests.Integration.ShellHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CShells.Tests.Unit.Hosting;
+
+/// <summary>
+/// Tests for deferred shell context disposal:
+/// when a shell is reloaded, its old <see cref="IServiceProvider"/> must not be disposed
+/// while in-flight request scopes are still active (tracked via <see cref="IShellHost.AcquireContextScope"/>).
+/// </summary>
+public class DeferredShellContextDisposalTests
+{
+    // -------------------------------------------------------------------------
+    // Immediate disposal (no active scopes)
+    // -------------------------------------------------------------------------
+
+    [Fact(DisplayName = "ReloadAll disposes old context immediately when no scope handle is active")]
+    public async Task ReloadAll_WithNoActiveScope_DisposesOldContextImmediately()
+    {
+        var shellId = new ShellId("Shell");
+        var runtime = CreateRuntime(shellId, ["Core"]);
+        await runtime.Manager.InitializeRuntimeAsync();
+
+        var oldProvider = runtime.Host.GetShell(shellId).ServiceProvider;
+
+        await runtime.Manager.ReloadAllShellsAsync();
+
+        Assert.True(IsDisposed(oldProvider),
+            "Old provider should be disposed immediately when no scope handle is active.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Deferred disposal (active scope present)
+    // -------------------------------------------------------------------------
+
+    [Fact(DisplayName = "ReloadAll defers old context disposal while a scope handle is active")]
+    public async Task ReloadAll_WithActiveScopeHandle_DefersOldContextDisposal()
+    {
+        var shellId = new ShellId("Shell");
+        var runtime = CreateRuntime(shellId, ["Core"]);
+        await runtime.Manager.InitializeRuntimeAsync();
+
+        var oldContext = runtime.Host.GetShell(shellId);
+
+        // Simulate an in-flight request that holds a scope on the old context.
+        var scopeHandle = runtime.Host.AcquireContextScope(oldContext);
+
+        await runtime.Manager.ReloadAllShellsAsync();
+
+        // Old provider must NOT be disposed while the scope is still active.
+        Assert.False(IsDisposed(oldContext.ServiceProvider),
+            "Old provider must not be disposed while an active scope handle exists.");
+
+        // Releasing the last scope should trigger the deferred disposal.
+        await scopeHandle.DisposeAsync();
+
+        Assert.True(IsDisposed(oldContext.ServiceProvider),
+            "Old provider should be disposed after the last scope handle is released.");
+    }
+
+    [Fact(DisplayName = "ReloadAll defers disposal until all scope handles are released")]
+    public async Task ReloadAll_WithTwoScopeHandles_DisposesAfterBothRelease()
+    {
+        var shellId = new ShellId("Shell");
+        var runtime = CreateRuntime(shellId, ["Core"]);
+        await runtime.Manager.InitializeRuntimeAsync();
+
+        var oldContext = runtime.Host.GetShell(shellId);
+
+        var handle1 = runtime.Host.AcquireContextScope(oldContext);
+        var handle2 = runtime.Host.AcquireContextScope(oldContext);
+
+        await runtime.Manager.ReloadAllShellsAsync();
+
+        Assert.False(IsDisposed(oldContext.ServiceProvider));
+
+        // First handle releases — second still active, must not dispose yet.
+        await handle1.DisposeAsync();
+        Assert.False(IsDisposed(oldContext.ServiceProvider),
+            "Old provider must not be disposed while a second scope handle is still active.");
+
+        // Second handle releases — disposal should fire.
+        await handle2.DisposeAsync();
+        Assert.True(IsDisposed(oldContext.ServiceProvider));
+    }
+
+    // -------------------------------------------------------------------------
+    // Double-dispose guard on ShellContextScopeHandle
+    // -------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Double-disposing a scope handle does not corrupt the active-scope counter")]
+    public async Task DoubleDisposeScopeHandle_DoesNotCorruptActiveScopeCounter()
+    {
+        var shellId = new ShellId("Shell");
+        var runtime = CreateRuntime(shellId, ["Core"]);
+        await runtime.Manager.InitializeRuntimeAsync();
+
+        var oldContext = runtime.Host.GetShell(shellId);
+        var handle = runtime.Host.AcquireContextScope(oldContext);
+
+        await runtime.Manager.ReloadAllShellsAsync();
+
+        // Dispose twice — the guard in ShellContextScopeHandle must prevent double-decrement.
+        await handle.DisposeAsync();
+        await handle.DisposeAsync();
+
+        // Counter must be exactly 0, not -1.
+        Assert.Equal(0, oldContext.ActiveScopes);
+
+        // Provider must have been disposed exactly once (not throw on the second DisposeAsync call).
+        Assert.True(IsDisposed(oldContext.ServiceProvider));
+    }
+
+    // -------------------------------------------------------------------------
+    // RemoveShell also defers disposal
+    // -------------------------------------------------------------------------
+
+    [Fact(DisplayName = "RemoveShell defers old context disposal while a scope handle is active")]
+    public async Task RemoveShell_WithActiveScopeHandle_DefersOldContextDisposal()
+    {
+        var shellId = new ShellId("Shell");
+        var runtime = CreateRuntime(shellId, ["Core"]);
+        await runtime.Manager.InitializeRuntimeAsync();
+
+        var oldContext = runtime.Host.GetShell(shellId);
+        var scopeHandle = runtime.Host.AcquireContextScope(oldContext);
+
+        await runtime.Manager.RemoveShellAsync(shellId);
+
+        Assert.False(IsDisposed(oldContext.ServiceProvider),
+            "Old provider must not be disposed while an active scope handle exists.");
+
+        await scopeHandle.DisposeAsync();
+
+        Assert.True(IsDisposed(oldContext.ServiceProvider));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the provider has been disposed.
+    /// A disposed <see cref="ServiceProvider"/> throws <see cref="ObjectDisposedException"/>
+    /// on any <c>GetService</c> call.
+    /// </summary>
+    private static bool IsDisposed(IServiceProvider provider)
+    {
+        try
+        {
+            provider.GetService(typeof(IDisposable));
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    private static TestRuntime CreateRuntime(ShellId shellId, IEnumerable<string> features)
+    {
+        var initialSettings = new ShellSettings(shellId, features.ToArray());
+        var provider = new MutableInMemoryShellSettingsProvider([initialSettings]);
+        var cache = new ShellSettingsCache();
+        cache.Load([initialSettings]);
+
+        var (services, rootProvider) = TestFixtures.CreateRootServices();
+        var accessor = TestFixtures.CreateRootServicesAccessor(services);
+        var featureFactory = new DefaultShellFeatureFactory(rootProvider);
+        var exclusionRegistry = new ShellServiceExclusionRegistry([]);
+        var stateStore = new ShellRuntimeStateStore();
+        var runtimeCatalog = new RuntimeFeatureCatalog(
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+
+        var host = new DefaultShellHost(
+            cache,
+            _ => Task.FromResult<IReadOnlyCollection<Assembly>>([typeof(TestFixtures).Assembly]),
+            rootProvider,
+            accessor,
+            featureFactory,
+            exclusionRegistry,
+            seedDesiredStateFromCache: true,
+            runtimeFeatureCatalog: runtimeCatalog,
+            runtimeStateStore: stateStore,
+            notificationPublisher: new SilentNotificationPublisher(),
+            logger: NullLogger<DefaultShellHost>.Instance);
+
+        var accessorService = new ShellRuntimeStateAccessor(stateStore);
+        var manager = new DefaultShellManager(
+            host, cache, provider, stateStore, runtimeCatalog, accessorService,
+            new SilentNotificationPublisher(), NullLogger<DefaultShellManager>.Instance);
+
+        return new(host, manager);
+    }
+
+    private sealed record TestRuntime(DefaultShellHost Host, DefaultShellManager Manager);
+
+    private sealed class SilentNotificationPublisher : INotificationPublisher
+    {
+        public Task PublishAsync<TNotification>(
+            TNotification notification,
+            INotificationStrategy? strategy = null,
+            CancellationToken cancellationToken = default) where TNotification : class, INotification
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Problem

When a shell reload is triggered via `ReloadAllShellsAsync`, `DefaultShellHost.CommitCandidateAsync` disposed the old shell's root `IServiceProvider` **synchronously** — even if an active HTTP request was still executing within that shell (e.g. the reload endpoint itself trying to serialize its response).

This caused an `ObjectDisposedException` because .NET's `ServiceProvider.GetService(Type, Scope)` checks the root's `_disposed` flag before any resolution, including from child scopes that haven't been disposed yet.

The failure was only observed in Docker/Production (where Nuplane packages are loaded and real per-shell DI containers are built) and not locally (where no packages are loaded and `ShellMiddleware` falls through to the host service provider, which is never disposed).

## Root Cause

```
System.ObjectDisposedException: Cannot access a disposed object. Object name: 'IServiceProvider'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, ...)
   at Elsa.Common.Serialization.ConfigurableSerializer.CreateInstance[T]()   ← uses disposed root provider
   at Elsa.Shells.Api.Endpoints.Shells.ReloadAll.ReloadAll.SendResponseAsync(...)
   at Elsa.Shells.Api.Endpoints.Shells.ReloadAll.ReloadAll.HandleAsync(...)
   at CShells.AspNetCore.Middleware.ShellMiddleware.InvokeAsync(HttpContext context)
```

`ReloadAll.HandleAsync` calls `ReloadAllShellsAsync` (which disposes the old shell's root provider), then tries to serialize the response using `ApiSerializer` — which holds a captured reference to that now-disposed root provider.

## Fix

Introduce **active-scope tracking** on `ShellContext` so that `DefaultShellHost` can defer disposal of a replaced context until all outstanding request scopes have released.

### Changed files

| File | Change |
|---|---|
| `ShellContext.cs` | Internal active-scope counter and `IsPendingDisposal` flag |
| `IShellHost.cs` | New `AcquireContextScope(ShellContext)` with a default no-op (backward compatible) |
| `ShellContextScopeHandle.cs` | New — increments counter on creation, decrements on `DisposeAsync`, triggers deferred disposal when last scope releases |
| `DefaultShellHost.cs` | Implements `AcquireContextScope`; replaces direct `DisposeShellContextAsync` calls with `DisposeOrDeferContextAsync` in both `CommitCandidateAsync` and `RemoveAppliedRuntimeAsync` |
| `ShellMiddleware.cs` | Wraps each request in `await using var scopeHandle = _host.AcquireContextScope(shellContext)`, released after `_next()` returns |

### Disposal sequence after fix

1. Reload endpoint calls `ReloadAllShellsAsync`
2. `CommitCandidateAsync` sees `ActiveScopes > 0` → marks context pending, does not dispose
3. `SendResponseAsync` succeeds — root provider is still alive
4. `_next(context)` returns in `ShellMiddleware`
5. `await using` releases `scopeHandle` → last scope drops to 0 → old root provider is disposed
6. Kestrel flushes response and fires `RegisterForDispose` items — safe since scope disposal doesn't re-resolve from the root

### Backward compatibility

`IShellHost.AcquireContextScope` has a default no-op implementation, so existing `IShellHost` implementations compile without changes.

## Test plan

- [x] All 399 existing unit tests pass (`dotnet test`)
- [ ] Verify `POST /elsa/api/shells/reload` returns 200 OK when running via Docker