### PR TITLE
Harden configuration feature normalization

### DIFF
--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -33,11 +33,14 @@ The `Features` property supports an object-map syntax where each property key is
 
 Features with no settings use an empty object `{}`. All properties within a feature's object are treated as settings — there is no special `Name` property since the object key serves as the feature name.
 
+Do not repeat the feature name inside an object-map entry. If a `Name` property is present there, it is delivered to the feature as configuration and does not rename, enable, disable, or replace the feature identified by the object key.
+
 ### Validation Rules
 
 - **No duplicates**: Each feature name must appear exactly once per shell.
 - **No mixing**: A shell's `Features` value must be entirely array syntax or entirely object-map syntax. Mixing both styles is rejected with an error that identifies the affected shell.
 - **Values must be objects**: In object-map syntax, every feature value must be a JSON object (not a string, number, or array).
+- **No silent skips**: Blank array entries and array objects with missing or blank `Name` values are rejected before the shell is activated.
 
 ## Inline Configuration (Array Syntax)
 
@@ -61,6 +64,28 @@ Each entry in the `Features` array can be either a string (feature name) or an o
   }
 }
 ```
+
+For compatibility with older configuration, array objects may also place settings under a `Settings` wrapper:
+
+```json
+{
+  "CShells": {
+    "Shells": [
+      {
+        "Name": "Default",
+        "Features": [
+          {
+            "Name": "Analytics",
+            "Settings": { "TopPostsCount": 10 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Do not mix the `Settings` wrapper with direct sibling settings in the same feature entry.
 
 ### Consuming Inline Settings
 

--- a/specs/002-feature-object-map/contracts/feature-configuration-contract.md
+++ b/specs/002-feature-object-map/contracts/feature-configuration-contract.md
@@ -26,6 +26,17 @@ The behavior applies to:
 }
 ```
 
+Array object entries may also use a legacy `Settings` wrapper:
+
+```json
+{
+  "Name": "Default",
+  "Features": [
+    { "Name": "Analytics", "Settings": { "TopPostsCount": 10 } }
+  ]
+}
+```
+
 ### Object-Map Form
 
 ```json
@@ -44,9 +55,11 @@ The behavior applies to:
 - Array entries normalize into feature definitions in array order.
 - Object-map entries normalize into feature definitions in property declaration order.
 - In object-map form, the property key is the only feature identifier.
-- In object-map form, every property inside the feature value object, including `Name`, is treated as feature configuration.
+- In object-map form, every property inside the feature value object, including `Name`, is treated as feature configuration even when blank.
 - In object-map form, the feature value must be an object.
 - Nested objects and arrays inside feature settings remain part of the feature configuration payload.
+- In array object form, `Name` identifies the feature and all other direct properties are settings.
+- In legacy array object form, `Settings` may wrap the settings object. `Settings` must not be mixed with direct sibling settings.
 
 ## Invalid Input Rules
 
@@ -55,6 +68,9 @@ The following inputs must be rejected:
 - A `Features` section that combines array-like numeric children and object-map named children for the same shell
 - An object-map entry whose value is `null`, a scalar, or an array
 - An array-object entry that omits the `Name` property in array form
+- An array entry whose string value is blank
+- An array-object entry whose `Name` property is blank
+- An array-object entry that mixes a `Settings` wrapper with direct sibling settings
 - Any input that cannot be normalized without silently discarding feature configuration data
 
 ## Serialization Rules

--- a/specs/002-feature-object-map/spec.md
+++ b/specs/002-feature-object-map/spec.md
@@ -13,6 +13,9 @@
 - Q: How should object-map feature order be handled before dependency resolution? → A: Preserve object-map entry order exactly as declared in configuration.
 - Q: Which configuration entry points should accept object-map syntax? → A: Support object-map syntax for configuration providers and direct JSON deserialization of shell config models.
 - Q: Which syntax should be preferred when serializing shell config models back to JSON? → A: Prefer serializing object-map syntax whenever possible.
+- Q: What should happen when an object-map feature contains an inner blank `Name` property? → A: The feature remains identified by the map key and the blank `Name` remains feature configuration; it must not cause the feature entry or its settings to be skipped.
+- Q: How should invalid array feature entries be handled? → A: Reject them with actionable errors; array entries with blank string values or missing/blank `Name` properties must never be silently ignored.
+- Q: How should the legacy array `Settings` wrapper be treated? → A: Continue to support `{ "Name": "Feature", "Settings": { ... } }` as compatibility syntax, but reject entries that mix `Settings` with direct sibling settings.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -62,6 +65,7 @@ As a shell configuration author, I want invalid feature configuration shapes to 
 2. **Given** a shell configuration source that produces an ambiguous `Features` definition for the same shell, **When** the shell settings are loaded, **Then** loading fails instead of silently choosing one interpretation.
 3. **Given** a shell config model with an invalid object-map feature entry loaded through direct JSON deserialization, **When** the model is converted into runtime shell settings, **Then** loading fails with an error that identifies the shell name and the invalid feature entry.
 4. **Given** a shell configuration loaded through `IConfiguration` that configures the same feature more than once, **When** the shell settings are loaded, **Then** loading fails with an error that identifies the shell and duplicate feature name.
+5. **Given** a shell configuration loaded through `IConfiguration` that contains an object-map feature with an inner blank `Name` property and other settings, **When** the shell settings are loaded, **Then** the feature is enabled under the map key and all settings, including `Name`, remain available to that feature.
 
 ### Edge Cases
 
@@ -69,6 +73,9 @@ As a shell configuration author, I want invalid feature configuration shapes to 
 - A feature map contains nested settings objects and arrays, which must remain available to the feature as structured configuration values.
 - A feature map contains a null, scalar, or array value for a feature entry and must be rejected as invalid input.
 - A feature map entry may contain a setting named `Name`; the feature identity remains the map key and the inner `Name` value remains available as feature configuration.
+- A feature map entry may contain a blank setting named `Name`; the feature identity still remains the map key.
+- An array entry with a blank string value or blank/missing `Name` must be rejected before activation.
+- An array object may use a legacy `Settings` wrapper for feature settings, but must not mix that wrapper with direct sibling settings.
 - Object-map entries preserve declaration order before dependency resolution is applied.
 - Features serialized back to JSON use empty objects for enabled features that have no explicit settings.
 - Equivalent feature definitions may be supplied in either syntax, but a single `Features` node is treated as one shape only: array or object map.
@@ -85,16 +92,20 @@ As a shell configuration author, I want invalid feature configuration shapes to 
 - **FR-003**: The system MUST treat an empty object-map value for a feature as an enabled feature with no feature-specific settings.
 - **FR-004**: The system MUST treat every property inside an object-map feature value as configuration data for that feature.
 - **FR-004a**: In object-map syntax, the system MUST determine feature identity exclusively from the map key and MUST NOT assign special meaning to an inner `Name` property.
+- **FR-004b**: In object-map syntax, an inner `Name` property with a blank value MUST remain feature configuration and MUST NOT cause the feature entry or its settings to be skipped.
 - **FR-005**: The system MUST preserve nested feature settings from object-map values so they remain available through the same feature configuration access pattern used by existing configured features.
 - **FR-005a**: The system MUST preserve object-map declaration order as the configured feature order before any dependency ordering is applied.
 - **FR-006**: The system MUST produce the same enabled feature names and feature-specific configuration values for semantically equivalent array-based and object-map definitions.
 - **FR-006a**: When serializing shell configuration models to JSON, the system MUST prefer object-map syntax for the `Features` value whenever the configured features can be represented in that syntax.
 - **FR-006b**: When serializing an enabled feature with no explicit settings in object-map syntax, the system MUST emit that feature with an empty object value.
 - **FR-007**: The system MUST continue to support the current array object form where a feature is declared as an object containing a `Name` property and additional settings.
+- **FR-007a**: The system MUST continue to support the legacy array object form where feature settings are nested under a `Settings` object.
+- **FR-007b**: The system MUST reject array object entries that mix a `Settings` wrapper with direct sibling settings.
 - **FR-008**: The system MUST reject object-map feature entries whose value is not an object.
 - **FR-009**: The system MUST report invalid feature definitions with an actionable error that identifies the affected shell and feature entry.
 - **FR-010**: The system MUST reject ambiguous `Features` definitions for the same shell rather than silently merging array and object-map interpretations.
 - **FR-011**: The system MUST reject duplicate configured feature names within a single shell definition, regardless of whether the input uses array syntax or object-map syntax.
+- **FR-012**: All `IConfiguration`-backed shell composition paths MUST use the same feature normalization rules as `ShellBuilder.FromConfiguration`.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -194,8 +194,16 @@ internal static class ConfigurationHelper
     public static string[] ExtractFeatureNames(IEnumerable<FeatureEntry> features)
     {
         return features
-            .Where(f => !string.IsNullOrWhiteSpace(f.Name))
-            .Select(f => f.Name.Trim())
+            .Select((feature, index) =>
+            {
+                if (string.IsNullOrWhiteSpace(feature.Name))
+                {
+                    throw new InvalidOperationException(
+                        $"Configured feature entry at index {index} must define a non-empty feature name.");
+                }
+
+                return feature.Name.Trim();
+            })
             .ToArray();
     }
 
@@ -356,17 +364,17 @@ internal static class ConfigurationHelper
 
                 if (settingsWrapper is not null)
                 {
-                    if (directSettings.Count > 0)
-                    {
-                        throw new InvalidOperationException(
-                            $"Feature '{entry.Name}'{shellContext} mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
-                    }
-
                     var settingsChildren = settingsWrapper.GetChildren().ToList();
                     if (settingsWrapper.Value is not null && settingsChildren.Count == 0)
                     {
                         throw new InvalidOperationException(
                             $"Feature '{entry.Name}'{shellContext} uses a 'Settings' wrapper that must contain an object value.");
+                    }
+
+                    if (directSettings.Count > 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Feature '{entry.Name}'{shellContext} mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
                     }
 
                     PopulateEntrySettings(entry, settingsChildren);

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -301,10 +301,10 @@ internal static class ConfigurationHelper
     {
         var shape = DetectFeaturesShape(featuresSection);
 
-        return shape switch
+        var entries = shape switch
         {
             FeaturesShape.Empty => [],
-            FeaturesShape.Array => ParseArrayFeaturesFromConfiguration(featuresSection),
+            FeaturesShape.Array => ParseArrayFeaturesFromConfiguration(featuresSection, shellName),
             FeaturesShape.Object => ParseObjectMapFeaturesFromConfiguration(featuresSection, shellName),
             FeaturesShape.Ambiguous => throw new InvalidOperationException(
                 $"Shell '{shellName ?? "unknown"}' has an ambiguous 'Features' section that mixes array and object-map children. " +
@@ -312,11 +312,15 @@ internal static class ConfigurationHelper
             _ => throw new InvalidOperationException(
                 $"Shell '{shellName ?? "unknown"}' has an unrecognized 'Features' configuration shape '{shape}'."),
         };
+
+        ValidateNoDuplicateFeatures(entries, shellName ?? "unknown");
+        return entries;
     }
 
-    private static List<FeatureEntry> ParseArrayFeaturesFromConfiguration(IConfigurationSection featuresSection)
+    private static List<FeatureEntry> ParseArrayFeaturesFromConfiguration(IConfigurationSection featuresSection, string? shellName = null)
     {
         var entries = new List<FeatureEntry>();
+        var shellContext = shellName is not null ? $" in shell '{shellName}'" : "";
 
         foreach (var featureSection in featuresSection.GetChildren())
         {
@@ -324,35 +328,52 @@ internal static class ConfigurationHelper
             if (!featureSection.GetChildren().Any())
             {
                 var name = featureSection.Value;
-                if (!string.IsNullOrWhiteSpace(name))
-                    entries.Add(FeatureEntry.FromName(name.Trim()));
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    throw new InvalidOperationException(
+                        $"Feature array entry '{featureSection.Key}'{shellContext} must define a non-empty feature name.");
+                }
+
+                entries.Add(FeatureEntry.FromName(name.Trim()));
             }
             else
             {
                 // This is an object with Name and settings
                 var name = featureSection["Name"];
                 if (string.IsNullOrWhiteSpace(name))
-                    continue;
+                {
+                    throw new InvalidOperationException(
+                        $"Feature array entry '{featureSection.Key}'{shellContext} must define a non-empty 'Name' property.");
+                }
 
                 var entry = new FeatureEntry { Name = name.Trim() };
+                var children = featureSection.GetChildren().ToList();
+                var settingsWrapper = children.FirstOrDefault(c => c.Key.Equals("Settings", StringComparison.OrdinalIgnoreCase));
+                var directSettings = children
+                    .Where(c => !c.Key.Equals("Name", StringComparison.OrdinalIgnoreCase))
+                    .Where(c => !c.Key.Equals("Settings", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
 
-                // All other children are settings
-                foreach (var settingSection in featureSection.GetChildren())
+                if (settingsWrapper is not null)
                 {
-                    if (settingSection.Key.Equals("Name", StringComparison.OrdinalIgnoreCase))
-                        continue;
+                    if (directSettings.Count > 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Feature '{entry.Name}'{shellContext} mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
+                    }
 
-                    if (settingSection.GetChildren().Any())
+                    var settingsChildren = settingsWrapper.GetChildren().ToList();
+                    if (settingsWrapper.Value is not null && settingsChildren.Count == 0)
                     {
-                        // Complex nested setting - store as JsonElement
-                        var json = SerializeConfigurationSection(settingSection);
-                        entry.Settings[settingSection.Key] = JsonSerializer.Deserialize<JsonElement>(json);
+                        throw new InvalidOperationException(
+                            $"Feature '{entry.Name}'{shellContext} uses a 'Settings' wrapper that must contain an object value.");
                     }
-                    else
-                    {
-                        // Simple value
-                        entry.Settings[settingSection.Key] = settingSection.Value;
-                    }
+
+                    PopulateEntrySettings(entry, settingsChildren);
+                }
+                else
+                {
+                    PopulateEntrySettings(entry, directSettings);
                 }
 
                 entries.Add(entry);
@@ -409,5 +430,21 @@ internal static class ConfigurationHelper
         }
 
         return entries;
+    }
+
+    private static void PopulateEntrySettings(FeatureEntry entry, IEnumerable<IConfigurationSection> settingSections)
+    {
+        foreach (var settingSection in settingSections)
+        {
+            if (settingSection.GetChildren().Any())
+            {
+                var json = SerializeConfigurationSection(settingSection);
+                entry.Settings[settingSection.Key] = JsonSerializer.Deserialize<JsonElement>(json);
+            }
+            else
+            {
+                entry.Settings[settingSection.Key] = settingSection.Value;
+            }
+        }
     }
 }

--- a/src/CShells/Configuration/FeatureEntryJsonConverter.cs
+++ b/src/CShells/Configuration/FeatureEntryJsonConverter.cs
@@ -96,16 +96,33 @@ public class FeatureEntryJsonConverter : JsonConverter<FeatureEntry>
             throw new JsonException("Feature name cannot be null or empty");
 
         var entry = new FeatureEntry { Name = name.Trim() };
+        var settingsWrapper = root.EnumerateObject()
+            .FirstOrDefault(property => property.Name.Equals("Settings", StringComparison.OrdinalIgnoreCase));
+        var hasSettingsWrapper = settingsWrapper.Value.ValueKind != JsonValueKind.Undefined;
+        var directSettings = root.EnumerateObject()
+            .Where(property => !property.Name.Equals(NameProperty, StringComparison.OrdinalIgnoreCase))
+            .Where(property => !property.Name.Equals("Settings", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (hasSettingsWrapper)
+        {
+            if (directSettings.Count > 0)
+                throw new JsonException(
+                    $"Feature '{entry.Name}' mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
+
+            if (settingsWrapper.Value.ValueKind != JsonValueKind.Object)
+                throw new JsonException(
+                    $"Feature '{entry.Name}' uses a 'Settings' wrapper that must contain an object value.");
+
+            foreach (var property in settingsWrapper.Value.EnumerateObject())
+                entry.Settings[property.Name] = CloneJsonElement(property.Value);
+
+            return entry;
+        }
 
         // All other properties are settings
-        foreach (var property in root.EnumerateObject())
-        {
-            if (property.Name.Equals(NameProperty, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            // Clone the JsonElement to keep it alive after document disposal
+        foreach (var property in directSettings)
             entry.Settings[property.Name] = CloneJsonElement(property.Value);
-        }
 
         return entry;
     }
@@ -127,6 +144,4 @@ public class FeatureEntryJsonConverter : JsonConverter<FeatureEntry>
         };
     }
 }
-
-
 

--- a/src/CShells/Configuration/FeatureEntryJsonConverter.cs
+++ b/src/CShells/Configuration/FeatureEntryJsonConverter.cs
@@ -106,13 +106,13 @@ public class FeatureEntryJsonConverter : JsonConverter<FeatureEntry>
 
         if (hasSettingsWrapper)
         {
-            if (directSettings.Count > 0)
-                throw new JsonException(
-                    $"Feature '{entry.Name}' mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
-
             if (settingsWrapper.Value.ValueKind != JsonValueKind.Object)
                 throw new JsonException(
                     $"Feature '{entry.Name}' uses a 'Settings' wrapper that must contain an object value.");
+
+            if (directSettings.Count > 0)
+                throw new JsonException(
+                    $"Feature '{entry.Name}' mixes the 'Settings' wrapper with direct settings. Use one feature settings style.");
 
             foreach (var property in settingsWrapper.Value.EnumerateObject())
                 entry.Settings[property.Name] = CloneJsonElement(property.Value);
@@ -144,4 +144,3 @@ public class FeatureEntryJsonConverter : JsonConverter<FeatureEntry>
         };
     }
 }
-

--- a/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
+++ b/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
@@ -39,67 +39,15 @@ public sealed class ConfigurationShellBlueprint : IShellBlueprint
     public Task<ShellSettings> ComposeAsync(CancellationToken cancellationToken = default)
     {
         var settings = new ShellSettings(new ShellId(Name));
-        var enabledFeatures = new List<string>();
 
         var featuresSection = _section.GetSection("Features");
-        foreach (var featureSection in featuresSection.GetChildren())
-        {
-            // Three shapes supported:
-            //   Array + string:     "Features": [ "Core" ]           → Value="Core", Key="0"
-            //   Array + object:     "Features": [ { "Name": "Core" } ] → Name="Core", Key="0"
-            //   Object map:         "Features": { "Core": {} }        → Key="Core"
-            var featureName = featureSection.Value
-                              ?? featureSection["Name"]
-                              ?? (IsNumericKey(featureSection.Key) ? null : featureSection.Key);
-
-            if (string.IsNullOrWhiteSpace(featureName))
-                continue;
-
-            enabledFeatures.Add(featureName);
-
-            // Settings in array+object form live under `Settings:*`; in object-map form the
-            // feature section's direct children (other than `Name`) ARE the settings.
-            var settingsSection = featureSection.GetSection("Settings");
-            if (settingsSection.Exists())
-            {
-                foreach (var kv in Flatten(settingsSection))
-                    settings.ConfigurationData[$"{featureName}:{kv.Key}"] = kv.Value;
-            }
-            else if (!IsNumericKey(featureSection.Key))
-            {
-                foreach (var kv in Flatten(featureSection))
-                {
-                    if (string.Equals(kv.Key, "Name", StringComparison.OrdinalIgnoreCase))
-                        continue;
-                    settings.ConfigurationData[$"{featureName}:{kv.Key}"] = kv.Value;
-                }
-            }
-        }
-
-        settings.EnabledFeatures = [.. enabledFeatures];
+        var features = ConfigurationHelper.ParseFeaturesFromConfiguration(featuresSection, Name);
+        settings.EnabledFeatures = ConfigurationHelper.ExtractFeatureNames(features);
+        ConfigurationHelper.PopulateFeatureSettings(features, settings.ConfigurationData);
 
         var configurationSection = _section.GetSection("Configuration");
-        foreach (var kv in Flatten(configurationSection))
-            settings.ConfigurationData[kv.Key] = kv.Value;
+        ConfigurationHelper.LoadConfigurationFromSection(configurationSection, settings.ConfigurationData);
 
         return Task.FromResult(settings);
-    }
-
-    private static bool IsNumericKey(string key) => int.TryParse(key, out _);
-
-    /// <summary>Flattens a configuration section to a flat key → value map using colon joins.</summary>
-    private static IEnumerable<KeyValuePair<string, string>> Flatten(IConfiguration section)
-    {
-        foreach (var child in section.GetChildren())
-        {
-            if (child.Value is not null)
-            {
-                yield return new KeyValuePair<string, string>(child.Key, child.Value);
-                continue;
-            }
-
-            foreach (var descendant in Flatten(child))
-                yield return new KeyValuePair<string, string>($"{child.Key}:{descendant.Key}", descendant.Value);
-        }
     }
 }

--- a/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
@@ -43,7 +43,7 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         var direct = _shellsSection.GetSection(name);
         if (direct.Exists())
         {
-            var candidate = direct["Name"] ?? direct.Key;
+            var candidate = ResolveShellName(direct);
             if (string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult<ProvidedBlueprint?>(
@@ -55,7 +55,7 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         // "Name" property whose value differs from the key. Scan to honor that override.
         foreach (var child in _shellsSection.GetChildren())
         {
-            var candidate = child["Name"] ?? child.Key;
+            var candidate = ResolveShellName(child);
             if (string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult<ProvidedBlueprint?>(
@@ -73,8 +73,7 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         query.EnsureValid();
 
         var ordered = _shellsSection.GetChildren()
-            .Select(c => c["Name"] ?? c.Key)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(ResolveShellName)
             .Where(name => query.NamePrefix is null ||
                            name.StartsWith(query.NamePrefix, StringComparison.OrdinalIgnoreCase))
             .Where(name => query.Cursor is null ||
@@ -95,5 +94,20 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
 
         var nextCursor = hasMore && items.Count > 0 ? items[^1].Name : null;
         return Task.FromResult(new BlueprintPage(items, nextCursor));
+    }
+
+    private static string ResolveShellName(IConfigurationSection shellSection)
+    {
+        var configuredName = shellSection["Name"];
+        if (!string.IsNullOrWhiteSpace(configuredName))
+            return configuredName.Trim();
+
+        if (int.TryParse(shellSection.Key, out _))
+        {
+            throw new InvalidOperationException(
+                $"Configured shell entry '{shellSection.Path}' must define a non-empty 'Name' property when using array syntax.");
+        }
+
+        return shellSection.Key.Trim();
     }
 }

--- a/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
@@ -55,7 +55,9 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         // "Name" property whose value differs from the key. Scan to honor that override.
         foreach (var child in _shellsSection.GetChildren())
         {
-            var candidate = ResolveShellName(child);
+            if (!TryResolveShellName(child, out var candidate))
+                continue;
+
             if (string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult<ProvidedBlueprint?>(
@@ -109,5 +111,24 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         }
 
         return shellSection.Key.Trim();
+    }
+
+    private static bool TryResolveShellName(IConfigurationSection shellSection, out string name)
+    {
+        var configuredName = shellSection["Name"];
+        if (!string.IsNullOrWhiteSpace(configuredName))
+        {
+            name = configuredName.Trim();
+            return true;
+        }
+
+        if (int.TryParse(shellSection.Key, out _))
+        {
+            name = "";
+            return false;
+        }
+
+        name = shellSection.Key.Trim();
+        return true;
     }
 }

--- a/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
@@ -42,6 +42,47 @@ public class FeatureEntryJsonConverterTests
         Assert.Equal(5000, entry.Settings["MaxAmount"]);
     }
 
+    [Fact(DisplayName = "Deserialize object feature entry supports Settings wrapper")]
+    public void Deserialize_ObjectFeatureEntryWithSettingsWrapper_ReturnsFeatureEntryWithSettings()
+    {
+        // Arrange
+        var json = """{ "Name": "Analytics", "Settings": { "TopPostsCount": 10, "Window": "Weekly" } }""";
+
+        // Act
+        var entry = JsonSerializer.Deserialize<FeatureEntry>(json, Options);
+
+        // Assert
+        Assert.NotNull(entry);
+        Assert.Equal("Analytics", entry.Name);
+        Assert.Equal(2, entry.Settings.Count);
+        Assert.Equal(10, entry.Settings["TopPostsCount"]);
+        Assert.Equal("Weekly", entry.Settings["Window"]);
+    }
+
+    [Fact(DisplayName = "Deserialize object feature entry rejects mixed Settings wrapper and direct settings")]
+    public void Deserialize_ObjectFeatureEntryWithMixedSettingsStyles_Throws()
+    {
+        // Arrange
+        var json = """{ "Name": "Analytics", "Settings": { "TopPostsCount": 10 }, "Window": "Weekly" }""";
+
+        // Act & Assert
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<FeatureEntry>(json, Options));
+        Assert.Contains("mixes", ex.Message);
+        Assert.Contains("Analytics", ex.Message);
+    }
+
+    [Fact(DisplayName = "Deserialize object feature entry rejects scalar Settings wrapper")]
+    public void Deserialize_ObjectFeatureEntryWithScalarSettingsWrapper_Throws()
+    {
+        // Arrange
+        var json = """{ "Name": "Analytics", "Settings": "invalid" }""";
+
+        // Act & Assert
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<FeatureEntry>(json, Options));
+        Assert.Contains("Settings", ex.Message);
+        Assert.Contains("object", ex.Message);
+    }
+
     [Fact(DisplayName = "Deserialize object feature entry with nested settings")]
     public void Deserialize_ObjectFeatureEntryWithNestedSettings_PreservesStructure()
     {
@@ -428,4 +469,3 @@ public class FeatureEntryJsonConverterTests
         Assert.Contains("empty", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
-

--- a/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
@@ -83,6 +83,35 @@ public class FeatureEntryJsonConverterTests
         Assert.Contains("object", ex.Message);
     }
 
+    [Fact(DisplayName = "Deserialize object feature entry reports scalar Settings before mixed styles")]
+    public void Deserialize_ObjectFeatureEntryWithScalarSettingsWrapperAndDirectSettings_ReportsScalarSettings()
+    {
+        // Arrange
+        var json = """{ "Name": "Analytics", "Settings": "invalid", "Window": "Weekly" }""";
+
+        // Act & Assert
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<FeatureEntry>(json, Options));
+        Assert.Contains("Settings", ex.Message);
+        Assert.Contains("object", ex.Message);
+        Assert.DoesNotContain("mixes", ex.Message);
+    }
+
+    [Fact(DisplayName = "Extracting ShellConfig feature names rejects blank programmatic entries")]
+    public void ShellBuilder_FromShellConfigWithBlankFeatureName_Throws()
+    {
+        // Arrange
+        var config = new ShellConfig
+        {
+            Name = "TestShell",
+            Features = [new FeatureEntry { Name = "" }]
+        };
+        var builder = new ShellBuilder("TestShell");
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.FromConfiguration(config));
+        Assert.Contains("non-empty feature name", ex.Message);
+    }
+
     [Fact(DisplayName = "Deserialize object feature entry with nested settings")]
     public void Deserialize_ObjectFeatureEntryWithNestedSettings_PreservesStructure()
     {

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -129,6 +129,24 @@ public class ConfigurationShellBlueprintTests
         Assert.Contains("Analytics", ex.Message);
     }
 
+    [Fact(DisplayName = "Array feature reports scalar Settings before mixed styles")]
+    public async Task ComposeAsync_ArrayObjectScalarSettingsWrapperAndDirectSettings_ReportsScalarSettings()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0:Name"] = "Analytics",
+            ["Features:0:Settings"] = "invalid",
+            ["Features:0:Window"] = "Weekly",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bp.ComposeAsync());
+        Assert.Contains("Settings", ex.Message);
+        Assert.Contains("object", ex.Message);
+        Assert.DoesNotContain("mixes", ex.Message);
+    }
+
     [Fact(DisplayName = "Duplicate configured features throw before activation")]
     public async Task ComposeAsync_DuplicateFeatures_Throws()
     {

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -1,4 +1,5 @@
 using CShells.Lifecycle.Blueprints;
+using CShells.Configuration;
 using Microsoft.Extensions.Configuration;
 
 namespace CShells.Tests.Unit.Lifecycle.Blueprints;
@@ -44,5 +45,125 @@ public class ConfigurationShellBlueprintTests
 
         Assert.True(settings.ConfigurationData.ContainsKey("Analytics:TopPostsCount"));
         Assert.Equal("10", settings.ConfigurationData["Analytics:TopPostsCount"]);
+    }
+
+    [Fact(DisplayName = "Object-map inner Name is configuration, not feature identity")]
+    public async Task ComposeAsync_ObjectMapInnerName_IsConfiguration()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:Identity:Name"] = "",
+            ["Features:Identity:SigningKey"] = "secret",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Equal("", settings.ConfigurationData["Identity:Name"]);
+        Assert.Equal("secret", settings.ConfigurationData["Identity:SigningKey"]);
+    }
+
+    [Fact(DisplayName = "Array feature object supports direct settings")]
+    public async Task ComposeAsync_ArrayObjectDirectSettings_AppearInConfigurationData()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0:Name"] = "Analytics",
+            ["Features:0:TopPostsCount"] = "10",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Analytics"], settings.EnabledFeatures);
+        Assert.Equal("10", settings.ConfigurationData["Analytics:TopPostsCount"]);
+    }
+
+    [Fact(DisplayName = "Array feature object rejects missing Name")]
+    public async Task ComposeAsync_ArrayObjectMissingName_Throws()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0:TopPostsCount"] = "10",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bp.ComposeAsync());
+        Assert.Contains("Name", ex.Message);
+        Assert.Contains("payments", ex.Message);
+    }
+
+    [Fact(DisplayName = "Array feature rejects blank string entry")]
+    public async Task ComposeAsync_BlankArrayString_Throws()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0"] = "",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bp.ComposeAsync());
+        Assert.Contains("non-empty feature name", ex.Message);
+        Assert.Contains("payments", ex.Message);
+    }
+
+    [Fact(DisplayName = "Array feature rejects mixed Settings wrapper and direct settings")]
+    public async Task ComposeAsync_ArrayObjectMixedSettingsStyles_Throws()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0:Name"] = "Analytics",
+            ["Features:0:Settings:TopPostsCount"] = "10",
+            ["Features:0:Window"] = "Weekly",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bp.ComposeAsync());
+        Assert.Contains("mixes", ex.Message);
+        Assert.Contains("Analytics", ex.Message);
+    }
+
+    [Fact(DisplayName = "Duplicate configured features throw before activation")]
+    public async Task ComposeAsync_DuplicateFeatures_Throws()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:0"] = "Core",
+            ["Features:1"] = "core",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("payments", root);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => bp.ComposeAsync());
+        Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("payments", ex.Message);
+    }
+
+    [Fact(DisplayName = "Configuration blueprint and ShellBuilder use equivalent feature normalization")]
+    public async Task ComposeAsync_MatchesShellBuilderFeatureNormalization()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Shell:Features:Identity:Name"] = "Display Name",
+            ["Shell:Features:Identity:SigningKey"] = "secret",
+            ["Shell:Configuration:WebRouting:Path"] = "",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var section = root.GetSection("Shell");
+        var bp = new ConfigurationShellBlueprint("payments", section);
+
+        var blueprintSettings = await bp.ComposeAsync();
+        var builderSettings = new ShellBuilder("payments")
+            .FromConfiguration(section)
+            .Build();
+
+        Assert.Equal(builderSettings.EnabledFeatures, blueprintSettings.EnabledFeatures);
+        Assert.Equal(builderSettings.ConfigurationData, blueprintSettings.ConfigurationData);
     }
 }

