### PR TITLE
Fix cold-start rematch for fallback endpoints

### DIFF
--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -88,11 +88,12 @@ public class ShellMiddleware(
             return;
         }
 
-        // Cold activation: UseRouting() ran before this middleware and found no endpoints
-        // (they hadn't been registered yet). Now that activation has completed and the
-        // ShellEndpointRegistrationHandler has published the shell's endpoints, re-match
-        // the request so the endpoint middleware downstream can execute the handler.
-        if (wasCold && context.GetEndpoint() is null)
+        // Cold activation: UseRouting() ran before this middleware and either found no endpoint,
+        // or selected a host fallback endpoint because shell endpoints had not been registered yet.
+        // Now that activation has completed and the ShellEndpointRegistrationHandler has published
+        // the shell's endpoints, re-match the request so downstream endpoint middleware can execute
+        // the shell handler instead of a preselected fallback.
+        if (wasCold && ShouldTryMatchEndpointAfterColdActivation(context.GetEndpoint()))
             TryMatchEndpointAfterColdActivation(context, shellId.Value);
 
         // BeginScope increments the shell's active-scope counter (so in-flight drains' phase-1
@@ -146,11 +147,22 @@ public class ShellMiddleware(
         return $"{request.Host}:{request.Path}:{request.Method}";
     }
 
+    private static bool ShouldTryMatchEndpointAfterColdActivation(Endpoint? endpoint)
+    {
+        if (endpoint is null)
+            return true;
+
+        if (endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is not null)
+            return false;
+
+        return endpoint is RouteEndpoint { Order: int.MaxValue };
+    }
+
     /// <summary>
-    /// After a cold shell activation, UseRouting() has already run and found no endpoint.
-    /// The shell's endpoints are now registered in the <see cref="DynamicShellEndpointDataSource"/>.
-    /// Walk the data source and set the first matching endpoint on the context so the downstream
-    /// endpoint middleware can execute it.
+    /// After a cold shell activation, UseRouting() has already run and may have found no endpoint
+    /// or selected a host fallback endpoint. The shell's endpoints are now registered in the
+    /// <see cref="DynamicShellEndpointDataSource"/>. Walk the data source and set the first
+    /// matching endpoint on the context so the downstream endpoint middleware can execute it.
     /// </summary>
     private void TryMatchEndpointAfterColdActivation(HttpContext context, ShellId shellId)
     {

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -143,6 +143,102 @@ public class ShellMiddlewareLazyActivationTests
         Assert.False(intHandlerInvoked, "int-handler must be rejected by the inline `:int` constraint.");
     }
 
