### PR TITLE
feat: use map-based shell configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+packages/
 
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,3 +135,10 @@ Package versions are centrally managed in `Directory.Packages.props` — never s
 | Reference feature implementations | `samples/CShells.Workbench.Features/` |
 | Integration test helper | `tests/CShells.Tests/TestHelpers/DefaultShellHostFixture.cs` |
 
+
+## Active Technologies
+- C# 14 / .NET 10 with `Microsoft.Extensions.Configuration`, `System.Text.Json`, and existing CShells abstractions; no new third-party packages (011-map-shell-config)
+- Configuration provider inputs only; no persistent storage (011-map-shell-config)
+
+## Recent Changes
+- 011-map-shell-config: Planned map-based shell configuration under `CShells:Shells`

--- a/README.md
+++ b/README.md
@@ -199,22 +199,23 @@ public class WeatherFeature : IShellFeature
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "Weather"],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {},
+          "Weather": {}
+        },
         "Configuration": {
           "WebRouting": {
             "Path": ""
           }
         }
       },
-      {
-        "Name": "Admin",
-        "Features": [
-          "Core",
-          { "Name": "Admin", "MaxUsers": 100, "EnableAuditLog": true }
-        ],
+      "Admin": {
+        "Features": {
+          "Core": {},
+          "Admin": { "MaxUsers": 100, "EnableAuditLog": true }
+        },
         "Configuration": {
           "WebRouting": {
             "Path": "admin",
@@ -222,10 +223,18 @@ public class WeatherFeature : IShellFeature
           }
         }
       }
-    ]
+    }
   }
 }
 ```
+
+Shell names are the keys under `CShells:Shells`. This makes overrides stable, for example:
+
+```bash
+CSHELLS__SHELLS__DEFAULT__FEATURES__WEATHER__APIKEY=...
+```
+
+Use PascalCase shell names in JSON, such as `Default` or `MyShell`; environment variable keys are commonly written in uppercase.
 
 You can also override the configuration section name via `builder.AddShells("MySection")`.
 

--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -18,15 +18,14 @@ The `Features` property supports an object-map syntax where each property key is
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": {
           "Core": {},
           "Analytics": { "TopPostsCount": 10 }
         }
       }
-    ]
+    }
   }
 }
 ```
@@ -49,9 +48,8 @@ Each entry in the `Features` array can be either a string (feature name) or an o
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": [
           "Core",
           {
@@ -60,7 +58,7 @@ Each entry in the `Features` array can be either a string (feature name) or an o
           }
         ]
       }
-    ]
+    }
   }
 }
 ```
@@ -70,9 +68,8 @@ For compatibility with older configuration, array objects may also place setting
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": [
           {
             "Name": "Analytics",
@@ -80,7 +77,7 @@ For compatibility with older configuration, array objects may also place setting
           }
         ]
       }
-    ]
+    }
   }
 }
 ```
@@ -156,15 +153,14 @@ public class DatabaseOptions
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": [
           "Core",
           { "Name": "Database", "ConnectionString": "Server=localhost;Database=App;..." }
         ]
       }
-    ]
+    }
   }
 }
 ```
@@ -174,17 +170,19 @@ Or use the shell's `Configuration` section:
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "Database"],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {},
+          "Database": {}
+        },
         "Configuration": {
           "Database": {
             "ConnectionString": "Server=localhost;Database=App;..."
           }
         }
       }
-    ]
+    }
   }
 }
 ```
@@ -195,7 +193,7 @@ Settings are resolved in this order (highest wins):
 
 1. **Environment variables** — `Shells__Default__Configuration__FeatureName__Property`
 2. **Inline feature configuration** — settings in the `Features` array
-3. **Shell Configuration section** — `CShells:Shells[].Configuration.FeatureName`
+3. **Shell Configuration section** — `CShells:Shells.<ShellName>.Configuration.FeatureName`
 4. **Root configuration** — `FeatureName:Property`
 5. **Property defaults** — default values on the options class
 
@@ -249,7 +247,7 @@ Never store secrets in `appsettings.json`. Use the standard .NET mechanisms:
 
 ```bash
 # Development — User Secrets
-dotnet user-secrets set "CShells:Shells:0:Configuration:Database:ConnectionString" "Server=dev;..."
+dotnet user-secrets set "CShells:Shells:Default:Configuration:Database:ConnectionString" "Server=dev;..."
 
 # Production — Environment Variables or Azure Key Vault
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,22 +67,20 @@ Define your shells in `appsettings.json`:
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Cache", "Blog"],
+    "Shells": {
+      "Default": {
+        "Features": { "Cache": {}, "Blog": {} },
         "Configuration": {
           "WebRouting": { "Path": "" }
         }
       },
-      {
-        "Name": "Premium",
-        "Features": ["Cache", "Blog", "Analytics"],
+      "Premium": {
+        "Features": { "Cache": {}, "Blog": {}, "Analytics": {} },
         "Configuration": {
           "WebRouting": { "Path": "premium" }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -13,10 +13,10 @@ Give each shell a unique path prefix:
 ```json
 {
   "CShells": {
-    "Shells": [
-      { "Name": "Acme",    "Configuration": { "WebRouting": { "Path": "tenants/acme" } } },
-      { "Name": "Contoso", "Configuration": { "WebRouting": { "Path": "tenants/contoso" } } }
-    ]
+    "Shells": {
+      "Acme": { "Configuration": { "WebRouting": { "Path": "tenants/acme" } }  },
+      "Contoso": { "Configuration": { "WebRouting": { "Path": "tenants/contoso" } }  }
+    }
   }
 }
 ```
@@ -32,9 +32,9 @@ Result:
 ```json
 {
   "CShells": {
-    "Shells": [
-      { "Name": "Acme", "Configuration": { "WebRouting": { "Host": "acme.example.com" } } }
-    ]
+    "Shells": {
+      "Acme": { "Configuration": { "WebRouting": { "Host": "acme.example.com" } }  }
+    }
   }
 }
 ```
@@ -61,7 +61,15 @@ Register host routes **before** `MapShells()` to avoid shadowing.
 Set `Path` to `""` when the **entire** application is multi-tenant:
 
 ```json