--- a/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
@@ -39,6 +39,22 @@ public class ConfigurationShellBlueprintProviderTests
         Assert.Equal("Acme", result!.Blueprint.Name);
     }
 
+    [Fact(DisplayName = "GetAsync falls back to object-map key when explicit Name is blank")]
+    public async Task Get_ObjectMapBlankName_FallsBackToKey()
+    {
+        var section = BuildSection(new Dictionary<string, string?>
+        {
+            ["Default:Name"] = "",
+            ["Default:Features:0"] = "Core",
+        });
+        var provider = new ConfigurationShellBlueprintProvider(section);
+
+        var result = await provider.GetAsync("Default");
+
+        Assert.NotNull(result);
+        Assert.Equal("Default", result!.Blueprint.Name);
+    }
+
     [Fact(DisplayName = "GetAsync is case-insensitive")]
     public async Task Get_CaseInsensitive()
     {
@@ -108,6 +124,36 @@ public class ConfigurationShellBlueprintProviderTests
         var third = await provider.ListAsync(new BlueprintListQuery(Cursor: second.NextCursor, Limit: 2));
         Assert.Equal(["e"], third.Items.Select(i => i.Name));
         Assert.Null(third.NextCursor);
+    }
+
+    [Fact(DisplayName = "ListAsync falls back to object-map key when explicit Name is blank")]
+    public async Task List_ObjectMapBlankName_FallsBackToKey()
+    {
+        var section = BuildSection(new Dictionary<string, string?>
+        {
+            ["Default:Name"] = "",
+            ["Default:Features:0"] = "Core",
+        });
+        var provider = new ConfigurationShellBlueprintProvider(section);
+
+        var page = await provider.ListAsync(new BlueprintListQuery(Limit: 10));
+
+        Assert.Equal(["Default"], page.Items.Select(i => i.Name));
+    }
+
+    [Fact(DisplayName = "ListAsync rejects array shell entries without Name")]
+    public async Task List_ArrayEntryWithoutName_Throws()
+    {
+        var section = BuildSection(new Dictionary<string, string?>
+        {
+            ["0:Features:0"] = "Core",
+        });
+        var provider = new ConfigurationShellBlueprintProvider(section);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.ListAsync(new BlueprintListQuery(Limit: 10)));
+        Assert.Contains("Name", ex.Message);
+        Assert.Contains("array syntax", ex.Message);
     }
 
     private static IConfiguration BuildSection(IDictionary<string, string?> pairs) =>