+    [Fact(DisplayName = "Cold-start re-match replaces non-shell fallback endpoint")]
+    public async Task ColdStart_ReMatch_ReplacesFallbackEndpoint()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("Default");
+        var settings = new ShellSettings();
+        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+
+        var shellEndpointInvoked = false;
+        var shellEndpoint = new RouteEndpoint(
+            _ => { shellEndpointInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("elsa/api/package/version"),
+            order: 0,
+            new EndpointMetadataCollection(shellMetadata, new HttpMethodMetadata(["GET"])),
+            displayName: "package-version");
+        dataSource.AddEndpoints([shellEndpoint]);
+
+        var fallbackInvoked = false;
+        var fallbackEndpoint = new RouteEndpoint(
+            _ => { fallbackInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("{*path:nonfile}"),
+            order: int.MaxValue,
+            EndpointMetadataCollection.Empty,
+            displayName: "spa-fallback");
+
+        var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
+        var middleware = new ShellMiddleware(
+            ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
+            new FixedShellResolver("Default"),
+            new ColdActivatingRegistry(shell),
+            dataSource,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new ShellMiddlewareOptions()));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
+        ctx.Request.Method = "GET";
+        ctx.Request.Path = "/elsa/api/package/version";
+        ctx.SetEndpoint(fallbackEndpoint);
+        ctx.RequestServices = new ServiceCollection().AddRouting().BuildServiceProvider();
+
+        await middleware.InvokeAsync(ctx);
+
+        Assert.Equal("package-version", ctx.GetEndpoint()?.DisplayName);
+        Assert.True(shellEndpointInvoked);
+        Assert.False(fallbackInvoked);
+    }
+
+    [Fact(DisplayName = "Cold-start re-match preserves non-shell host endpoint")]
+    public async Task ColdStart_ReMatch_PreservesHostEndpoint()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("Default");
+        var settings = new ShellSettings();
+        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+
+        var shellEndpointInvoked = false;
+        var shellEndpoint = new RouteEndpoint(
+            _ => { shellEndpointInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("host/status"),
+            order: 0,
+            new EndpointMetadataCollection(shellMetadata, new HttpMethodMetadata(["GET"])),
+            displayName: "shell-status");
+        dataSource.AddEndpoints([shellEndpoint]);
+
+        var hostEndpointInvoked = false;
+        var hostEndpoint = new RouteEndpoint(
+            _ => { hostEndpointInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("host/status"),
+            order: 0,
+            new EndpointMetadataCollection(new HttpMethodMetadata(["GET"])),
+            displayName: "host-status");
+
+        var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
+        var middleware = new ShellMiddleware(
+            ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
+            new FixedShellResolver("Default"),
+            new ColdActivatingRegistry(shell),
+            dataSource,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new ShellMiddlewareOptions()));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
+        ctx.Request.Method = "GET";
+        ctx.Request.Path = "/host/status";
+        ctx.SetEndpoint(hostEndpoint);
+        ctx.RequestServices = new ServiceCollection().AddRouting().BuildServiceProvider();
+
+        await middleware.InvokeAsync(ctx);
+
+        Assert.Equal("host-status", ctx.GetEndpoint()?.DisplayName);
+        Assert.True(hostEndpointInvoked);
+        Assert.False(shellEndpointInvoked);
+    }
+
     // =================================================================
     // Test doubles
     // =================================================================

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -191,6 +191,54 @@ public class ShellMiddlewareLazyActivationTests
         Assert.False(fallbackInvoked);
     }
 
+    [Fact(DisplayName = "Cold-start re-match preserves fallback endpoint when no shell endpoint matches")]
+    public async Task ColdStart_ReMatch_PreservesFallbackEndpoint_WhenNoShellEndpointMatches()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("Default");
+        var settings = new ShellSettings();
+        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+
+        var shellEndpointInvoked = false;
+        var shellEndpoint = new RouteEndpoint(
+            _ => { shellEndpointInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("elsa/api/package/version"),
+            order: 0,
+            new EndpointMetadataCollection(shellMetadata, new HttpMethodMetadata(["GET"])),
+            displayName: "package-version");
+        dataSource.AddEndpoints([shellEndpoint]);
+
+        var fallbackInvoked = false;
+        var fallbackEndpoint = new RouteEndpoint(
+            _ => { fallbackInvoked = true; return Task.CompletedTask; },
+            RoutePatternFactory.Parse("{*path:nonfile}"),
+            order: int.MaxValue,
+            EndpointMetadataCollection.Empty,
+            displayName: "spa-fallback");
+
+        var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
+        var middleware = new ShellMiddleware(
+            ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
+            new FixedShellResolver("Default"),
+            new ColdActivatingRegistry(shell),
+            dataSource,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new ShellMiddlewareOptions()));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
+        ctx.Request.Method = "GET";
+        ctx.Request.Path = "/does/not/match";
+        ctx.SetEndpoint(fallbackEndpoint);
+        ctx.RequestServices = new ServiceCollection().AddRouting().BuildServiceProvider();
+
+        await middleware.InvokeAsync(ctx);
+
+        Assert.Equal("spa-fallback", ctx.GetEndpoint()?.DisplayName);
+        Assert.True(fallbackInvoked);
+        Assert.False(shellEndpointInvoked);
+    }
+
     [Fact(DisplayName = "Cold-start re-match preserves non-shell host endpoint")]
     public async Task ColdStart_ReMatch_PreservesHostEndpoint()
     {


### PR DESCRIPTION
## Summary
- re-run cold-start shell endpoint matching when routing preselected a host fallback endpoint
- preserve already-matched shell endpoints and normal host endpoints
- add regression coverage for SPA fallback replacement and host endpoint preservation

## Validation
- dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter FullyQualifiedName~ShellMiddlewareLazyActivationTests
- dotnet build src/CShells.AspNetCore/CShells.AspNetCore.csproj