-{ "Name": "Default", "Configuration": { "WebRouting": { "Path": "" } } }
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": { "WebRouting": { "Path": "" } }
+      }
+    }
+  }
+}
 ```
 
 > **Warning:** shell routes will match all root-level requests. Only use this when you have no host-specific routes.

--- a/docs/shell-resolution.md
+++ b/docs/shell-resolution.md
@@ -40,12 +40,11 @@ Note: path-based resolution is attempted first by the unified resolver. The reso
   ```json
   {
     "CShells": {
-      "Shells": [
-        {
-          "Name": "Acme",
+      "Shells": {
+        "Acme": {
           "Configuration": { "WebRouting": { "HeaderName": "X-Tenant-Id" } }
         }
-      ]
+      }
     }
   }
   ```
@@ -93,16 +92,14 @@ Configure a path prefix per shell in `appsettings.json`:
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Configuration": { "WebRouting": { "Path": "" } }
       },
-      {
-        "Name": "Acme",
+      "Acme": {
         "Configuration": { "WebRouting": { "Path": "acme" } }
       }
-    ]
+    }
   }
 }
 ```
@@ -118,12 +115,11 @@ Result (assuming both shells are currently applied):
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Acme",
+    "Shells": {
+      "Acme": {
         "Configuration": { "WebRouting": { "Host": "acme.example.com" } }
       }
-    ]
+    }
   }
 }
 ```

--- a/samples/CShells.Workbench/appsettings.json
+++ b/samples/CShells.Workbench/appsettings.json
@@ -7,10 +7,12 @@
   },
   "AllowedHosts": "*",
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": [ "Core", "Posts" ],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {},
+          "Posts": {}
+        },
         "Configuration": {
           "WebRouting": {
             "Path": ""
@@ -18,9 +20,12 @@
           "Plan": "Free"
         }
       },
-      {
-        "Name": "Acme",
-        "Features": [ "Core", "Posts", "Comments" ],
+      "Acme": {
+        "Features": {
+          "Core": {},
+          "Posts": {},
+          "Comments": {}
+        },
         "Configuration": {
           "WebRouting": {
             "Path": "acme"
@@ -28,8 +33,7 @@
           "Plan": "Pro"
         }
       },
-      {
-        "Name": "Contoso",
+      "Contoso": {
         "Features": {
           "Core": {},
           "Posts": {},
@@ -43,6 +47,6 @@
           "Plan": "Enterprise"
         }
       }
-    ]
+    }
   }
 }

--- a/specs/011-map-shell-config/checklists/requirements.md
+++ b/specs/011-map-shell-config/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Map-Based Shell Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-05-07. The specification is ready for `/speckit.plan`.

--- a/specs/011-map-shell-config/contracts/configuration-schema.md
+++ b/specs/011-map-shell-config/contracts/configuration-schema.md
@@ -1,0 +1,154 @@
+# Contract: Map-Based Shell Configuration
+
+## Supported `CShells:Shells` Shape
+
+`CShells:Shells` is an object whose property names are shell names. The property value is the shell definition.
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "WebRouting": {
+            "Path": ""
+          }
+        },
+        "Features": {
+          "DefaultAdminUser": {
+            "AdminPassword": "password"
+          },
+          "Identity": {
+            "SigningKey": "..."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Shell Name Contract
+
+- The shell name is the immediate child key under `CShells:Shells`.
+- The shell definition does not need a shell-level `Name` property.
+- A shell-level `Name` property is not a supported identity override.
+- Blank shell keys are invalid.
+- Numeric shell keys are invalid because they indicate the removed array shape.
+
+## Unsupported Shape
+
+The previous array shape is not supported.
+
+```json
+{
+  "CShells": {
+    "Shells": [
+      {
+        "Name": "Default",
+        "Features": {
+          "Identity": {
+            "SigningKey": "..."
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Implementations must reject this shape before shell activation with an actionable error naming `CShells:Shells`.
+
+## Environment Variable Contract
+
+Environment variable paths target named shells instead of array indices.
+
+```text
+CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY=test
+```
+
+This path targets:
+
+```text
+CShells:Shells:Default:Features:Identity:SigningKey
+```
+
+For shell names with multiple words, use PascalCase in JSON and the deployment environment's preferred key form in environment variables. Example:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "MyShell": {
+        "Features": {
+          "Identity": {}
+        }
+      }
+    }
+  }
+}
+```
+
+```text
+CSHELLS__SHELLS__MY_SHELL__FEATURES__IDENTITY__SIGNINGKEY=test
+```
+
+## Layered Merge Contract
+
+Given a base layer:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "Plan": "Free",
+          "WebRouting": {
+            "Path": ""
+          }
+        },
+        "Features": {
+          "Identity": {
+            "SigningKey": "base"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And a later layer:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "Plan": "Enterprise"
+        }
+      },
+      "Contoso": {
+        "Configuration": {
+          "WebRouting": {
+            "Path": "contoso"
+          }
+        },
+        "Features": {
+          "Identity": {}
+        }
+      }
+    }
+  }
+}
+```
+
+The final configuration contains:
+
+- `Default` with `Plan` overridden to `Enterprise`.
+- `Default` retaining `WebRouting:Path` and `Identity:SigningKey` from the base layer.
+- `Contoso` added as a second shell.
+
+No array position participates in shell identity or merging.

--- a/specs/011-map-shell-config/contracts/configuration-schema.md
+++ b/specs/011-map-shell-config/contracts/configuration-schema.md
@@ -73,7 +73,7 @@ This path targets:
 CShells:Shells:Default:Features:Identity:SigningKey
 ```
 
-For shell names with multiple words, use PascalCase in JSON and the deployment environment's preferred key form in environment variables. Example:
+For shell names with multiple words, use PascalCase in JSON and the same shell-name segment in environment variables (casing may differ, but do not add underscores within the shell name). Example:
 
 ```json
 {
@@ -90,7 +90,7 @@ For shell names with multiple words, use PascalCase in JSON and the deployment e
 ```
 
 ```text
-CSHELLS__SHELLS__MY_SHELL__FEATURES__IDENTITY__SIGNINGKEY=test
+CSHELLS__SHELLS__MYSHELL__FEATURES__IDENTITY__SIGNINGKEY=test
 ```
 
 ## Layered Merge Contract

--- a/specs/011-map-shell-config/data-model.md
+++ b/specs/011-map-shell-config/data-model.md
@@ -1,0 +1,113 @@
+# Data Model: Map-Based Shell Configuration
+
+## Shell Configuration Map
+
+Represents the value under `CShells:Shells`.
+
+### Fields
+
+- `Entries`: ordered configuration children keyed by shell name.
+
+### Validation Rules
+
+- Must be an object/map shape, not an array shape.
+- Immediate child keys must be non-empty, non-whitespace shell names.
+- Numeric immediate child keys are invalid because they indicate unsupported array syntax.
+- Keys are matched according to the host configuration system's normal key comparison behavior.
+
+### Relationships
+
+- Contains one `Shell Definition` per shell key.
+- Provides the identity for each runtime `Shell Name`.
+
+## Shell Definition
+
+Represents the configuration payload for one shell.
+
+### Fields
+
+- `Configuration`: optional shell-specific configuration values, flattened into colon-separated runtime configuration data.
+- `Features`: optional feature configuration map using the existing feature-entry contract.
+
+### Validation Rules
+
+- Must not rely on an inner shell-level `Name` property for identity.
+- If an inner shell-level `Name` property exists, it must not override the shell map key.
+- Existing feature configuration validation still applies to `Features`.
+
+### Relationships
+
+- Belongs to exactly one `Shell Configuration Map` entry.
+- Produces one runtime shell settings object when composed.
+- Contains zero or more `Feature Configuration Entry` values.
+
+## Shell Name
+
+The stable shell identifier derived from the map key.
+
+### Fields
+
+- `Value`: non-empty string from the immediate child key under `CShells:Shells`.
+- `ConfigurationPath`: the key path `CShells:Shells:{Value}`.
+
+### Validation Rules
+
+- Must be non-empty after trimming.
+- Must not be derived from an inner property.
+- Recommended JSON/configuration convention is PascalCase, for example `Default` or `MyShell`.
+- Environment variable examples may use uppercase and underscores where required by deployment conventions.
+
+### Relationships
+
+- Exposed through runtime shell settings, blueprint names, shell summaries, descriptors, and registry operations.
+- Used in environment override paths.
+
+## Feature Configuration Entry
+
+Represents one configured feature inside a shell definition.
+
+### Fields
+
+- `Name`: feature name from the feature map key.
+- `Settings`: feature-specific configuration values.
+
+### Validation Rules
+
+- Existing feature map behavior remains unchanged.
+- Feature identity comes from the feature map key in object-map syntax.
+- Feature settings flatten under the feature name in shell configuration data.
+
+### Relationships
+
+- Belongs to a `Shell Definition`.
+- Contributes to the shell's enabled feature list and feature-specific settings.
+
+## Configuration Layer
+
+Represents a contributing configuration source such as base application settings, deployment settings, or environment variables.
+
+### Fields
+
+- `KeyPaths`: hierarchical configuration paths supplied by the layer.
+- `Precedence`: the existing configuration provider ordering that determines final values.
+
+### Validation Rules
+
+- Layers merge by complete key path.
+- Later layers may override nested values for an existing named shell.
+- Later layers may add new named shell entries.
+- Later layers must not depend on array positions to identify shells.
+
+### Relationships
+
+- Multiple layers combine to form the final `Shell Configuration Map`.
+- Environment variable layers can target shell settings through named paths such as `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY`.
+
+## State Transitions
+
+Configuration data has no independent lifecycle state in this feature. It transitions through the existing pipeline:
+
+1. Configuration providers produce the final named key tree.
+2. The shell blueprint provider resolves a named child section.
+3. The shell blueprint composes runtime shell settings using the map key as shell name.
+4. Existing shell lifecycle components activate or reload shells from those settings.

--- a/specs/011-map-shell-config/data-model.md
+++ b/specs/011-map-shell-config/data-model.md
@@ -55,7 +55,7 @@ The stable shell identifier derived from the map key.
 - Must be non-empty after trimming.
 - Must not be derived from an inner property.
 - Recommended JSON/configuration convention is PascalCase, for example `Default` or `MyShell`.
-- Environment variable examples may use uppercase and underscores where required by deployment conventions.
+- Environment variable examples may use uppercase for key segments, but must not add underscores inside a shell name segment unless the configured shell name itself contains underscores.
 
 ### Relationships
 

--- a/specs/011-map-shell-config/plan.md
+++ b/specs/011-map-shell-config/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Map-Based Shell Configuration
+
+**Branch**: `011-map-shell-config` | **Date**: 2026-05-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-map-shell-config/spec.md`
+
+## Summary
+
+Replace shell configuration under `CShells:Shells` with a single supported object-map shape where each child key is the shell name. The runtime configuration provider will derive shell identity exclusively from the child section key, reject numeric child keys as unsupported array syntax, and remove the fallback that treats an inner `Name` value as shell identity. Configuration binding models, documentation, samples, and tests will align with map syntax so environment variable overrides and layered configuration merge by shell name instead of by array index.
+
+The implementation stays inside the existing CShells configuration and lifecycle provider surfaces. Feature configuration remains unchanged: shell entries still contain `Features` using the existing feature map syntax, and feature-specific values continue to flatten into shell configuration data.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 — library projects multi-target existing supported target frameworks; tests target the repository test framework configuration  
+**Primary Dependencies**: `Microsoft.Extensions.Configuration`, `System.Text.Json`, existing CShells abstractions and lifecycle providers; no new third-party packages  
+**Storage**: N/A — configuration is read from existing configuration providers and in-memory test dictionaries  
+**Testing**: xUnit 2.x with `Assert.*`; unit tests in `tests/CShells.Tests/Unit/`; integration coverage through existing configuration/lifecycle test helpers where needed  
+**Target Platform**: CShells library consumers and ASP.NET Core hosts using the existing configuration provider pipeline  
+**Project Type**: Multi-package .NET library with samples and documentation  
+**Performance Goals**: Preserve current `ConfigurationShellBlueprintProvider.GetAsync(name)` direct-key lookup behavior for named shells; avoid extra full-section scans for normal named lookups  
+**Constraints**: No backward compatibility for array shell syntax; feature map syntax remains unchanged; errors must be clear and occur before shell activation; docs and samples must not show the old shell array shape  
+**Scale/Scope**: All configured shells under `CShells:Shells`; layered configuration from application settings, additional config files, and environment variables; sample and documentation updates across the repository
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Abstraction-First Architecture | PASS | Uses existing configuration/lifecycle abstractions; no new public abstraction required. |
+| II. Feature Modularity | PASS | Feature declarations remain declarative and map-based; no feature coupling introduced. |
+| III. Modern C# Style | PASS | Implementation will follow existing C# 14 conventions, `var`, guard clauses, and collection expressions. |
+| IV. Explicit Error Handling | PASS | Unsupported array shell syntax and invalid shell keys will fail with actionable messages naming `CShells:Shells`. |
+| V. Test Coverage | PASS | Adds/updates unit tests for map loading, rejection, environment overrides, and layered merge behavior. |
+| VI. Simplicity & Minimalism | PASS | Removes compatibility fallback instead of adding dual-format complexity. |
+| VII. Lifecycle & Concurrency Contracts | PASS | No lifecycle state-machine or concurrency behavior changes; provider continues to compose blueprints lazily. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-map-shell-config/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── configuration-schema.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells/
+│   ├── Configuration/
+│   │   ├── CShellsOptions.cs
+│   │   └── ShellConfig.cs
+│   └── Lifecycle/
+│       └── Providers/
+│           └── ConfigurationShellBlueprintProvider.cs
+└── CShells.Abstractions/
+    └── Lifecycle/
+        └── ShellDescriptor.cs
+
+tests/
+└── CShells.Tests/
+    └── Unit/
+        ├── Configuration/
+        └── Lifecycle/
+            └── Providers/
+
+samples/
+└── CShells.Workbench/
+    └── appsettings.json
+
+docs/
+wiki/
+README.md
+src/*/README.md
+samples/*/README.md
+```
+
+**Structure Decision**: Implement in the existing CShells configuration and lifecycle provider directories because the feature changes configuration shape and shell name resolution only. Tests mirror the touched `src/` paths under `tests/CShells.Tests/Unit/`. Documentation updates cover repository-level docs, package READMEs, wiki pages, and sample configuration files that currently show `CShells:Shells`.
+
+## Complexity Tracking
+
+No constitution violations or added complexity require justification.
+
+## Phase 0: Research
+
+Completed in [research.md](research.md). Decisions:
+
+- Bind/read `CShells:Shells` as named children rather than a list.
+- Derive shell identity exclusively from the child section key.
+- Reject numeric child keys as unsupported shell array syntax.
+- Preserve existing feature map parsing unchanged.
+- Document PascalCase shell keys and uppercase environment variable examples.
+
+## Phase 1: Design
+
+Completed design artifacts:
+
+- [data-model.md](data-model.md) defines the shell configuration map, shell definition, shell name, and configuration-layer behavior.
+- [contracts/configuration-schema.md](contracts/configuration-schema.md) documents the supported external configuration contract.
+- [quickstart.md](quickstart.md) gives verification examples for JSON configuration, environment overrides, and layered merging.
+
+## Phase 1 Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Abstraction-First Architecture | PASS | No new abstractions; public behavior is documented as configuration contract. |
+| II. Feature Modularity | PASS | Existing feature map contract remains intact. |
+| III. Modern C# Style | PASS | Planned code changes are small and align with project conventions. |
+| IV. Explicit Error Handling | PASS | Design includes early rejection paths for array shell entries and blank names. |
+| V. Test Coverage | PASS | Quickstart and data model map directly to unit/integration test tasks. |
+| VI. Simplicity & Minimalism | PASS | Removes old shell syntax instead of maintaining a compatibility layer. |
+| VII. Lifecycle & Concurrency Contracts | PASS | Blueprint composition remains lazy and stateless with respect to lifecycle transitions. |

--- a/specs/011-map-shell-config/quickstart.md
+++ b/specs/011-map-shell-config/quickstart.md
@@ -1,0 +1,180 @@
+# Quickstart: Map-Based Shell Configuration
+
+## 1. Configure shells as a map
+
+Use shell names as keys under `CShells:Shells`.
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "WebRouting": {
+            "Path": ""
+          },
+          "Plan": "Enterprise"
+        },
+        "Features": {
+          "DefaultAdminUser": {
+            "AdminPassword": "password"
+          },
+          "Identity": {
+            "SigningKey": "local-dev-key"
+          }
+        }
+      },
+      "Contoso": {
+        "Configuration": {
+          "WebRouting": {
+            "Path": "contoso"
+          },
+          "Plan": "Standard"
+        },
+        "Features": {
+          "Identity": {
+            "SigningKey": "contoso-local-key"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Do not include a shell-level `Name` property. `Default` and `Contoso` are the shell names.
+
+## 2. Override one shell with an environment variable
+
+Set an environment variable that names the target shell in the path.
+
+```bash
+export CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY=test
+```
+
+Expected result:
+
+- The `Default` shell's `Identity:SigningKey` is `test`.
+- The `Contoso` shell's `Identity:SigningKey` remains `contoso-local-key`.
+- Reordering shell entries in JSON does not change which shell is targeted.
+
+## 3. Merge layered configuration by shell name
+
+Base application settings:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "Plan": "Free",
+          "WebRouting": {
+            "Path": ""
+          }
+        },
+        "Features": {
+          "Identity": {
+            "SigningKey": "base"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Deployment settings:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "Plan": "Enterprise"
+        }
+      },
+      "Contoso": {
+        "Configuration": {
+          "WebRouting": {
+            "Path": "contoso"
+          }
+        },
+        "Features": {
+          "Identity": {
+            "SigningKey": "contoso"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Expected result:
+
+- `Default:Configuration:Plan` is `Enterprise`.
+- `Default:Configuration:WebRouting:Path` remains from the base layer.
+- `Default:Features:Identity:SigningKey` remains from the base layer unless separately overridden.
+- `Contoso` is added as a separate shell.
+
+## 4. Verify unsupported array syntax fails
+
+This shape is unsupported:
+
+```json
+{
+  "CShells": {
+    "Shells": [
+      {
+        "Name": "Default",
+        "Features": {
+          "Identity": {}
+        }
+      }
+    ]
+  }
+}
+```
+
+Expected result:
+
+- Shell loading fails before activation.
+- The error identifies `CShells:Shells`.
+- The error explains that shell entries must be named map entries.
+
+## 5. Naming convention
+
+Use PascalCase shell keys in JSON:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "MyShell": {
+        "Features": {
+          "Identity": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Use the environment's preferred uppercase/underscore form when writing environment variables:
+
+```bash
+export CSHELLS__SHELLS__MY_SHELL__FEATURES__IDENTITY__SIGNINGKEY=test
+```
+
+The configuration system maps the environment variable path back to the named shell path.
+
+## 6. Suggested verification commands
+
+```bash
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~ConfigurationShellBlueprintProviderTests"
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~Configuration"
+dotnet test tests/CShells.Tests/
+dotnet build
+```

--- a/specs/011-map-shell-config/quickstart.md
+++ b/specs/011-map-shell-config/quickstart.md
@@ -162,10 +162,10 @@ Use PascalCase shell keys in JSON:
 }
 ```
 
-Use the environment's preferred uppercase/underscore form when writing environment variables:
+Use the same PascalCase shell name segment in environment variable paths — casing may differ, but do not introduce underscores within the shell name segment:
 
 ```bash
-export CSHELLS__SHELLS__MY_SHELL__FEATURES__IDENTITY__SIGNINGKEY=test
+export CSHELLS__SHELLS__MYSHELL__FEATURES__IDENTITY__SIGNINGKEY=test
 ```
 
 The configuration system maps the environment variable path back to the named shell path.

--- a/specs/011-map-shell-config/research.md
+++ b/specs/011-map-shell-config/research.md
@@ -57,7 +57,7 @@
 
 ## Decision 6: Document casing conventions separately for config and environment variables
 
-**Decision**: Recommend PascalCase shell names in JSON/configuration files and show uppercase, underscore-separated environment variable paths where host environments commonly require or prefer uppercase keys, for example `CSHELLS__SHELLS__MY_SHELL__...`.
+**Decision**: Recommend PascalCase shell names in JSON/configuration files and show the same shell-name segment in environment variable paths, allowing casing differences but not added underscores, for example `CSHELLS__SHELLS__MYSHELL__...`.
 
 **Rationale**: Shell names are user-visible in configuration and management surfaces, while environment variables often follow uppercase conventions. Documenting both avoids ambiguity without adding custom normalization rules.
 

--- a/specs/011-map-shell-config/research.md
+++ b/specs/011-map-shell-config/research.md
@@ -1,0 +1,78 @@
+# Research: Map-Based Shell Configuration
+
+## Decision 1: Read shells as named configuration children
+
+**Decision**: Treat `CShells:Shells` as an object map. Each immediate child section is one shell, and the child section key is the shell name.
+
+**Rationale**: This matches how the .NET configuration system merges hierarchical keys: later providers override or extend the same path by key name. A named shell path such as `CShells:Shells:Default` is stable across file reordering and has a clear environment variable equivalent.
+
+**Alternatives considered**:
+
+- Continue binding `CShells:Shells` to a list: rejected because array indices merge by position and create opaque override paths.
+- Support both array and map shapes: rejected because the specification explicitly removes backward compatibility and the constitution favors simpler breaking changes when they improve API quality.
+
+## Decision 2: Shell identity comes only from the map key
+
+**Decision**: Populate runtime shell names, blueprint names, summaries, descriptors, and registry-visible names from the `CShells:Shells` child key only.
+
+**Rationale**: A single source of identity prevents drift between the configuration path and the runtime shell name. It also makes environment overrides self-documenting because the shell identifier appears in the path.
+
+**Alternatives considered**:
+
+- Allow an inner `Name` property to override the key: rejected because it reintroduces duplicate identity and weakens merge-by-name semantics.
+- Treat inner `Name` as a required field: rejected because the target format intentionally drops it.
+
+## Decision 3: Reject numeric shell child keys as unsupported array syntax
+
+**Decision**: If an immediate child under `CShells:Shells` has a numeric key, fail with an actionable error that identifies the path and explains that shell entries must be named.
+
+**Rationale**: Configuration arrays appear as numeric child keys. Rejecting them early prevents accidental activation from unsupported legacy configuration and gives users a direct migration clue.
+
+**Alternatives considered**:
+
+- Silently skip numeric children: rejected because silent failures violate explicit error handling and can hide missing shells.
+- Interpret numeric keys as shell names: rejected because it would make array syntax appear to work while creating invalid shell names like `0`.
+
+## Decision 4: Preserve existing feature map behavior
+
+**Decision**: Do not change feature parsing. A shell definition's `Features` node continues to use the existing feature object-map behavior, including treating a feature entry's inner `Name` as feature configuration rather than feature identity in object-map syntax.
+
+**Rationale**: The shell format change intentionally mirrors the already-supported feature map shape. Reworking feature parsing would expand scope and risk regressions unrelated to shell identity.
+
+**Alternatives considered**:
+
+- Remove legacy feature array support at the same time: rejected as unrelated scope; the feature specification only removes shell array support.
+- Add a new feature configuration shape: rejected because the existing map syntax already satisfies the need.
+
+## Decision 5: Keep direct-key lookup as the provider fast path
+
+**Decision**: `ConfigurationShellBlueprintProvider.GetAsync(name)` should continue to use direct child lookup for normal named shells and should remove the fallback scan for inner `Name` overrides.
+
+**Rationale**: Map syntax makes direct lookup correct by construction and avoids O(N) scans for normal requests. Removing the fallback also enforces the single-source-of-truth rule for shell identity.
+
+**Alternatives considered**:
+
+- Keep fallback scanning for compatibility: rejected because array/name compatibility is explicitly out of scope.
+- Always enumerate children: rejected because it is unnecessary and less scalable than direct lookup.
+
+## Decision 6: Document casing conventions separately for config and environment variables
+
+**Decision**: Recommend PascalCase shell names in JSON/configuration files and show uppercase, underscore-separated environment variable paths where host environments commonly require or prefer uppercase keys, for example `CSHELLS__SHELLS__MY_SHELL__...`.
+
+**Rationale**: Shell names are user-visible in configuration and management surfaces, while environment variables often follow uppercase conventions. Documenting both avoids ambiguity without adding custom normalization rules.
+
+**Alternatives considered**:
+
+- Require uppercase shell names everywhere: rejected because it degrades readability in JSON and runtime display names.
+- Implement custom environment variable name normalization: rejected because it would diverge from the existing configuration provider behavior.
+
+## Decision 7: Update configuration model serialization around shell maps
+
+**Decision**: Change root shell configuration models that represent `CShells:Shells` from list-shaped storage to map-shaped storage, while keeping per-shell `ShellConfig` focused on shell contents.
+
+**Rationale**: Direct JSON deserialization or serialization of the root configuration model should reflect the supported external contract. Keeping `Name` out of per-shell examples and model expectations reinforces map-key identity.
+
+**Alternatives considered**:
+
+- Keep list-shaped model but convert at provider boundaries: rejected because direct model usage would still expose unsupported array syntax.
+- Add separate legacy and map model types: rejected as unnecessary compatibility complexity.

--- a/specs/011-map-shell-config/spec.md
+++ b/specs/011-map-shell-config/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Map-Based Shell Configuration
+
+**Feature Branch**: `011-map-shell-config`  
+**Created**: 2026-05-07  
+**Status**: Draft  
+**Input**: User description: "CShells: Map-Based Shell Configuration. Replace the current array under `CShells:Shells`, where each shell repeats a `Name` property, with map syntax where each child key is the shell name. Drop the shell `Name` property, do not support both formats, update documentation and examples, document environment variable override paths and shell naming conventions, and verify map loading, shell naming, environment overrides, and configuration merging across layers."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Shells By Name (Priority: P1)
+
+As a CShells configuration author, I want shells declared as named entries under `CShells:Shells` so each shell's identity is visible in the configuration path and does not need to be repeated inside the shell body.
+
+**Why this priority**: This is the core format change. It makes shell configuration consistent with feature configuration and removes duplicate shell names from configuration files.
+
+**Independent Test**: Can be fully tested by loading a configuration whose `CShells:Shells` value is a named object map and confirming each shell exists with the name from its map key and the expected configuration and features.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configuration with `CShells:Shells:Default` and no inner `Name` value, **When** shell settings are loaded, **Then** the system creates a shell named `Default` with its configured routing and features.
+2. **Given** a configuration with multiple named shell entries, **When** shell settings are loaded, **Then** each resulting shell uses its own map key as its name and keeps its own configuration and feature settings.
+3. **Given** a shell entry that contains feature settings using the existing feature map syntax, **When** shell settings are loaded, **Then** the shell enables those features and preserves their configured values.
+
+---
+
+### User Story 2 - Override Shell Settings With Stable Paths (Priority: P2)
+
+As an operator, I want environment variable overrides to include the shell name rather than an array index so overrides are self-documenting and remain stable when configuration files are reordered.
+
+**Why this priority**: One of the main user-facing benefits is safer operational overrides. Named paths avoid brittle index-based overrides in deployment environments.
+
+**Independent Test**: Can be fully tested by loading base configuration plus an environment override such as `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY=test` and confirming the override applies only to the `Default` shell's `Identity` feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** a base configuration for shell `Default` with an `Identity` signing key, **When** an environment override targets `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY`, **Then** the `Default` shell receives the overridden signing key.
+2. **Given** multiple shells with the same feature enabled, **When** an environment override targets one named shell, **Then** only that named shell's feature setting changes.
+3. **Given** shell entries are reordered in a configuration file, **When** the same named environment override is applied, **Then** it still targets the same shell.
+
+---
+
+### User Story 3 - Merge Shell Configuration By Name (Priority: P3)
+
+As an application maintainer, I want configuration layers to merge shell entries by shell name so app defaults, deployment configuration, and environment overrides combine predictably.
+
+**Why this priority**: Named merging prevents accidental cross-shell configuration caused by array index differences across configuration layers.
+
+**Independent Test**: Can be fully tested by loading layered configuration where each layer defines or overrides named shell entries in different orders and confirming the final shell set and settings are merged by shell name.
+
+**Acceptance Scenarios**:
+
+1. **Given** a base layer defines `Default` and a later layer overrides `Default:Configuration:Plan`, **When** configuration is loaded, **Then** the final `Default` shell contains the overridden plan and retains unaffected settings from the base layer.
+2. **Given** a later layer adds a new named shell, **When** configuration is loaded, **Then** the final shell set contains both the original shells and the newly added shell.
+3. **Given** two layers list shell entries in different orders, **When** configuration is loaded, **Then** shell settings are combined by shell name rather than by position.
+
+---
+
+### User Story 4 - Update Guidance And Samples (Priority: P4)
+
+As a developer adopting CShells, I want documentation and sample configuration to show only the map-based shell format so new projects follow the supported shape from the start.
+
+**Why this priority**: Documentation must match the only supported format; otherwise users may copy an obsolete array shape that no longer loads.
+
+**Independent Test**: Can be fully tested by reviewing repository documentation and sample configuration and confirming all shell examples use named map entries without inner shell `Name` properties, including environment override guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a README, docs page, or sample configuration that shows `CShells:Shells`, **When** it is reviewed, **Then** it uses map syntax with shell names as keys and no shell-level `Name` property.
+2. **Given** environment variable guidance is documented, **When** a user reads it, **Then** it shows named paths such as `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY` and explains why named paths are stable.
+3. **Given** shell naming guidance is documented, **When** a user defines a shell intended for environment overrides, **Then** they can choose a name that is clear and compatible with environment variable path conventions.
+
+### Edge Cases
+
+- Shell entries with blank or whitespace-only map keys are invalid and must fail before shell activation with a clear message.
+- Shell entries that still rely on an inner shell `Name` value must not be accepted as an alternative source of shell identity.
+- A shell map entry that contains an inner `Name` setting must not override the map key; shell identity comes only from the map key.
+- Duplicate shell names after configuration provider normalization must resolve according to normal configuration precedence and must not produce two runtime shells with the same name.
+- Layered configuration where a later source adds nested settings for an existing shell must merge into that named shell without removing unrelated shell settings.
+- Environment variable shell-name casing may differ from display casing; matching must follow the configuration system's normal key matching behavior while preserving the configured shell name used by CShells.
+- Empty `CShells:Shells` configuration is valid only if existing startup behavior already permits no configured shells; otherwise it must fail with the existing missing-shell behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST accept `CShells:Shells` as a map whose child keys are shell names and whose values are shell definitions.
+- **FR-002**: The system MUST assign each loaded shell's name from its `CShells:Shells` map key.
+- **FR-003**: The system MUST no longer require or rely on a shell-level `Name` property inside each shell definition.
+- **FR-004**: The system MUST reject the previous array-based `CShells:Shells` shape as unsupported.
+- **FR-005**: The system MUST preserve existing shell definition content under each named shell, including `Configuration` values and feature map entries.
+- **FR-006**: The system MUST ensure all shell-facing APIs, registries, and runtime descriptors expose the shell name populated from the map key.
+- **FR-007**: The system MUST support named environment variable override paths for shell-specific feature settings, including `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY` targeting the `Default` shell's `Identity` feature signing key.
+- **FR-008**: The system MUST merge layered shell configuration by shell name so later layers can override or extend a named shell without depending on shell order.
+- **FR-009**: The system MUST fail before shell activation when a shell map key is blank or otherwise invalid for use as a shell name.
+- **FR-010**: The system MUST provide actionable error feedback when unsupported array syntax is encountered, including the affected configuration path.
+- **FR-011**: Documentation and sample configuration MUST use map syntax for all `CShells:Shells` examples and MUST remove shell-level `Name` properties from those examples.
+- **FR-012**: Documentation MUST include environment variable override examples that demonstrate named shell paths and explain that named paths are stable across configuration reordering.
+- **FR-013**: Documentation MUST define the shell naming convention for configuration keys: use PascalCase for display-oriented shell names, and use uppercase with underscores when writing environment variable paths where required by the host environment, for example `MyShell` represented as `CSHELLS__SHELLS__MY_SHELL__...`.
+
+### Key Entities *(include if feature involves data)*
+
+- **Shell Configuration Map**: The collection under `CShells:Shells` where each entry key is the shell name and each entry value is that shell's definition.
+- **Shell Definition**: The per-shell configuration payload containing shell-specific configuration values and enabled feature definitions, identified by the parent map key rather than by an inner property.
+- **Shell Name**: The stable identifier derived from a shell map key and exposed consistently through runtime shell settings, descriptors, registries, and management views.
+- **Feature Configuration Entry**: A named feature entry within a shell definition, preserving the existing feature map behavior and feature-specific settings.
+- **Configuration Layer**: A source of configuration values, such as base application settings, deployment-specific settings, or environment overrides, that contributes to the final named shell configuration.
+
+### Assumptions
+
+- Backward compatibility with the previous array-based shell format is intentionally out of scope.
+- Feature configuration map syntax remains unchanged.
+- Configuration key matching and environment variable normalization follow the host configuration system's existing behavior.
+- `Default` is the canonical shell name used in examples unless a sample needs multiple shells.
+- PascalCase is the preferred shell-name convention in configuration files because shell names are user-visible, while environment variable examples may use uppercase keys to match common deployment conventions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of map-format shell configuration tests load shells with names matching their `CShells:Shells` map keys.
+- **SC-002**: 100% of tests for shell-specific feature settings confirm existing feature map settings remain available after the shell format change.
+- **SC-003**: An environment override using `CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY=test` changes only the `Default` shell's `Identity` signing key in the verified configuration.
+- **SC-004**: Layered configuration tests demonstrate that at least three layers can override, extend, and add named shells without depending on array position.
+- **SC-005**: 100% of unsupported array-format shell configuration tests fail before shell activation with an actionable error that names the `CShells:Shells` path.
+- **SC-006**: Repository documentation and sample configuration contain no `CShells:Shells` array examples and no shell-level `Name` properties in shell examples.

--- a/specs/011-map-shell-config/spec.md
+++ b/specs/011-map-shell-config/spec.md
@@ -95,7 +95,7 @@ As a developer adopting CShells, I want documentation and sample configuration t
 - **FR-010**: The system MUST provide actionable error feedback when unsupported array syntax is encountered, including the affected configuration path.
 - **FR-011**: Documentation and sample configuration MUST use map syntax for all `CShells:Shells` examples and MUST remove shell-level `Name` properties from those examples.
 - **FR-012**: Documentation MUST include environment variable override examples that demonstrate named shell paths and explain that named paths are stable across configuration reordering.
-- **FR-013**: Documentation MUST define the shell naming convention for configuration keys: use PascalCase for display-oriented shell names, and use uppercase with underscores when writing environment variable paths where required by the host environment, for example `MyShell` represented as `CSHELLS__SHELLS__MY_SHELL__...`.
+- **FR-013**: Documentation MUST define the shell naming convention for configuration keys: use PascalCase for display-oriented shell names, and use the same shell-name segment without adding underscores when writing environment variable paths, for example `MyShell` represented as `CSHELLS__SHELLS__MYSHELL__...`.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/011-map-shell-config/tasks.md
+++ b/specs/011-map-shell-config/tasks.md
@@ -1,0 +1,241 @@
+# Tasks: Map-Based Shell Configuration
+
+**Input**: Design documents from `/specs/011-map-shell-config/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/configuration-schema.md, quickstart.md
+
+**Tests**: Test tasks are included because the specification explicitly requires verification for map loading, shell naming, environment overrides, layered merging, unsupported array rejection, and documentation/sample updates.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other tasks in the same phase because it touches different files or has no dependency on incomplete tasks
+- **[Story]**: User story label for story phases only
+- Every task includes an exact repository path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the current baseline and affected surface before changing behavior.
+
+- [X] T001 Review existing shell configuration model and provider behavior in src/CShells/Configuration/CShellsOptions.cs, src/CShells/Configuration/ShellConfig.cs, and src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T002 [P] Review existing provider tests in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs for explicit Name fallback and array shell expectations
+- [X] T003 [P] Review existing configuration model tests in tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs for shell-level Name and list-shaped CShellsOptions assumptions
+- [X] T004 [P] Review sample and documentation shell-array references in README.md, docs/, wiki/, samples/CShells.Workbench/appsettings.json, src/CShells/README.md, src/CShells.AspNetCore/README.md, and src/CShells.FastEndpoints/README.md
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared model/provider rules that every story depends on.
+
+**⚠️ CRITICAL**: No user story work can be completed until these shared behavior decisions are reflected in tests and code.
+
+- [X] T005 Change CShellsOptions.Shells from list-shaped storage to map-shaped storage in src/CShells/Configuration/CShellsOptions.cs
+- [X] T006 Remove shell identity requirements from ShellConfig and update XML docs to describe shell contents only in src/CShells/Configuration/ShellConfig.cs
+- [X] T007 Update or replace shell configuration JSON model tests for map-shaped root options in tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
+- [X] T008 Add a shared test helper for building CShells:Shells configuration sections in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+
+**Checkpoint**: Root configuration model and test scaffolding are ready for story-specific behavior.
+
+---
+
+## Phase 3: User Story 1 - Configure Shells By Name (Priority: P1) 🎯 MVP
+
+**Goal**: Shells load from named map entries, and runtime shell identity always comes from the map key.
+
+**Independent Test**: Load a map-format `CShells:Shells` section with multiple shell keys and verify provider get/list/compose operations expose the key-derived shell names and preserve configuration and feature settings.
+
+### Tests for User Story 1
+
+- [X] T009 [P] [US1] Add provider test for GetAsync using a map key without inner Name in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T010 [P] [US1] Add provider test for ListAsync returning map-key shell names in sorted order in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T011 [P] [US1] Add compose test proving map-key shell loads feature map settings and Configuration values in tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+- [X] T012 [P] [US1] Add test proving an inner shell-level Name value does not override the map key in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Remove explicit Name override fallback from GetAsync in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T014 [US1] Update ListAsync name resolution to return only validated child section keys in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T015 [US1] Replace ResolveShellName/TryResolveShellName helpers with a key-only validation helper in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T016 [US1] Update affected provider tests to expect key-derived names only in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T017 [US1] Run User Story 1 tests with dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~ConfigurationShellBlueprintProviderTests|FullyQualifiedName~ConfigurationShellBlueprintTests"
+
+**Checkpoint**: User Story 1 is functional and testable independently: map-format shells load by name and do not use inner shell Name for identity.
+
+---
+
+## Phase 4: User Story 2 - Override Shell Settings With Stable Paths (Priority: P2)
+
+**Goal**: Environment-style named paths target a specific shell and remain independent of shell ordering.
+
+**Independent Test**: Load base shell config plus named override keys and verify only the targeted shell's feature setting changes.
+
+### Tests for User Story 2
+
+- [X] T018 [P] [US2] Add environment-style override test for CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY__SIGNINGKEY behavior in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T019 [P] [US2] Add test proving named override affects only Default when Default and Contoso both configure Identity in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T020 [P] [US2] Add test proving shell entry order does not affect named lookup or override targeting in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Ensure ConfigurationShellBlueprintProvider.GetAsync directly resolves named shell sections after overrides in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T022 [US2] Ensure ConfigurationShellBlueprint ComposeAsync preserves feature map override values in src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
+- [X] T023 [US2] Run User Story 2 tests with dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~ConfigurationShellBlueprintProviderTests"
+
+**Checkpoint**: User Story 2 is functional and testable independently: named environment-style paths target the intended shell only.
+
+---
+
+## Phase 5: User Story 3 - Merge Shell Configuration By Name (Priority: P3)
+
+**Goal**: Layered configuration combines shell definitions by shell name, allowing overrides, extensions, and additions without array index coupling.
+
+**Independent Test**: Load multiple configuration layers with named shell entries in different orders and verify the final shell set and settings merge by shell name.
+
+### Tests for User Story 3
+
+- [X] T024 [P] [US3] Add layered merge test where a later layer overrides Default:Configuration:Plan while preserving other Default values in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T025 [P] [US3] Add layered merge test where a later layer adds Contoso beside Default in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T026 [P] [US3] Add unsupported array syntax test for numeric CShells:Shells child keys in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+- [X] T027 [P] [US3] Update integration tests that currently use CShells:Shells:0 paths to named shell paths in tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
+
+### Implementation for User Story 3
+
+- [X] T028 [US3] Add numeric child-key rejection with an actionable CShells:Shells error in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T029 [US3] Ensure ListAsync fails before activation when numeric child keys indicate array shell syntax in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T030 [US3] Ensure GetAsync does not skip unrelated numeric array entries during lookup in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+- [X] T031 [US3] Run User Story 3 tests with dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~ConfigurationShellBlueprintProviderTests|FullyQualifiedName~ShellRegistryConfigureAllShellsTests"
+
+**Checkpoint**: User Story 3 is functional and testable independently: layered named configuration merges correctly and array shell syntax is rejected.
+
+---
+
+## Phase 6: User Story 4 - Update Guidance And Samples (Priority: P4)
+
+**Goal**: Repository documentation and samples show only map-based shell configuration and named environment override paths.
+
+**Independent Test**: Search documentation and samples for old `CShells:Shells` array examples, shell-level Name properties in shell examples, and index-based override paths; verify none remain except intentionally documented unsupported examples.
+
+### Documentation Tasks for User Story 4
+
+- [X] T032 [P] [US4] Update root shell configuration examples and env-var guidance in README.md
+- [X] T033 [P] [US4] Update shell configuration guide examples in wiki/Configuring-Shells.md
+- [X] T034 [P] [US4] Update getting started shell examples in docs/getting-started.md and wiki/Getting-Started.md
+- [X] T035 [P] [US4] Update shell resolution examples in docs/shell-resolution.md and wiki/Shell-Resolution.md
+- [X] T036 [P] [US4] Update integration pattern examples in docs/integration-patterns.md and wiki/Integration-Patterns.md
+- [X] T037 [P] [US4] Update feature configuration precedence and override examples in docs/feature-configuration.md and wiki/Feature-Configuration.md
+- [X] T038 [P] [US4] Update FastEndpoints shell examples in src/CShells.FastEndpoints/README.md and wiki/FastEndpoints-Integration.md
+- [X] T039 [P] [US4] Update package README examples in src/CShells/README.md and src/CShells.AspNetCore/README.md
+- [X] T040 [P] [US4] Convert sample app shell configuration to map syntax in samples/CShells.Workbench/appsettings.json
+- [X] T041 [P] [US4] Review provider-specific standalone shell file examples in src/CShells.Providers.FluentStorage/README.md and update only references that describe CShells:Shells root syntax
+
+### Validation for User Story 4
+
+- [X] T042 [US4] Run documentation search to verify no unsupported CShells:Shells array examples remain in README.md, docs/, wiki/, samples/, and src/*/README.md
+- [X] T043 [US4] Run documentation search to verify index-based shell override paths such as CShells:Shells:0 and CShells__Shells__0 are replaced in README.md, docs/, wiki/, samples/, and src/*/README.md
+
+**Checkpoint**: User Story 4 is functional and testable independently: docs and samples teach the supported map syntax only.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the whole feature, clean up migration residue, and ensure quickstart scenarios pass.
+
+- [X] T044 [P] Remove or update obsolete comments mentioning shell array support in src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs and src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
+- [X] T045 [P] Search source and tests for CShells:Shells:0 paths and update any remaining shell-root usages to named paths in src/ and tests/
+- [X] T046 [P] Search source and tests for shell-level Name assumptions in root shell configuration models and remove unsupported expectations in src/ and tests/
+- [X] T047 Run quickstart verification commands from specs/011-map-shell-config/quickstart.md
+- [X] T048 Run full validation with dotnet test and dotnet build
+- [X] T049 Review git diff for unrelated changes and keep the final patch scoped to map-based shell configuration
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup; blocks user story completion.
+- **User Story 1 (Phase 3)**: Depends on Foundational; establishes map-key shell identity and is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational and benefits from US1 implementation; can be tested through named provider paths.
+- **User Story 3 (Phase 5)**: Depends on Foundational and US1 rejection/name-resolution behavior.
+- **User Story 4 (Phase 6)**: Depends on the contract decisions and can run in parallel with code stories after Foundational.
+- **Polish (Phase 7)**: Depends on desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 Configure Shells By Name**: MVP; no dependency on other user stories after Foundational.
+- **US2 Override Shell Settings With Stable Paths**: Requires map-key lookup from US1 for final behavior; tests can be drafted in parallel.
+- **US3 Merge Shell Configuration By Name**: Requires map-key validation and array rejection semantics from US1.
+- **US4 Update Guidance And Samples**: Can be implemented in parallel with code changes once the supported contract is stable.
+
+### Within Each User Story
+
+- Write/update tests first and confirm they fail where behavior changes.
+- Implement the minimum code or documentation change for the story.
+- Run the story-specific validation command before moving to the next story.
+- Keep story changes independently reviewable.
+
+### Parallel Opportunities
+
+- T002, T003, and T004 can run in parallel during setup.
+- T009, T010, T011, and T012 can be drafted in parallel because they cover separate acceptance cases.
+- T018, T019, and T020 can be drafted in parallel because they are independent override scenarios.
+- T024, T025, T026, and T027 can be drafted in parallel because they cover separate merge/rejection scenarios.
+- T032 through T041 can run in parallel because they touch different documentation/sample files.
+- T044, T045, and T046 can run in parallel after all implementation stories are complete.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add provider test for GetAsync using a map key without inner Name in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs"
+Task: "Add provider test for ListAsync returning map-key shell names in sorted order in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs"
+Task: "Add compose test proving map-key shell loads feature map settings and Configuration values in tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs"
+Task: "Add test proving an inner shell-level Name value does not override the map key in tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs"
+```
+
+## Parallel Example: User Story 4
+
+```bash
+Task: "Update root shell configuration examples and env-var guidance in README.md"
+Task: "Update shell configuration guide examples in wiki/Configuring-Shells.md"
+Task: "Update getting started shell examples in docs/getting-started.md and wiki/Getting-Started.md"
+Task: "Convert sample app shell configuration to map syntax in samples/CShells.Workbench/appsettings.json"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Stop and validate with T017.
+5. Demonstrate that `CShells:Shells:Default` loads a shell named `Default` without an inner `Name` property.
+
+### Incremental Delivery
+
+1. Deliver US1 to establish map-key shell identity.
+2. Deliver US2 to prove named override paths work for operators.
+3. Deliver US3 to prove layered configuration merges by name and old array syntax fails clearly.
+4. Deliver US4 to align docs and samples with the only supported shape.
+5. Complete Phase 7 validation before handoff.
+
+### Parallel Team Strategy
+
+1. One developer updates provider/model behavior for US1-US3.
+2. Another developer updates docs and samples for US4 after the contract is confirmed.
+3. Tests for US2 and US3 can be drafted while US1 implementation is in progress.
+4. Final validation runs after code, docs, and samples converge.
+
+## Notes
+
+- `[P]` tasks must not edit the same file at the same time unless coordinated.
+- Feature configuration array support is not in scope for removal; only shell array syntax under `CShells:Shells` is removed.
+- Provider-specific standalone shell JSON files may still legitimately contain a shell-level `Name` if they are not examples of the `CShells:Shells` root map contract; review before changing.
+- Keep error messages actionable and include `CShells:Shells` when rejecting old array syntax.

--- a/src/CShells.Abstractions/ShellSettings.cs
+++ b/src/CShells.Abstractions/ShellSettings.cs
@@ -36,7 +36,7 @@ public class ShellSettings
     /// Gets or sets shell-specific configuration data as a dictionary.
     /// Keys use colon-separated format for hierarchical data (e.g., "WebRouting:Path").
     /// </summary>
-    public IDictionary<string, object> ConfigurationData { get; set; } = new Dictionary<string, object>();
+    public IDictionary<string, object> ConfigurationData { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets the code-first feature configurators registered via

--- a/src/CShells.AspNetCore/README.md
+++ b/src/CShells.AspNetCore/README.md
@@ -54,19 +54,17 @@ public class WeatherFeature : IWebShellFeature
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Weather"],
+    "Shells": {
+      "Default": {
+        "Features": { "Weather": {} },
         "Configuration": {
           "WebRouting": {
             "Path": ""
           }
         }
       },
-      {
-        "Name": "Admin",
-        "Features": ["Admin"],
+      "Admin": {
+        "Features": { "Admin": {} },
         "Configuration": {
           "WebRouting": {
             "Path": "admin",
@@ -74,7 +72,7 @@ public class WeatherFeature : IWebShellFeature
           }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/src/CShells.FastEndpoints/README.md
+++ b/src/CShells.FastEndpoints/README.md
@@ -63,10 +63,9 @@ public class GetWeatherEndpoint : EndpointWithoutRequest<WeatherResponse>
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "FastEndpoints", "MyApi"],
+    "Shells": {
+      "Default": {
+        "Features": { "Core": {}, "FastEndpoints": {}, "MyApi": {} },
         "Configuration": {
           "WebRouting": {
             "Path": "",
@@ -77,7 +76,7 @@ public class GetWeatherEndpoint : EndpointWithoutRequest<WeatherResponse>
           }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/src/CShells/Configuration/CShellsOptions.cs
+++ b/src/CShells/Configuration/CShellsOptions.cs
@@ -11,7 +11,7 @@ public class CShellsOptions
     public const string SectionName = "CShells";
 
     /// <summary>
-    /// Gets or sets the collection of shell configurations.
+    /// Gets or sets shell configurations keyed by shell name.
     /// </summary>
-    public List<ShellConfig> Shells { get; set; } = [];
+    public Dictionary<string, ShellConfig> Shells { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/CShells/Configuration/ShellConfig.cs
+++ b/src/CShells/Configuration/ShellConfig.cs
@@ -3,12 +3,13 @@ using System.Text.Json.Serialization;
 namespace CShells.Configuration;
 
 /// <summary>
-/// Configuration model for a shell section in appsettings.json.
+/// Configuration model for a single shell definition.
 /// </summary>
 public class ShellConfig
 {
     /// <summary>
-    /// Gets or sets the name of the shell.
+    /// Gets or sets the optional shell name used by standalone shell configuration providers.
+    /// Root <c>CShells:Shells</c> configuration derives shell identity from the parent map key.
     /// </summary>
     public string Name { get; set; } = string.Empty;
 

--- a/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
@@ -24,6 +24,7 @@ namespace CShells.Lifecycle.Providers;
 public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvider
 {
     private readonly IConfiguration _shellsSection;
+    private const string ShellsPath = "CShells:Shells";
 
     /// <summary>Stable identifier emitted as <see cref="BlueprintSummary.SourceId"/>.</summary>
     public const string SourceIdValue = nameof(ConfigurationShellBlueprintProvider);
@@ -37,33 +38,12 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
     public Task<ProvidedBlueprint?> GetAsync(string name, CancellationToken cancellationToken = default)
     {
         Guard.Against.NullOrWhiteSpace(name);
+        ValidateShellEntries();
 
-        // O(1) fast path: direct key lookup. Covers the common case where the configuration
-        // key matches the shell name.
-        var direct = _shellsSection.GetSection(name);
-        if (direct.Exists())
-        {
-            var candidate = ResolveShellName(direct);
-            if (string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.FromResult<ProvidedBlueprint?>(
-                    new ProvidedBlueprint(new ConfigurationShellBlueprint(candidate, direct)));
-            }
-        }
-
-        // O(N) fallback: the configured child may expose a different name via an explicit
-        // "Name" property whose value differs from the key. Scan to honor that override.
-        foreach (var child in _shellsSection.GetChildren())
-        {
-            if (!TryResolveShellName(child, out var candidate))
-                continue;
-
-            if (string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.FromResult<ProvidedBlueprint?>(
-                    new ProvidedBlueprint(new ConfigurationShellBlueprint(candidate, child)));
-            }
-        }
+        var direct = FindShellSection(name);
+        if (direct is not null)
+            return Task.FromResult<ProvidedBlueprint?>(
+                new ProvidedBlueprint(new ConfigurationShellBlueprint(ValidateShellName(direct), direct)));
 
         return Task.FromResult<ProvidedBlueprint?>(null);
     }
@@ -74,8 +54,10 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         Guard.Against.Null(query);
         query.EnsureValid();
 
+        ValidateShellEntries();
+
         var ordered = _shellsSection.GetChildren()
-            .Select(ResolveShellName)
+            .Select(ValidateShellName)
             .Where(name => query.NamePrefix is null ||
                            name.StartsWith(query.NamePrefix, StringComparison.OrdinalIgnoreCase))
             .Where(name => query.Cursor is null ||
@@ -98,37 +80,37 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         return Task.FromResult(new BlueprintPage(items, nextCursor));
     }
 
-    private static string ResolveShellName(IConfigurationSection shellSection)
+    private void ValidateShellEntries()
     {
-        var configuredName = shellSection["Name"];
-        if (!string.IsNullOrWhiteSpace(configuredName))
-            return configuredName.Trim();
-
-        if (int.TryParse(shellSection.Key, out _))
-        {
-            throw new InvalidOperationException(
-                $"Configured shell entry '{shellSection.Path}' must define a non-empty 'Name' property when using array syntax.");
-        }
-
-        return shellSection.Key.Trim();
+        foreach (var child in _shellsSection.GetChildren())
+            ValidateShellName(child);
     }
 
-    private static bool TryResolveShellName(IConfigurationSection shellSection, out string name)
+    private IConfigurationSection? FindShellSection(string name)
     {
-        var configuredName = shellSection["Name"];
-        if (!string.IsNullOrWhiteSpace(configuredName))
+        foreach (var child in _shellsSection.GetChildren())
+            if (string.Equals(ValidateShellName(child), name, StringComparison.OrdinalIgnoreCase))
+                return child;
+
+        return null;
+    }
+
+    private static string ValidateShellName(IConfigurationSection shellSection)
+    {
+        var shellName = shellSection.Key.Trim();
+
+        if (string.IsNullOrWhiteSpace(shellName))
         {
-            name = configuredName.Trim();
-            return true;
+            throw new InvalidOperationException(
+                $"Configured shell entry '{shellSection.Path}' under '{ShellsPath}' must use a non-empty shell name as the map key.");
         }
 
-        if (int.TryParse(shellSection.Key, out _))
+        if (int.TryParse(shellName, out _))
         {
-            name = "";
-            return false;
+            throw new InvalidOperationException(
+                $"Configured shell entry '{shellSection.Path}' under '{ShellsPath}' uses unsupported array syntax. Configure shells as named map entries, for example '{ShellsPath}:Default'.");
         }
 
-        name = shellSection.Key.Trim();
-        return true;
+        return shellName;
     }
 }

--- a/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfigurationShellBlueprintProvider.cs
@@ -38,10 +38,8 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
     public Task<ProvidedBlueprint?> GetAsync(string name, CancellationToken cancellationToken = default)
     {
         Guard.Against.NullOrWhiteSpace(name);
-        ValidateShellEntries();
-
-        var direct = FindShellSection(name);
-        if (direct is not null)
+        var shells = LoadShellEntries();
+        if (shells.TryGetValue(name, out var direct))
             return Task.FromResult<ProvidedBlueprint?>(
                 new ProvidedBlueprint(new ConfigurationShellBlueprint(ValidateShellName(direct), direct)));
 
@@ -54,9 +52,9 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         Guard.Against.Null(query);
         query.EnsureValid();
 
-        ValidateShellEntries();
+        var shells = LoadShellEntries();
 
-        var ordered = _shellsSection.GetChildren()
+        var ordered = shells.Values
             .Select(ValidateShellName)
             .Where(name => query.NamePrefix is null ||
                            name.StartsWith(query.NamePrefix, StringComparison.OrdinalIgnoreCase))
@@ -80,19 +78,13 @@ public sealed class ConfigurationShellBlueprintProvider : IShellBlueprintProvide
         return Task.FromResult(new BlueprintPage(items, nextCursor));
     }
 
-    private void ValidateShellEntries()
+    private Dictionary<string, IConfigurationSection> LoadShellEntries()
     {
+        var shells = new Dictionary<string, IConfigurationSection>(StringComparer.OrdinalIgnoreCase);
         foreach (var child in _shellsSection.GetChildren())
-            ValidateShellName(child);
-    }
+            shells[ValidateShellName(child)] = child;
 
-    private IConfigurationSection? FindShellSection(string name)
-    {
-        foreach (var child in _shellsSection.GetChildren())
-            if (string.Equals(ValidateShellName(child), name, StringComparison.OrdinalIgnoreCase))
-                return child;
-
-        return null;
+        return shells;
     }
 
     private static string ValidateShellName(IConfigurationSection shellSection)

--- a/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
@@ -58,7 +58,9 @@ internal sealed class ConfiguredShellBlueprintProvider(
             var merged = new ShellSettings(shellSpecific.Id)
             {
                 EnabledFeatures = MergeFeatures(defaults.EnabledFeatures, shellSpecific.EnabledFeatures),
-                ConfigurationData = new Dictionary<string, object>(defaults.ConfigurationData)
+                ConfigurationData = new Dictionary<string, object>(
+                    defaults.ConfigurationData,
+                    StringComparer.OrdinalIgnoreCase)
             };
 
             foreach (var (key, value) in shellSpecific.ConfigurationData)

--- a/src/CShells/README.md
+++ b/src/CShells/README.md
@@ -46,12 +46,11 @@ public class CoreFeature : IShellFeature
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": [ "Core" ]
+    "Shells": {
+      "Default": {
+        "Features": { "Core": {} }
       }
-    ]
+    }
   }
 }
 ```

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
@@ -31,8 +31,7 @@ public class ShellRegistryConfigureAllShellsTests
         // Build a minimal IConfiguration that defines a shell with one feature.
         var configData = new Dictionary<string, string?>
         {
-            ["CShells:Shells:0:Name"] = "catalog",
-            ["CShells:Shells:0:Features:0"] = "ShellSpecificFeature",
+            ["CShells:Shells:catalog:Features:ShellSpecificFeature:Enabled"] = "true",
         };
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(configData)
@@ -90,8 +89,7 @@ public class ShellRegistryConfigureAllShellsTests
     {
         var configData = new Dictionary<string, string?>
         {
-            ["CShells:Shells:0:Name"] = "catalog",
-            ["CShells:Shells:0:Configuration:Plan"] = "Enterprise",
+            ["CShells:Shells:catalog:Configuration:Plan"] = "Enterprise",
         };
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(configData)

--- a/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
@@ -11,44 +11,41 @@ public class ShellConfigJsonConverterTests
         Converters = { new FeatureEntryListJsonConverter() }
     };
 
-    [Fact(DisplayName = "ShellConfig round-trip with object-map Features preserves features")]
-    public void RoundTrip_ObjectMapFeatures_PreservesFeatures()
+    [Fact(DisplayName = "CShellsOptions round-trip with shell map preserves shell keys and features")]
+    public void CShellsOptions_RoundTrip_ShellMapPreservesKeysAndFeatures()
     {
-        // Arrange
         var json = """
         {
-            "Name": "Default",
-            "Features": {
-                "Core": {},
-                "Posts": {},
-                "Analytics": { "TopPostsCount": 10 }
+            "Shells": {
+                "Default": {
+                    "Features": {
+                        "Core": {},
+                        "Posts": {},
+                        "Analytics": { "TopPostsCount": 10 }
+                    }
+                }
             }
         }
         """;
 
-        // Act — deserialize
-        var config = Deserialize(json);
+        var options = JsonSerializer.Deserialize<CShellsOptions>(json, Options);
+        var serialized = JsonSerializer.Serialize(options, Options);
+        var roundTripped = JsonSerializer.Deserialize<CShellsOptions>(serialized, Options);
 
-        // Act — serialize back
-        var serialized = JsonSerializer.Serialize(config, Options);
-        var roundTripped = Deserialize(serialized);
-
-        // Assert
-        Assert.Equal("Default", roundTripped.Name);
-        Assert.Equal(3, roundTripped.Features.Count);
-        Assert.Equal("Core", roundTripped.Features[0].Name);
-        Assert.Equal("Posts", roundTripped.Features[1].Name);
-        Assert.Equal("Analytics", roundTripped.Features[2].Name);
-        Assert.Equal(10, roundTripped.Features[2].Settings["TopPostsCount"]);
+        Assert.NotNull(roundTripped);
+        var shell = Assert.Single(roundTripped.Shells, pair => pair.Key == "Default").Value;
+        Assert.Equal(3, shell.Features.Count);
+        Assert.Equal("Core", shell.Features[0].Name);
+        Assert.Equal("Posts", shell.Features[1].Name);
+        Assert.Equal("Analytics", shell.Features[2].Name);
+        Assert.Equal(10, shell.Features[2].Settings["TopPostsCount"]);
     }
 
     [Fact(DisplayName = "ShellConfig round-trip with array Features preserves features")]
     public void RoundTrip_ArrayFeatures_PreservesFeatures()
     {
-        // Arrange
         var json = """
         {
-            "Name": "Default",
             "Features": [
                 "Core",
                 { "Name": "Analytics", "TopPostsCount": 10 }
@@ -56,14 +53,10 @@ public class ShellConfigJsonConverterTests
         }
         """;
 
-        // Act — deserialize
         var config = Deserialize(json);
-
-        // Act — serialize back (now outputs object-map form)
         var serialized = JsonSerializer.Serialize(config, Options);
         var roundTripped = Deserialize(serialized);
 
-        // Assert
         Assert.Equal(2, roundTripped.Features.Count);
         Assert.Equal("Core", roundTripped.Features[0].Name);
         Assert.Equal("Analytics", roundTripped.Features[1].Name);
@@ -73,10 +66,8 @@ public class ShellConfigJsonConverterTests
     [Fact(DisplayName = "ShellConfig serialization prefers object-map output")]
     public void Serialization_PrefersObjectMapOutput()
     {
-        // Arrange
         var config = new ShellConfig
         {
-            Name = "TestShell",
             Features =
             [
                 FeatureEntry.FromName("Core"),
@@ -84,10 +75,8 @@ public class ShellConfigJsonConverterTests
             ]
         };
 
-        // Act
         var json = JsonSerializer.Serialize(config, Options);
 
-        // Assert
         var features = ParseFeatures(json);
         Assert.Equal(JsonValueKind.Object, features.ValueKind);
         Assert.True(features.TryGetProperty("Core", out _));
@@ -97,17 +86,13 @@ public class ShellConfigJsonConverterTests
     [Fact(DisplayName = "ShellConfig serialization emits empty objects for features without settings")]
     public void Serialization_EmitsEmptyObjects_ForFeaturesWithoutSettings()
     {
-        // Arrange
         var config = new ShellConfig
         {
-            Name = "TestShell",
             Features = [FeatureEntry.FromName("Core"), FeatureEntry.FromName("Posts")]
         };
 
-        // Act
         var json = JsonSerializer.Serialize(config, Options);
 
-        // Assert
         var features = ParseFeatures(json);
         Assert.Equal("{}", features.GetProperty("Core").GetRawText());
         Assert.Equal("{}", features.GetProperty("Posts").GetRawText());
@@ -116,10 +101,8 @@ public class ShellConfigJsonConverterTests
     [Fact(DisplayName = "ShellConfig deserialization handles object-map with nested settings")]
     public void Deserialization_ObjectMap_NestedSettings()
     {
-        // Arrange
         var json = """
         {
-            "Name": "TestShell",
             "Features": {
                 "Database": {
                     "Connection": {
@@ -131,10 +114,8 @@ public class ShellConfigJsonConverterTests
         }
         """;
 
-        // Act
         var config = Deserialize(json);
 
-        // Assert
         Assert.Single(config.Features);
         Assert.Equal("Database", config.Features[0].Name);
         var connection = Assert.IsType<JsonElement>(config.Features[0].Settings["Connection"]);
@@ -145,19 +126,16 @@ public class ShellConfigJsonConverterTests
     [Fact(DisplayName = "ShellConfig serialization rejects duplicate feature names")]
     public void Serialization_RejectsDuplicateFeatureNames()
     {
-        // Arrange — a ShellConfig with duplicate feature names
         var config = new ShellConfig
         {
-            Name = "TestShell",
             Features =
             [
                 FeatureEntry.FromName("Core"),
                 FeatureEntry.FromName("Analytics"),
-                FeatureEntry.FromName("Core") // duplicate
+                FeatureEntry.FromName("Core")
             ]
         };
 
-        // Act & Assert
         var ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(config, Options));
         Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Core", ex.Message);
@@ -166,29 +144,23 @@ public class ShellConfigJsonConverterTests
     [Fact(DisplayName = "ShellConfig deserialization of array with duplicate features preserves both")]
     public void Deserialization_ArrayWithDuplicates_PreservesBoth()
     {
-        // Arrange — JSON array with duplicates (JSON is valid; validation happens downstream)
         var json = """
         {
-            "Name": "TestShell",
             "Features": ["Core", "Core"]
         }
         """;
 
-        // Act
         var config = Deserialize(json);
 
-        // Assert — deserialization doesn't reject; runtime validation does
         Assert.Equal(2, config.Features.Count);
         Assert.All(config.Features, f => Assert.Equal("Core", f.Name));
     }
 
-    [Fact(DisplayName = "ShellConfig deserialization converts both shapes to same model")]
-    public void Deserialization_BothShapes_ProduceSameModel()
+    [Fact(DisplayName = "ShellConfig deserialization converts both feature shapes to same model")]
+    public void Deserialization_BothFeatureShapes_ProduceSameModel()
     {
-        // Arrange
         var arrayJson = """
         {
-            "Name": "Shell",
             "Features": [
                 "Core",
                 { "Name": "Analytics", "TopPostsCount": 10 }
@@ -198,7 +170,6 @@ public class ShellConfigJsonConverterTests
 
         var objectMapJson = """
         {
-            "Name": "Shell",
             "Features": {
                 "Core": {},
                 "Analytics": { "TopPostsCount": 10 }
@@ -206,19 +177,17 @@ public class ShellConfigJsonConverterTests
         }
         """;
 
-        // Act
         var arrayConfig = Deserialize(arrayJson);
         var objectMapConfig = Deserialize(objectMapJson);
 
-        // Assert
         Assert.Equal(arrayConfig.Features.Count, objectMapConfig.Features.Count);
 
-        for (var i = 0; i < arrayConfig.Features.Count; i++)
+        for (var index = 0; index < arrayConfig.Features.Count; index++)
         {
-            Assert.Equal(arrayConfig.Features[i].Name, objectMapConfig.Features[i].Name);
+            Assert.Equal(arrayConfig.Features[index].Name, objectMapConfig.Features[index].Name);
             Assert.Equal(
-                arrayConfig.Features[i].Settings.Keys.OrderBy(k => k),
-                objectMapConfig.Features[i].Settings.Keys.OrderBy(k => k));
+                arrayConfig.Features[index].Settings.Keys.OrderBy(k => k),
+                objectMapConfig.Features[index].Settings.Keys.OrderBy(k => k));
         }
     }
 

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -10,6 +10,28 @@ public class ConfigurationShellBlueprintTests
     {
         public new void Set(string key, string? value) => Data[key] = value;
     }
+
+    [Fact(DisplayName = "ComposeAsync uses blueprint name and loads map feature settings with shell configuration")]
+    public async Task ComposeAsync_MapFeatureSettingsAndShellConfiguration_LoadsRuntimeSettings()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:Identity:SigningKey"] = "secret",
+            ["Configuration:WebRouting:Path"] = "",
+            ["Configuration:Plan"] = "Enterprise",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal("Default", settings.Id.Name);
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Equal("secret", settings.ConfigurationData["Identity:SigningKey"]);
+        Assert.Equal("", settings.ConfigurationData["WebRouting:Path"]);
+        Assert.Equal("Enterprise", settings.ConfigurationData["Plan"]);
+    }
+
     [Fact(DisplayName = "ComposeAsync reflects runtime changes to the underlying IConfiguration")]
     public async Task ComposeAsync_ReflectsRuntimeConfigChanges()
     {

--- a/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Providers/ConfigurationShellBlueprintProviderTests.cs
@@ -7,62 +7,45 @@ namespace CShells.Tests.Unit.Lifecycle.Providers;
 public class ConfigurationShellBlueprintProviderTests
 {
     [Fact(DisplayName = "GetAsync returns the blueprint when the name exists as a child key")]
-    public async Task Get_ByKey()
+    public async Task GetAsync_MapKeyExists_ReturnsBlueprint()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["acme:Features:0"] = "Core",
-            ["contoso:Features:0"] = "Core",
+            ["Acme:Features:Core"] = "",
+            ["Contoso:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
-
-        var result = await provider.GetAsync("acme");
-
-        Assert.NotNull(result);
-        Assert.Equal("acme", result!.Blueprint.Name);
-        Assert.Null(result.Manager);
-    }
-
-    [Fact(DisplayName = "GetAsync returns the blueprint when the child declares an explicit Name")]
-    public async Task Get_ByExplicitName()
-    {
-        var section = BuildSection(new Dictionary<string, string?>
-        {
-            ["t1:Name"] = "Acme",
-            ["t2:Name"] = "Contoso",
-        });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
         var result = await provider.GetAsync("Acme");
 
         Assert.NotNull(result);
         Assert.Equal("Acme", result!.Blueprint.Name);
+        Assert.Null(result.Manager);
     }
 
-    [Fact(DisplayName = "GetAsync falls back to object-map key when explicit Name is blank")]
-    public async Task Get_ObjectMapBlankName_FallsBackToKey()
+    [Fact(DisplayName = "GetAsync ignores shell-level Name as identity override")]
+    public async Task GetAsync_ShellLevelNameDiffersFromMapKey_UsesMapKeyOnly()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["Default:Name"] = "",
-            ["Default:Features:0"] = "Core",
+            ["Default:Name"] = "Renamed",
+            ["Default:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
-        var result = await provider.GetAsync("Default");
+        var byMapKey = await provider.GetAsync("Default");
+        var byInnerName = await provider.GetAsync("Renamed");
 
-        Assert.NotNull(result);
-        Assert.Equal("Default", result!.Blueprint.Name);
+        Assert.NotNull(byMapKey);
+        Assert.Equal("Default", byMapKey!.Blueprint.Name);
+        Assert.Null(byInnerName);
     }
 
     [Fact(DisplayName = "GetAsync is case-insensitive")]
-    public async Task Get_CaseInsensitive()
+    public async Task GetAsync_NameDiffersByCase_ReturnsBlueprint()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["ACME:Features:0"] = "Core",
+            ["ACME:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
         var lower = await provider.GetAsync("acme");
 
@@ -70,29 +53,27 @@ public class ConfigurationShellBlueprintProviderTests
     }
 
     [Fact(DisplayName = "GetAsync returns null for unknown name")]
-    public async Task Get_Unknown_ReturnsNull()
+    public async Task GetAsync_UnknownName_ReturnsNull()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["present:Features:0"] = "Core",
+            ["Present:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
-        var result = await provider.GetAsync("missing");
+        var result = await provider.GetAsync("Missing");
 
         Assert.Null(result);
     }
 
-    [Fact(DisplayName = "ListAsync returns children sorted by name; all entries are Mutable=false")]
-    public async Task List_SortedReadOnly()
+    [Fact(DisplayName = "ListAsync returns children sorted by map key; all entries are Mutable=false")]
+    public async Task ListAsync_MapKeys_ReturnsSortedReadOnlyBlueprints()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["c:Features:0"] = "Core",
-            ["a:Features:0"] = "Core",
-            ["b:Features:0"] = "Core",
+            ["c:Features:Core"] = "",
+            ["a:Features:Core"] = "",
+            ["b:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
         var page = await provider.ListAsync(new BlueprintListQuery(Limit: 10));
 
@@ -102,77 +83,159 @@ public class ConfigurationShellBlueprintProviderTests
     }
 
     [Fact(DisplayName = "ListAsync paginates with Limit and NextCursor")]
-    public async Task List_Paginates()
+    public async Task ListAsync_MultipleMapKeys_Paginates()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["a:Features:0"] = "Core",
-            ["b:Features:0"] = "Core",
-            ["c:Features:0"] = "Core",
-            ["d:Features:0"] = "Core",
-            ["e:Features:0"] = "Core",
+            ["a:Features:Core"] = "",
+            ["b:Features:Core"] = "",
+            ["c:Features:Core"] = "",
+            ["d:Features:Core"] = "",
+            ["e:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
         var first = await provider.ListAsync(new BlueprintListQuery(Limit: 2));
+        var second = await provider.ListAsync(new BlueprintListQuery(Cursor: first.NextCursor, Limit: 2));
+        var third = await provider.ListAsync(new BlueprintListQuery(Cursor: second.NextCursor, Limit: 2));
+
         Assert.Equal(["a", "b"], first.Items.Select(i => i.Name));
         Assert.NotNull(first.NextCursor);
-
-        var second = await provider.ListAsync(new BlueprintListQuery(Cursor: first.NextCursor, Limit: 2));
         Assert.Equal(["c", "d"], second.Items.Select(i => i.Name));
-
-        var third = await provider.ListAsync(new BlueprintListQuery(Cursor: second.NextCursor, Limit: 2));
         Assert.Equal(["e"], third.Items.Select(i => i.Name));
         Assert.Null(third.NextCursor);
     }
 
-    [Fact(DisplayName = "ListAsync falls back to object-map key when explicit Name is blank")]
-    public async Task List_ObjectMapBlankName_FallsBackToKey()
+    [Fact(DisplayName = "GetAsync rejects numeric shell children as unsupported array syntax")]
+    public async Task GetAsync_NumericChildKey_Throws()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["Default:Name"] = "",
-            ["Default:Features:0"] = "Core",
+            ["0:Name"] = "Acme",
+            ["0:Features:Core"] = "",
+            ["Default:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
-        var page = await provider.ListAsync(new BlueprintListQuery(Limit: 10));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetAsync("Default"));
 
-        Assert.Equal(["Default"], page.Items.Select(i => i.Name));
+        Assert.Contains("CShells:Shells", ex.Message);
+        Assert.Contains("array syntax", ex.Message);
+        Assert.Contains("named map entries", ex.Message);
     }
 
-    [Fact(DisplayName = "ListAsync rejects array shell entries without Name")]
-    public async Task List_ArrayEntryWithoutName_Throws()
+    [Fact(DisplayName = "ListAsync rejects numeric shell children as unsupported array syntax")]
+    public async Task ListAsync_NumericChildKey_Throws()
     {
-        var section = BuildSection(new Dictionary<string, string?>
+        var provider = BuildProvider(new Dictionary<string, string?>
         {
-            ["0:Features:0"] = "Core",
+            ["0:Features:Core"] = "",
         });
-        var provider = new ConfigurationShellBlueprintProvider(section);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             provider.ListAsync(new BlueprintListQuery(Limit: 10)));
-        Assert.Contains("Name", ex.Message);
+
+        Assert.Contains("CShells:Shells", ex.Message);
         Assert.Contains("array syntax", ex.Message);
     }
 
-    [Fact(DisplayName = "GetAsync skips unrelated invalid array shell entries during fallback scan")]
-    public async Task Get_FallbackScanSkipsUnrelatedInvalidArrayEntry()
+    [Fact(DisplayName = "Named override targets only the requested shell feature setting")]
+    public async Task ComposeAsync_NamedOverride_TargetsOnlyRequestedShell()
     {
-        var section = BuildSection(new Dictionary<string, string?>
-        {
-            ["0:Features:0"] = "Core",
-            ["1:Name"] = "Acme",
-            ["1:Features:0"] = "Core",
-        });
-        var provider = new ConfigurationShellBlueprintProvider(section);
+        var provider = BuildProvider(
+            new Dictionary<string, string?>
+            {
+                ["Default:Features:Identity:SigningKey"] = "default-base",
+                ["Contoso:Features:Identity:SigningKey"] = "contoso-base",
+            },
+            new Dictionary<string, string?>
+            {
+                ["CSHELLS:SHELLS:DEFAULT:FEATURES:IDENTITY:SIGNINGKEY"] = "test",
+            });
 
-        var result = await provider.GetAsync("Acme");
+        var defaultSettings = await (await provider.GetAsync("Default"))!.Blueprint.ComposeAsync();
+        var contosoSettings = await (await provider.GetAsync("Contoso"))!.Blueprint.ComposeAsync();
 
-        Assert.NotNull(result);
-        Assert.Equal("Acme", result!.Blueprint.Name);
+        Assert.Equal("test", defaultSettings.ConfigurationData["Identity:SigningKey"]);
+        Assert.Equal("contoso-base", contosoSettings.ConfigurationData["Identity:SigningKey"]);
     }
 
-    private static IConfiguration BuildSection(IDictionary<string, string?> pairs) =>
-        new ConfigurationBuilder().AddInMemoryCollection(pairs).Build();
+    [Fact(DisplayName = "Named lookup is stable when shell entries are reordered")]
+    public async Task ComposeAsync_ReorderedShellEntries_NamedLookupRemainsStable()
+    {
+        var firstOrder = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Default:Features:Identity:SigningKey"] = "default",
+            ["Contoso:Features:Identity:SigningKey"] = "contoso",
+        });
+        var secondOrder = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Contoso:Features:Identity:SigningKey"] = "contoso",
+            ["Default:Features:Identity:SigningKey"] = "default",
+        });
+
+        var firstSettings = await (await firstOrder.GetAsync("Default"))!.Blueprint.ComposeAsync();
+        var secondSettings = await (await secondOrder.GetAsync("Default"))!.Blueprint.ComposeAsync();
+
+        Assert.Equal("default", firstSettings.ConfigurationData["Identity:SigningKey"]);
+        Assert.Equal("default", secondSettings.ConfigurationData["Identity:SigningKey"]);
+    }
+
+    [Fact(DisplayName = "Layered configuration overrides named shell values while preserving unaffected settings")]
+    public async Task ComposeAsync_LayeredConfiguration_MergesByShellName()
+    {
+        var provider = BuildProvider(
+            new Dictionary<string, string?>
+            {
+                ["Default:Configuration:Plan"] = "Free",
+                ["Default:Configuration:WebRouting:Path"] = "",
+                ["Default:Features:Identity:SigningKey"] = "base",
+            },
+            new Dictionary<string, string?>
+            {
+                ["CShells:Shells:Default:Configuration:Plan"] = "Enterprise",
+            });
+
+        var settings = await (await provider.GetAsync("Default"))!.Blueprint.ComposeAsync();
+
+        Assert.Equal("Enterprise", settings.ConfigurationData["Plan"]);
+        Assert.Equal("", settings.ConfigurationData["WebRouting:Path"]);
+        Assert.Equal("base", settings.ConfigurationData["Identity:SigningKey"]);
+    }
+
+    [Fact(DisplayName = "Layered configuration adds new named shells")]
+    public async Task ListAsync_LayeredConfiguration_AddsNamedShells()
+    {
+        var provider = BuildProvider(
+            new Dictionary<string, string?>
+            {
+                ["Default:Features:Identity:SigningKey"] = "default",
+            },
+            new Dictionary<string, string?>
+            {
+                ["CShells:Shells:Contoso:Configuration:WebRouting:Path"] = "contoso",
+                ["CShells:Shells:Contoso:Features:Identity"] = "",
+            });
+
+        var page = await provider.ListAsync(new BlueprintListQuery(Limit: 10));
+
+        Assert.Equal(["Contoso", "Default"], page.Items.Select(i => i.Name));
+    }
+
+    private static ConfigurationShellBlueprintProvider BuildProvider(params IDictionary<string, string?>[] layers)
+    {
+        var builder = new ConfigurationBuilder();
+        foreach (var layer in layers)
+            builder.AddInMemoryCollection(AddShellsPrefix(layer));
+
+        return new ConfigurationShellBlueprintProvider(
+            builder.Build().GetSection("CShells:Shells"));
+    }
+
+    private static Dictionary<string, string?> AddShellsPrefix(IDictionary<string, string?> pairs) =>
+        pairs.ToDictionary(
+            pair => pair.Key.StartsWith("CShells:", StringComparison.OrdinalIgnoreCase) ||
+                    pair.Key.StartsWith("CSHELLS:", StringComparison.OrdinalIgnoreCase)
+                ? pair.Key
+                : $"CShells:Shells:{pair.Key}",
+            pair => pair.Value,
+            StringComparer.OrdinalIgnoreCase);
 }

--- a/wiki/Configuring-Shells.md
+++ b/wiki/Configuring-Shells.md
@@ -23,22 +23,23 @@ The default configuration source. CShells reads from the `"CShells"` section by 
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "Weather"],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {},
+          "Weather": {}
+        },
         "Configuration": {
           "WebRouting": {
             "Path": ""
           }
         }
       },
-      {
-        "Name": "Admin",
-        "Features": [
-          "Core",
-          { "Name": "Admin", "MaxUsers": 100, "EnableAuditLog": true }
-        ],
+      "Admin": {
+        "Features": {
+          "Core": {},
+          "Admin": { "MaxUsers": 100, "EnableAuditLog": true }
+        },
         "Configuration": {
           "WebRouting": {
             "Path": "admin",
@@ -46,7 +47,7 @@ The default configuration source. CShells reads from the `"CShells"` section by 
           }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/wiki/FastEndpoints-Integration.md
+++ b/wiki/FastEndpoints-Integration.md
@@ -76,10 +76,9 @@ public class GetProductsEndpoint : EndpointWithoutRequest<List<ProductDto>>
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "FastEndpoints", "Products"],
+    "Shells": {
+      "Default": {
+        "Features": { "Core": {}, "FastEndpoints": {}, "Products": {} },
         "Configuration": {
           "WebRouting": {
             "Path": "",
@@ -90,7 +89,7 @@ public class GetProductsEndpoint : EndpointWithoutRequest<List<ProductDto>>
           }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/wiki/Feature-Configuration.md
+++ b/wiki/Feature-Configuration.md
@@ -10,7 +10,7 @@ Shell features can receive configuration from three places, listed in order of p
 
 1. **Environment variables** — override everything
 2. **Inline feature settings** — settings placed alongside the feature name in the `Features` section
-3. **Shell `Configuration` section** — `CShells:Shells[n]:Configuration:<FeatureName>`
+3. **Shell `Configuration` section** — `CShells:Shells:<ShellName>:Configuration:<FeatureName>`
 
 ---
 
@@ -21,9 +21,8 @@ Use an object-map where each property key is the feature name and the value supp
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": {
           "Core": {},
           "Database": {
@@ -33,7 +32,7 @@ Use an object-map where each property key is the feature name and the value supp
           "Logging": {}
         }
       }
-    ]
+    }
   }
 }
 ```
@@ -55,9 +54,8 @@ Place settings in a mixed array of strings and objects (the original syntax, sti
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
+    "Shells": {
+      "Default": {
         "Features": [
           "Core",
           {
@@ -68,7 +66,7 @@ Place settings in a mixed array of strings and objects (the original syntax, sti
           "Logging"
         ]
       }
-    ]
+    }
   }
 }
 ```
@@ -84,10 +82,13 @@ Use the `Configuration` section for shell-level configuration that applies to mu
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["Core", "Database", "Logging"],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {},
+          "Database": {},
+          "Logging": {}
+        },
         "Configuration": {
           "Database": {
             "ConnectionString": "Server=prod;Database=App;Integrated Security=true",
@@ -99,7 +100,7 @@ Use the `Configuration` section for shell-level configuration that applies to mu
           }
         }
       }
-    ]
+    }
   }
 }
 ```
@@ -241,7 +242,7 @@ Never store secrets in `appsettings.json`. Use environment variables or a secret
 ### Development (User Secrets)
 
 ```bash
-dotnet user-secrets set "CShells:Shells:0:Configuration:Database:ConnectionString" "Server=localhost;..."
+dotnet user-secrets set "CShells:Shells:Default:Configuration:Database:ConnectionString" "Server=localhost;..."
 ```
 
 ### Production (Environment Variables)
@@ -249,7 +250,7 @@ dotnet user-secrets set "CShells:Shells:0:Configuration:Database:ConnectionStrin
 Use double-underscore (`__`) as the hierarchy separator:
 
 ```bash
-CShells__Shells__0__Configuration__Database__ConnectionString="Server=prod;..."
+CSHELLS__SHELLS__DEFAULT__CONFIGURATION__DATABASE__CONNECTIONSTRING="Server=prod;..."
 ```
 
 ### Azure Key Vault / AWS Secrets Manager

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -91,17 +91,16 @@ In `appsettings.json`:
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Default",
-        "Features": ["CoreFeature", "Weather"],
+    "Shells": {
+      "Default": {
+        "Features": { "CoreFeature": {}, "Weather": {} },
         "Configuration": {
           "WebRouting": {
             "Path": ""
           }
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/wiki/Integration-Patterns.md
+++ b/wiki/Integration-Patterns.md
@@ -47,16 +47,14 @@ Give each shell a unique path prefix to avoid route conflicts:
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Acme",
+    "Shells": {
+      "Acme": {
         "Configuration": { "WebRouting": { "Path": "tenants/acme" } }
       },
-      {
-        "Name": "Contoso",
+      "Contoso": {
         "Configuration": { "WebRouting": { "Path": "tenants/contoso" } }
       }
-    ]
+    }
   }
 }
 ```
@@ -72,9 +70,14 @@ Use host routing when each tenant has its own subdomain:
 
 ```json
 {
-  "Name": "Acme",
-  "Configuration": {
-    "WebRouting": { "Host": "acme.example.com" }
+  "CShells": {
+    "Shells": {
+      "Acme": {
+        "Configuration": {
+          "WebRouting": { "Host": "acme.example.com" }
+        }
+      }
+    }
   }
 }
 ```
@@ -106,9 +109,14 @@ Use an empty path prefix when the entire application is multi-tenant:
 
 ```json
 {
-  "Name": "Default",
-  "Configuration": {
-    "WebRouting": { "Path": "" }
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Configuration": {
+          "WebRouting": { "Path": "" }
+        }
+      }
+    }
   }
 }
 ```

--- a/wiki/Shell-Resolution.md
+++ b/wiki/Shell-Resolution.md
@@ -37,14 +37,13 @@ A shell is resolved when the first URL path segment matches the shell's `WebRout
 ```json
 {
   "CShells": {
-    "Shells": [
-      {
-        "Name": "Acme",
+    "Shells": {
+      "Acme": {
         "Configuration": {
           "WebRouting": { "Path": "acme" }
         }
       }
-    ]
+    }
   }
 }
 ```
@@ -61,9 +60,14 @@ A shell is resolved when the request `Host` header matches the shell's `WebRouti
 
 ```json
 {
-  "Name": "Acme",
-  "Configuration": {
-    "WebRouting": { "Host": "acme.example.com" }
+  "CShells": {
+    "Shells": {
+      "Acme": {
+        "Configuration": {
+          "WebRouting": { "Host": "acme.example.com" }
+        }
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Replace root CShells shell configuration with map-based shell entries keyed by shell name
- Reject unsupported array shell syntax and remove inner Name identity override behavior
- Update Workbench sample, docs, wiki, and specification artifacts for map syntax

## Validation
- dotnet test tests/CShells.Tests/
- dotnet test
- dotnet build