--- a/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
@@ -156,6 +156,23 @@ public class ConfigurationShellBlueprintProviderTests
         Assert.Contains("array syntax", ex.Message);
     }
 
+    [Fact(DisplayName = "GetAsync skips unrelated invalid array shell entries during fallback scan")]
+    public async Task Get_FallbackScanSkipsUnrelatedInvalidArrayEntry()
+    {
+        var section = BuildSection(new Dictionary<string, string?>
+        {
+            ["0:Features:0"] = "Core",
+            ["1:Name"] = "Acme",
+            ["1:Features:0"] = "Core",
+        });
+        var provider = new ConfigurationShellBlueprintProvider(section);
+
+        var result = await provider.GetAsync("Acme");
+
+        Assert.NotNull(result);
+        Assert.Equal("Acme", result!.Blueprint.Name);
+    }
+
     private static IConfiguration BuildSection(IDictionary<string, string?> pairs) =>
         new ConfigurationBuilder().AddInMemoryCollection(pairs).Build();
 }


### PR DESCRIPTION
## Summary
- route configuration-backed shell composition through the shared feature normalization helper
- treat object-map feature inner Name values as configuration, including blank values, instead of feature identity
- reject invalid array feature entries, duplicate features, mixed Settings/direct settings, and array shell entries without Name
- document the object-map Name behavior and legacy array Settings wrapper

## Validation
- dotnet test tests/CShells.Tests/CShells.Tests.csproj
- dotnet test