### PR TITLE
Preserve missing features when expanding dependencies

### DIFF
--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -62,10 +62,9 @@ internal sealed class ShellProviderBuilder(
             ? _dependencyResolver.GetOrderedFeatures(availableEnabled, catalog.FeatureMap)
             : [];
 
-        // Dependencies are effective shell features too. Keep the settings instance aligned so
-        // later lifecycle handlers that resolve ShellSettings see the same feature set that was
-        // used to build the provider.
-        settings.EnabledFeatures = orderedFeatures;
+        // Dependencies are effective shell features too. Preserve configured-but-undiscovered
+        // feature names for diagnostics and management APIs instead of dropping them.
+        settings.EnabledFeatures = [..orderedFeatures, ..missing];
 
         var services = new ServiceCollection();
         CopyRootServices(services);

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -121,6 +121,22 @@ public class ShellRegistryActivateTests
         Assert.NotNull(shell.ServiceProvider.GetService<DependencyExpansionMarker>());
     }
 
+    [Fact(DisplayName = "Activation preserves missing feature names in ShellSettings")]
+    public async Task ActivateAsync_MissingFeatures_ArePreservedInShellSettings()
+    {
+        await using var host = BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryActivateTests>()
+            .AddShell("payments", shell => shell.WithFeatures("DependencyExpansionDependent", "MissingFeature")));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        var shell = await registry.ActivateAsync("payments");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Equal(
+            ["DependencyExpansionDependency", "DependencyExpansionDependent", "MissingFeature"],
+            settings.EnabledFeatures);
+    }
+
     internal static ServiceProvider BuildHost(Action<CShellsBuilder> configure)
     {
         var services = new ServiceCollection();

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -104,8 +104,8 @@ public class ShellRegistryActivateTests
         Assert.Same(shell, resolved);
     }
 
-    [Fact(DisplayName = "Activation exposes dependency-expanded feature set through ShellSettings")]
-    public async Task ActivateAsync_DependencyExpandedFeatures_AreExposedThroughShellSettings()
+    [Fact(DisplayName = "Activation expands feature dependencies in ShellSettings")]
+    public async Task ActivateAsync_DependencyFeatures_AreExpandedInShellSettings()
     {
         await using var host = BuildHost(cshells => cshells
             .WithAssemblyContaining<ShellRegistryActivateTests>()


### PR DESCRIPTION
## Summary
- expand discovered feature dependencies centrally during shell provider build
- preserve configured-but-undiscovered feature names for diagnostics and management APIs
- add regression coverage for dependency-expanded ShellSettings

## Validation
- dotnet test tests/CShells.Tests/CShells.Tests.csproj --no-restore