### PR TITLE
[codex] Add polymorphic feature configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ Package versions are centrally managed in `Directory.Packages.props` — never s
 ## Active Technologies
 - C# 14 / .NET 10 with `Microsoft.Extensions.Configuration`, `System.Text.Json`, and existing CShells abstractions; no new third-party packages (011-map-shell-config)
 - Configuration provider inputs only; no persistent storage (011-map-shell-config)
+- C# 14 / .NET 10; source projects multi-target `net8.0;net9.0;net10.0` per repository conventions + Existing `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `System.Reflection`, `Microsoft.Extensions.DependencyModel`; no new third-party packages (012-pattern-shared-assemblies)
+- N/A; selectors come from configuration and code-first registrations only (012-pattern-shared-assemblies)
 
 ## Recent Changes
 - 011-map-shell-config: Planned map-based shell configuration under `CShells:Shells`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,8 @@ Package versions are centrally managed in `Directory.Packages.props` — never s
 - Configuration provider inputs only; no persistent storage (011-map-shell-config)
 - C# 14 / .NET 10; source projects multi-target `net8.0;net9.0;net10.0` per repository conventions + Existing `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `System.Reflection`, `Microsoft.Extensions.DependencyModel`; no new third-party packages (012-pattern-shared-assemblies)
 - N/A; selectors come from configuration and code-first registrations only (012-pattern-shared-assemblies)
+- C# 14 / .NET 10; source projects multi-target `net8.0;net9.0;net10.0` per repository conventions + Existing `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `System.Text.Json`; no new third-party packages (014-polymorphic-feature-config)
+- N/A; configuration provider inputs only (014-polymorphic-feature-config)
 
 ## Recent Changes
 - 011-map-shell-config: Planned map-based shell configuration under `CShells:Shells`

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ public class WeatherFeature : IShellFeature
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {},
-          "Weather": {}
+          "Core": true,
+          "Weather": true
         },
         "Configuration": {
           "WebRouting": {
@@ -213,7 +213,7 @@ public class WeatherFeature : IShellFeature
       },
       "Admin": {
         "Features": {
-          "Core": {},
+          "Core": true,
           "Admin": { "MaxUsers": 100, "EnableAuditLog": true }
         },
         "Configuration": {
@@ -245,7 +245,10 @@ Create JSON files in a `Shells` folder (e.g., `Default.json`, `Admin.json`):
 ```json
 {
   "Name": "Default",
-  "Features": ["Core", "Weather"],
+  "Features": {
+    "Core": true,
+    "Weather": true
+  },
   "Configuration": {
     "WebRouting": {
       "Path": ""
@@ -353,7 +356,7 @@ Shared assembly selectors let a host include framework families without listing 
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {}
+          "Core": true
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -341,6 +341,40 @@ builder.AddShells(cshells =>
 
 If you do not call any assembly-source method, CShells preserves the default host-derived discovery behavior. As soon as you call `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)`, CShells switches to explicit provider mode and scans only the assemblies contributed by those appended providers.
 
+Shared assembly selectors let a host include framework families without listing every assembly:
+
+```json
+{
+  "CShells": {
+    "SharedAssemblies": [
+      "Elsa",
+      "Elsa.*"
+    ],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Entries without `*` match exact assembly simple names. Entries ending in `*` match simple-name prefixes, so `Elsa.*` matches `Elsa.Workflows` but not `Contoso.Workflows`. The wildcard is only valid as the final character. Use narrow framework contract or common infrastructure patterns; broad sharing can weaken shell isolation.
+
+Integration packages can contribute the same host-wide selectors in code:
+
+```csharp
+builder.AddShells(cshells =>
+{
+    cshells.WithSharedAssemblies("Elsa", "Elsa.*");
+    cshells.WithSharedAssembliesWhere(name =>
+        name.StartsWith("MyFramework.", StringComparison.OrdinalIgnoreCase));
+    cshells.WithConfigurationProvider(builder.Configuration);
+});
+```
+
 **FluentStorage setup (reads from Shells folder)**:
 
 ```csharp

--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -6,14 +6,14 @@ CShells provides a convention-based configuration system that lets features rece
 
 Features can be configured in four ways:
 
-1. **Object-map configuration** — features as property keys with settings as values (recommended)
+1. **Object-map configuration** — features as property keys with `true`, `false`, or settings objects (recommended)
 2. **Inline configuration** — settings defined directly alongside the feature name in the `Features` array
 3. **Explicit configuration** — implement `IConfigurableFeature<TOptions>` for strongly-typed options
 4. **Manual configuration** — use `IConfiguration` or `IOptions<T>` directly in `ConfigureServices`
 
 ## Object-Map Configuration (Recommended)
 
-The `Features` property supports an object-map syntax where each property key is the feature name and the property value provides the feature settings:
+The `Features` property supports an object-map syntax where each property key is the feature name and the property value declares whether the feature is enabled, disabled, or configured:
 
 ```json
 {
@@ -21,7 +21,8 @@ The `Features` property supports an object-map syntax where each property key is
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {},
+          "Core": true,
+          "LegacyAuth": false,
           "Analytics": { "TopPostsCount": 10 }
         }
       }
@@ -30,7 +31,29 @@ The `Features` property supports an object-map syntax where each property key is
 }
 ```
 
-Features with no settings use an empty object `{}`. All properties within a feature's object are treated as settings — there is no special `Name` property since the object key serves as the feature name.
+Use `true` to enable a feature with default settings, `false` to disable a feature, and an object to enable a feature with direct settings. Empty object `{}` remains valid for existing configuration and also enables the feature with defaults. All properties within a feature's object are treated as settings — there is no special `Name` or `Enabled` control property since the object key serves as the feature name.
+
+This form is friendly to layered configuration. A Docker-mounted file or environment variable can disable a feature supplied by application defaults:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": false
+        }
+      }
+    }
+  }
+}
+```
+
+String values `"true"` and `"false"` are also accepted case-insensitively so string-valued providers can enable or disable features:
+
+```bash
+CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY=false
+```
 
 Do not repeat the feature name inside an object-map entry. If a `Name` property is present there, it is delivered to the feature as configuration and does not rename, enable, disable, or replace the feature identified by the object key.
 
@@ -38,12 +61,13 @@ Do not repeat the feature name inside an object-map entry. If a `Name` property 
 
 - **No duplicates**: Each feature name must appear exactly once per shell.
 - **No mixing**: A shell's `Features` value must be entirely array syntax or entirely object-map syntax. Mixing both styles is rejected with an error that identifies the affected shell.
-- **Values must be objects**: In object-map syntax, every feature value must be a JSON object (not a string, number, or array).
+- **Values must be boolean or object**: In object-map syntax, every feature value must be `true`, `false`, string `"true"` / `"false"`, or a JSON object. Values such as `"yes"`, `0`, `null`, and arrays are rejected.
+- **Unknown features**: Unknown feature names set to `false` are ignored as no-op disablements; unknown feature names set to `true` or to an object are rejected before activation.
 - **No silent skips**: Blank array entries and array objects with missing or blank `Name` values are rejected before the shell is activated.
 
-## Inline Configuration (Array Syntax)
+## Legacy Inline Configuration (Array Syntax)
 
-Each entry in the `Features` array can be either a string (feature name) or an object with `Name` plus any additional properties:
+Object-map syntax is preferred because it merges predictably across configuration layers. Legacy `Features` arrays are still normalized when used directly. Each array entry can be either a string (feature name) or an object with `Name` plus any additional properties:
 
 ```json
 {
@@ -155,10 +179,10 @@ public class DatabaseOptions
   "CShells": {
     "Shells": {
       "Default": {
-        "Features": [
-          "Core",
-          { "Name": "Database", "ConnectionString": "Server=localhost;Database=App;..." }
-        ]
+        "Features": {
+          "Core": true,
+          "Database": { "ConnectionString": "Server=localhost;Database=App;..." }
+        }
       }
     }
   }
@@ -173,8 +197,8 @@ Or use the shell's `Configuration` section:
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {},
-          "Database": {}
+          "Core": true,
+          "Database": true
         },
         "Configuration": {
           "Database": {
@@ -191,8 +215,8 @@ Or use the shell's `Configuration` section:
 
 Settings are resolved in this order (highest wins):
 
-1. **Environment variables** — `Shells__Default__Configuration__FeatureName__Property`
-2. **Inline feature configuration** — settings in the `Features` array
+1. **Environment variables** — `CSHELLS__SHELLS__DEFAULT__FEATURES__FeatureName__Property`
+2. **Feature object-map configuration** — settings in the `Features` map
 3. **Shell Configuration section** — `CShells:Shells.<ShellName>.Configuration.FeatureName`
 4. **Root configuration** — `FeatureName:Property`
 5. **Property defaults** — default values on the options class
@@ -238,7 +262,10 @@ Override any setting with environment variables using hierarchical naming:
 
 ```bash
 # Override a feature setting for a specific shell
-Shells__Default__Configuration__Database__ConnectionString="Server=prod;..."
+CSHELLS__SHELLS__DEFAULT__CONFIGURATION__DATABASE__CONNECTIONSTRING="Server=prod;..."
+
+# Disable a default feature for a specific shell
+CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY=false
 ```
 
 ## Secrets Management
@@ -256,7 +283,7 @@ CShells works with any `IConfiguration` provider, including Azure Key Vault, AWS
 
 ## Best Practices
 
-1. **Use inline configuration** for simple, per-shell settings
+1. **Use object-map configuration** for simple, per-shell feature enablement and settings
 2. **Use `IConfigurableFeature<T>`** when you need typed access at feature construction time
 3. **Provide sensible defaults** so features work out of the box
 4. **Validate at startup** using DataAnnotations or custom validators

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,6 +124,28 @@ builder.AddShells(cshells =>
 
 Any call to `FromAssemblies(...)`, `FromHostAssemblies()`, or `WithAssemblyProvider(...)` switches CShells into explicit provider mode. In that mode, only the assemblies returned by those appended providers are scanned, and duplicate assemblies are discovered once in first-seen order.
 
+For framework ecosystems with many related packages, add host-wide shared assembly selectors under root `CShells:SharedAssemblies`:
+
+```json
+{
+  "CShells": {
+    "SharedAssemblies": [
+      "Elsa",
+      "Elsa.*"
+    ],
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Core": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Exact entries match one assembly simple name. Prefix wildcard entries must end in `*`, so `Elsa.*` matches `Elsa.Workflows` but not `Contoso.Workflows`.
+
 ### Testing the Result
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ For framework ecosystems with many related packages, add host-wide shared assemb
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {}
+          "Core": true
         }
       }
     }

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -120,6 +120,9 @@ builder.AddShells(cshells =>
 {
     cshells.WithConfigurationProvider(builder.Configuration);
     cshells.FromAssemblies(typeof(MyFeature).Assembly);
+    cshells.WithSharedAssemblies("Elsa", "Elsa.*");
+    cshells.WithSharedAssembliesWhere(name =>
+        name.StartsWith("MyFramework.", StringComparison.OrdinalIgnoreCase));
 });
 
 var app = builder.Build();
@@ -146,6 +149,25 @@ app.Run();
 | `AmbiguousMatchException` | Multiple shells share the same route | Give each shell a unique `WebRouting:Path` |
 | Host routes return 404 | A root-level shell (`Path: ""`) shadows them | Add path exclusions or move shells under a prefix |
 | Shell routes return 404 | `MapShells()` not called, or features not discovered | Verify `MapShells()` is in the pipeline and features are scanned |
+
+## Shared Assembly Selectors
+
+Use root `CShells:SharedAssemblies` configuration or code-first builder calls when an integration package needs to share a framework family:
+
+```json
+{
+  "CShells": {
+    "SharedAssemblies": [
+      "Elsa",
+      "Elsa.*"
+    ]
+  }
+}
+```
+
+`Elsa` is an exact assembly simple-name match. `Elsa.*` is a prefix match against simple names only. The wildcard is only valid as the final character; suffix or contains-style patterns such as `*.Contracts` are intentionally invalid.
+
+Prefer narrow patterns for framework contracts and common infrastructure. Avoid broad patterns that include shell-specific implementation assemblies, because sharing those assemblies can weaken shell isolation.
 
 ## Best Practices
 

--- a/samples/CShells.Workbench/appsettings.json
+++ b/samples/CShells.Workbench/appsettings.json
@@ -14,8 +14,9 @@
     "Shells": {
       "Default": {
         "Features": {
-          "Core": {},
-          "Posts": {}
+          "Core": true,
+          "Posts": true,
+          "Analytics": false
         },
         "Configuration": {
           "WebRouting": {
@@ -26,9 +27,10 @@
       },
       "Acme": {
         "Features": {
-          "Core": {},
-          "Posts": {},
-          "Comments": {}
+          "Core": true,
+          "Posts": true,
+          "Comments": true,
+          "Analytics": false
         },
         "Configuration": {
           "WebRouting": {
@@ -39,9 +41,9 @@
       },
       "Contoso": {
         "Features": {
-          "Core": {},
-          "Posts": {},
-          "Comments": {},
+          "Core": true,
+          "Posts": true,
+          "Comments": true,
           "Analytics": { "TopPostsCount": 10 }
         },
         "Configuration": {

--- a/samples/CShells.Workbench/appsettings.json
+++ b/samples/CShells.Workbench/appsettings.json
@@ -7,6 +7,10 @@
   },
   "AllowedHosts": "*",
   "CShells": {
+    "SharedAssemblies": [
+      "CShells.Workbench.Features",
+      "CShells.Workbench.Features.*"
+    ],
     "Shells": {
       "Default": {
         "Features": {

--- a/specs/012-pattern-shared-assemblies/checklists/requirements.md
+++ b/specs/012-pattern-shared-assemblies/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Pattern-Based Shared Assemblies
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The public method name `WithSharedAssembliesWhere` is included because it is part of the requested user-facing code-first experience, not an internal implementation detail.
+- No clarification markers remain; the feature is ready for `/speckit.plan`.

--- a/specs/012-pattern-shared-assemblies/contracts/shared-assemblies.md
+++ b/specs/012-pattern-shared-assemblies/contracts/shared-assemblies.md
@@ -1,0 +1,85 @@
+# Contract: Host-Wide Shared Assemblies
+
+## Configuration Contract
+
+Host applications declare exact names and prefix wildcard patterns in one root collection:
+
+```json
+{
+  "CShells": {
+    "SharedAssemblies": [
+      "Elsa",
+      "Elsa.*"
+    ],
+    "Shells": {
+      "Contoso": {
+        "Features": [ "Core" ]
+      }
+    }
+  }
+}
+```
+
+Contract rules:
+
+- `CShells:SharedAssemblies` is host-wide.
+- Entries without `*` match exact assembly simple names.
+- Entries ending in `*` match assembly simple-name prefixes.
+- Entries with `*` anywhere except the final character are invalid.
+- Blank or whitespace-only entries are invalid.
+- Matching is case-insensitive and uses only assembly simple names.
+- `CShells:Shells:<Name>` does not support overriding shared assembly selectors.
+
+## Code-First Builder Contract
+
+The builder exposes host-wide selector APIs:
+
+```csharp
+builder.AddShells(cshells => cshells
+    .WithSharedAssemblies("Elsa", "Elsa.*")
+    .WithSharedAssembliesWhere(name => name.StartsWith("MyFramework.", StringComparison.OrdinalIgnoreCase))
+    .WithConfigurationProvider(builder.Configuration));
+```
+
+Contract rules:
+
+- `WithSharedAssemblies(params string[] patterns)` appends exact names and prefix wildcard patterns to the host-wide selector collection.
+- `WithSharedAssembliesWhere(Func<string, bool> predicate)` appends a code-first predicate selector evaluated against assembly simple names only.
+- Null builder arguments, null string arrays, null entries, blank entries, and null predicates fail with argument validation.
+- Predicate exceptions fail with actionable feedback identifying the selector source.
+- Configuration and code-first selectors compose additively.
+
+## Public Abstractions Contract
+
+Public selector diagnostics live in `CShells.Abstractions`:
+
+```csharp
+namespace CShells.Features;
+
+public enum SharedAssemblySelectorKind
+{
+    Exact,
+    PrefixPattern,
+    Predicate
+}
+
+public sealed record SharedAssemblyMatch(
+    string AssemblyName,
+    SharedAssemblySelectorKind SelectorKind,
+    string? SelectorPattern,
+    string SelectorSource);
+```
+
+The implementation may expose match diagnostics through an inspectable service or resolver result, but must not require consumers to reference the implementation project to understand selector kinds or match results.
+
+## Matching Contract Examples
+
+| Selector | Candidate Simple Name | Result |
+|---|---|---|
+| `Elsa` | `Elsa` | Match |
+| `Elsa` | `Elsa.Workflows` | No match |
+| `Elsa.*` | `Elsa.Workflows` | Match |
+| `Elsa.*` | `Contoso.Elsa.Workflows` | No match |
+| `elsa.*` | `Elsa.Workflows` | Match |
+| `*.Contracts` | `Elsa.Contracts` | Invalid selector |
+| `Elsa.*.Abstractions` | `Elsa.Core.Abstractions` | Invalid selector |

--- a/specs/012-pattern-shared-assemblies/data-model.md
+++ b/specs/012-pattern-shared-assemblies/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Pattern-Based Shared Assemblies
+
+## Shared Assembly Selector
+
+Represents one host-wide rule that can select candidate assemblies for sharing.
+
+**Fields**:
+
+- `Kind`: `Exact`, `PrefixPattern`, or `Predicate`.
+- `Pattern`: Original string for exact and prefix-pattern selectors; null for predicates.
+- `Source`: Human-readable source, such as `CShells:SharedAssemblies:1` or `CShellsBuilder.WithSharedAssembliesWhere`.
+- `Predicate`: Code-first delegate for predicate selectors only.
+
+**Validation Rules**:
+
+- String selectors must be non-null, non-empty, and not whitespace-only.
+- `*` is valid only as the final character.
+- Entries without `*` are exact selectors.
+- Entries ending in `*` are prefix-pattern selectors.
+- Predicate selectors must be non-null.
+- Matching uses assembly simple names only with `StringComparer.OrdinalIgnoreCase`.
+
+## Assembly Simple Name
+
+The short assembly identity used for matching.
+
+**Fields**:
+
+- `Name`: `AssemblyName.Name` or equivalent simple name.
+
+**Validation Rules**:
+
+- Empty or null candidate names are ignored for matching.
+- Full names, versions, cultures, public key tokens, file names, and paths are never used for selector matching.
+
+## Shared Assembly Match
+
+Represents a positive decision that one candidate assembly is shared.
+
+**Fields**:
+
+- `AssemblyName`: Candidate simple name.
+- `SelectorKind`: The selector kind responsible for the match.
+- `SelectorPattern`: Exact name or prefix pattern when available.
+- `SelectorSource`: Configuration path or code-first source responsible for the match.
+
+**Relationships**:
+
+- A match references one selected assembly simple name.
+- A match references the first selector source responsible for the selected decision.
+- Multiple selectors may match the same assembly, but the final shared decision is emitted once.
+
+**Validation Rules**:
+
+- Deduplicate matches by assembly simple name case-insensitively.
+- Duplicate selectors across configuration and code-first setup must not create duplicate shared decisions or duplicate diagnostics.
+
+## Shared Assembly Configuration Source
+
+Represents the host-wide origin for selectors.
+
+**Fields**:
+
+- `ConfigurationPath`: Root configuration path for string selectors, e.g. `CShells:SharedAssemblies:0`.
+- `BuilderSource`: Public API source for code-first selectors, e.g. `WithSharedAssemblies("Elsa.*")`.
+
+**Validation Rules**:
+
+- Invalid configured entries must report the configuration path.
+- Invalid code-first entries must report the API source or argument name.
+
+## State Transitions
+
+Selectors are immutable after host configuration composition:
+
+```text
+Declared -> Validated/Compiled -> Applied To Candidate Assemblies -> Match Diagnostics Available
+```
+
+Invalid selectors stop at `Declared` and fail before shell activation.

--- a/specs/012-pattern-shared-assemblies/plan.md
+++ b/specs/012-pattern-shared-assemblies/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Pattern-Based Shared Assemblies
+
+**Branch**: `012-pattern-shared-assemblies` | **Date**: 2026-05-11 | **Spec**: [spec.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/spec.md)
+**Input**: Feature specification from `/specs/012-pattern-shared-assemblies/spec.md`
+
+## Summary
+
+Add host-wide shared assembly selection for feature discovery using one root `CShells:SharedAssemblies` collection and matching code-first builder APIs. Entries without `*` match exact assembly simple names, entries ending in `*` match simple-name prefixes, and predicate selectors are code-first only. The implementation will introduce public selector abstractions in `CShells.Abstractions`, resolver/matching implementation in `CShells`, validation and diagnostics for invalid selectors, and documentation showing safe framework-family usage.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10; source projects multi-target `net8.0;net9.0;net10.0` per repository conventions  
+**Primary Dependencies**: Existing `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `System.Reflection`, `Microsoft.Extensions.DependencyModel`; no new third-party packages  
+**Storage**: N/A; selectors come from configuration and code-first registrations only  
+**Testing**: xUnit in `tests/CShells.Tests/` with unit and configuration-focused tests  
+**Target Platform**: .NET library used by ASP.NET Core and generic host applications  
+**Project Type**: Multi-package .NET library  
+**Performance Goals**: Shared assembly filtering remains linear over candidate assembly names; selector matching should avoid repeated parsing per assembly by compiling/validating selectors once during builder/configuration setup  
+**Constraints**: Match only assembly simple names, case-insensitively; `*` may appear only as final character; selectors are host-wide and not per-shell; no new third-party packages; public extensibility contracts belong in abstractions first  
+**Scale/Scope**: Host dependency contexts with tens to hundreds of assembly names and a small shared selector list; exact and pattern deduplication must be deterministic and diagnostics must identify selector sources
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Abstraction-First Architecture**: PASS. Public selector contracts and options will be introduced in `CShells.Abstractions`; resolver implementation remains in `CShells`.
+- **II. Feature Modularity**: PASS. The feature affects host-level feature assembly discovery and does not add a shell feature or cross-feature coupling.
+- **III. Modern C# Style**: PASS. Plan targets C# 14 conventions, nullable-safe APIs, explicit access modifiers, primary constructors where useful, and collection expressions.
+- **IV. Explicit Error Handling**: PASS. Invalid configuration entries and throwing predicates surface actionable exceptions with selector source/path context.
+- **V. Test Coverage**: PASS. Unit tests cover grammar, exact/prefix matching, source deduplication, configuration binding, builder APIs, and resolver integration.
+- **VI. Simplicity & Minimalism**: PASS. Use one unified `SharedAssemblies` collection and no new packages; add only the abstractions required for public predicate/source diagnostics.
+- **VII. Lifecycle & Concurrency Contracts**: PASS. No shell lifecycle state changes; selector registries are constructed during host setup and read-only during discovery.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-pattern-shared-assemblies/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── shared-assemblies.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells.Abstractions/
+│   └── Features/
+│       ├── ISharedAssemblySelector.cs
+│       └── SharedAssemblyMatch.cs
+├── CShells/
+│   ├── Configuration/
+│   │   └── CShellsOptions.cs
+│   ├── DependencyInjection/
+│   │   ├── CShellsBuilder.cs
+│   │   └── CShellsBuilderExtensions.cs
+│   └── Features/
+│       ├── FeatureAssemblyResolver.cs
+│       ├── SharedAssemblySelector.cs
+│       ├── SharedAssemblySelectorProvider.cs
+│       └── SharedAssemblyPattern.cs
+└── CShells.AspNetCore/
+    └── Extensions/
+        └── ShellExtensions.cs
+
+tests/
+└── CShells.Tests/
+    └── Unit/
+        ├── Configuration/
+        │   └── SharedAssemblyConfigurationTests.cs
+        ├── DependencyInjection/
+        │   └── CShellsBuilderSharedAssemblyTests.cs
+        └── Features/
+            ├── SharedAssemblyPatternTests.cs
+            └── FeatureAssemblyResolverSharedAssemblyTests.cs
+
+docs/
+├── getting-started.md
+└── integration-patterns.md
+
+README.md
+samples/
+└── CShells.Workbench/
+    └── appsettings.json
+```
+
+**Structure Decision**: Implement as a host-level library capability in the existing CShells packages. Public selector/match contracts live in `CShells.Abstractions`, while parsing, matching, configuration binding, and feature assembly filtering live in `CShells`. Tests mirror the touched source areas under `tests/CShells.Tests/Unit/`.
+
+## Phase 0: Research
+
+Research completed in [research.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/research.md). No `NEEDS CLARIFICATION` items remain.
+
+## Phase 1: Design & Contracts
+
+Design artifacts:
+
+- [data-model.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/data-model.md)
+- [contracts/shared-assemblies.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/contracts/shared-assemblies.md)
+- [quickstart.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/quickstart.md)
+
+## Constitution Check
+
+*Post-design re-check.*
+
+- **I. Abstraction-First Architecture**: PASS. Contracts file explicitly places public selector interfaces/records in `CShells.Abstractions`.
+- **II. Feature Modularity**: PASS. The design composes with existing feature discovery and does not alter feature dependency resolution.
+- **III. Modern C# Style**: PASS. Contracts and implementation are planned as nullable-safe C# APIs with public XML docs.
+- **IV. Explicit Error Handling**: PASS. Invalid entries, unsupported wildcard positions, null predicates, null assemblies, and throwing predicates have defined error behavior.
+- **V. Test Coverage**: PASS. Quickstart and contracts define verifiable unit/integration scenarios for every success criterion.
+- **VI. Simplicity & Minimalism**: PASS. One unified collection avoids parallel schema and minimizes API surface.
+- **VII. Lifecycle & Concurrency Contracts**: PASS. Host-level selector state is immutable after builder/configuration composition and does not introduce async mutable lifecycle state.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/012-pattern-shared-assemblies/quickstart.md
+++ b/specs/012-pattern-shared-assemblies/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Pattern-Based Shared Assemblies
+
+## Configuration
+
+Add host-wide shared assembly selectors under root `CShells:SharedAssemblies`:
+
+```json
+{
+  "CShells": {
+    "SharedAssemblies": [
+      "Elsa",
+      "Elsa.*"
+    ],
+    "Shells": {
+      "Contoso": {
+        "Features": [ "Core" ],
+        "Configuration": {
+          "WebRouting": {
+            "Path": "contoso"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Wire configuration as usual:
+
+```csharp
+builder.Services.AddCShells(cshells => cshells
+    .WithConfigurationProvider(builder.Configuration));
+```
+
+Expected behavior:
+
+- `Elsa` matches only the `Elsa` assembly simple name.
+- `Elsa.*` matches `Elsa.Workflows` and other simple names beginning with `Elsa.`.
+- `Contoso.Workflows` does not match either selector.
+- `*.Contracts` is invalid because `*` is not the final character in a prefix pattern.
+
+## Code-First
+
+Reusable integration packages can contribute the same selectors through the builder:
+
+```csharp
+builder.Services.AddCShells(cshells => cshells
+    .WithSharedAssemblies("Elsa", "Elsa.*")
+    .WithSharedAssembliesWhere(name =>
+        name.StartsWith("MyFramework.", StringComparison.OrdinalIgnoreCase)));
+```
+
+Configuration and code-first selectors compose additively and produce one shared decision per assembly simple name.
+
+## Verification
+
+Run focused tests while implementing:
+
+```bash
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~SharedAssembly"
+```
+
+Run the complete test suite before handing off:
+
+```bash
+dotnet test
+```
+
+Documentation updates should show:
+
+- Root `CShells:SharedAssemblies` configuration.
+- Exact-name and prefix wildcard examples.
+- `WithSharedAssembliesWhere` for code-first predicate selection.
+- Guidance that broad shared assembly patterns can weaken shell isolation.

--- a/specs/012-pattern-shared-assemblies/research.md
+++ b/specs/012-pattern-shared-assemblies/research.md
@@ -1,0 +1,57 @@
+# Research: Pattern-Based Shared Assemblies
+
+## Decision: Use one root `CShells:SharedAssemblies` configuration collection
+
+**Rationale**: Exact names and prefix wildcard patterns are the same conceptual user input: a host-wide selector over assembly simple names. A single collection makes configuration compact, keeps examples easy to read, and matches the clarified spec: entries without `*` are exact names; entries ending in `*` are prefix patterns.
+
+**Alternatives considered**:
+
+- Separate `SharedAssemblyNames` and `SharedAssemblyPatterns`: clearer at the type level, but more verbose and creates duplicate validation/deduplication paths.
+- Per-shell selector configuration: rejected by clarification because shared assembly selection affects host-level discovery/isolation before shell activation.
+- Pattern-only collection layered on existing explicit assembly APIs: rejected because it would split equivalent string selectors across multiple concepts.
+
+## Decision: Restrict wildcard grammar to final-character `*`
+
+**Rationale**: Prefix-only matching supports framework-family cases like `Elsa.*` while avoiding broad suffix or contains patterns that can accidentally share implementation assemblies. It also allows a small parser with deterministic validation and no regular expression dependency.
+
+**Alternatives considered**:
+
+- Glob-style `*` anywhere: too broad for an isolation boundary and more expensive to explain/test.
+- Dot-only `Prefix.*`: safer, but would unnecessarily reject valid simple-name families like `Elsa*` if a host truly needs them.
+- Regex patterns: too powerful for the initial feature and adds unnecessary complexity.
+
+## Decision: Match and deduplicate by assembly simple name using `StringComparer.OrdinalIgnoreCase`
+
+**Rationale**: The existing host assembly resolver already uses case-insensitive simple-name comparison for `AssemblyName` de-duplication. Reusing ordinal case-insensitive semantics keeps behavior consistent and independent of culture.
+
+**Alternatives considered**:
+
+- Current-culture case-insensitive comparison: rejected because assembly identity comparisons should not vary by UI culture.
+- Case-sensitive matching: rejected by the spec and common assembly-name expectations.
+
+## Decision: Compile/validate selectors once, then apply them during host assembly filtering
+
+**Rationale**: The candidate assembly set is already enumerated by `FeatureAssemblyResolver.ResolveHostAssemblies`. Parsing each selector once gives clear startup/configuration failures and keeps filtering linear over `(assembly names * selectors)`.
+
+**Alternatives considered**:
+
+- Parse pattern strings for each assembly: simpler initially, but repeats validation work and delays invalid selector errors.
+- Introduce a new discovery pipeline abstraction: rejected as unnecessary because the existing resolver already supports a filter hook.
+
+## Decision: Keep predicate selectors code-first only
+
+**Rationale**: Predicate selectors require executable code and source attribution. They fit the builder API, not configuration providers. Configuration remains declarative and string-pattern based.
+
+**Alternatives considered**:
+
+- Expression strings in configuration: rejected because it creates parsing/security complexity and a new language surface.
+- Type-name predicates loaded from configuration: rejected because it overlaps with custom `IFeatureAssemblyProvider` and increases activation complexity.
+
+## Decision: Surface diagnostics through selector source metadata
+
+**Rationale**: Troubleshooting requires knowing whether a match came from root configuration, a builder registration, or a predicate. Store a source description alongside each selector and attach it to match diagnostics and exception messages.
+
+**Alternatives considered**:
+
+- Log only matched assembly names: insufficient for stale/misspelled patterns and broad wildcard troubleshooting.
+- Throw without configuration path/source: violates explicit error handling expectations and makes deployment config hard to fix.

--- a/specs/012-pattern-shared-assemblies/spec.md
+++ b/specs/012-pattern-shared-assemblies/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Pattern-Based Shared Assemblies
+
+**Feature Branch**: `012-pattern-shared-assemblies`  
+**Created**: 2026-05-11  
+**Status**: Draft  
+**Input**: User description: "Add pattern-based shared assembly selection for CShells. Users should be able to specify shared assembly simple-name patterns from configuration such as appsettings.json, using wildcard patterns like Elsa.* to reduce verbose lists for framework ecosystems. The feature should also support code-first selection, including a predicate-style WithSharedAssembliesWhere experience. Matching is against assembly simple names only. Pattern support should be explicit and bounded so framework contracts/common infrastructure can be shared without accidentally sharing tenant-specific implementation assemblies."
+
+## Clarifications
+
+### Session 2026-05-11
+
+- Q: What wildcard grammar should shared assembly patterns support? → A: `*` is allowed only as the final character, so patterns are exact names or prefix patterns like `Elsa.*`.
+- Q: Should shared assembly selectors be host-wide or per-shell? → A: Selectors are host-wide under the root `CShells` configuration and code-first builder APIs.
+- Q: Should exact names and wildcard patterns use one collection or separate configuration/API collections? → A: Use one unified host-wide `SharedAssemblies` collection for exact names and prefix wildcard patterns.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Shared Assemblies With Patterns (Priority: P1)
+
+As a CShells host author, I want to declare shared assembly patterns in configuration so framework ecosystems with many related packages can be shared without listing every assembly one by one.
+
+**Why this priority**: Configuration-driven setup is the main usability problem. It lets hosts and deployment environments express shared framework families consistently without recompiling application code.
+
+**Independent Test**: Can be fully tested by loading root `CShells:SharedAssemblies` configuration that declares exact and wildcard shared assembly simple-name patterns in one collection, then confirming matching assemblies are treated as shared and non-matching assemblies are not.
+
+**Acceptance Scenarios**:
+
+1. **Given** root `CShells:SharedAssemblies` configuration declares entries `Elsa` and `Elsa.*`, **When** assemblies named `Elsa`, `Elsa.Workflows`, and `Contoso.Workflows` are evaluated, **Then** only `Elsa` and `Elsa.Workflows` match the shared assembly configuration.
+2. **Given** configuration declares an exact shared assembly name without a wildcard, **When** an assembly with a longer name that begins with the same text is evaluated, **Then** the longer name does not match.
+3. **Given** configuration declares multiple shared assembly patterns, **When** an assembly matches any one pattern, **Then** it is considered shared exactly once.
+
+---
+
+### User Story 2 - Configure Shared Assemblies In Code (Priority: P2)
+
+As a library integrator, I want a code-first way to select shared assemblies, including predicate-based matching, so reusable integration packages can provide sensible defaults for framework-specific shared assemblies.
+
+**Why this priority**: Framework integration packages need an ergonomic way to register shared assembly conventions without requiring every consuming application to repeat the same configuration.
+
+**Independent Test**: Can be fully tested by configuring shared assembly matching in code and confirming the resulting shared assembly decisions are the same as equivalent configuration-driven patterns.
+
+**Acceptance Scenarios**:
+
+1. **Given** a code-first shared assembly pattern is registered for `Elsa.*`, **When** assemblies named `Elsa.Workflows` and `Other.Workflows` are evaluated, **Then** only `Elsa.Workflows` matches.
+2. **Given** a code-first predicate-based selector is registered, **When** assemblies are evaluated, **Then** the predicate can include or exclude assemblies based on their simple names.
+3. **Given** configuration-driven and code-first shared assembly selectors are both present, **When** assemblies are evaluated, **Then** an assembly matching either source is considered shared without producing duplicate shared entries.
+
+---
+
+### User Story 3 - Keep Matching Explicit And Bounded (Priority: P3)
+
+As an application maintainer, I want shared assembly matching to be limited to assembly simple names so wildcard use is predictable and does not accidentally match file paths, versions, cultures, or tenant-specific implementation details.
+
+**Why this priority**: Shared assemblies affect isolation boundaries. Predictable matching reduces the risk of unintentionally sharing runtime implementation assemblies that should remain shell-specific.
+
+**Independent Test**: Can be fully tested by evaluating assemblies whose simple names, full names, versions, cultures, and file paths differ and confirming only simple-name patterns affect the result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pattern `Elsa.*`, **When** an assembly full name includes version and culture metadata, **Then** the match decision uses only the simple name portion.
+2. **Given** an assembly file path contains a matching folder or file segment but the simple assembly name does not match, **When** the assembly is evaluated, **Then** it is not considered shared.
+3. **Given** a pattern is overly broad, **When** the host starts, **Then** users can identify the configured pattern responsible for the shared match during diagnostics or troubleshooting.
+
+---
+
+### User Story 4 - Document Framework-Friendly Usage (Priority: P4)
+
+As a developer adopting CShells with a framework such as Elsa, I want examples and guidance that show when to use exact names, wildcard patterns, and predicate-based code selection so I can reduce verbosity without weakening shell isolation.
+
+**Why this priority**: The feature adds a powerful shortcut. Documentation must set expectations around safe use, especially around framework contracts and common infrastructure versus shell-specific implementations.
+
+**Independent Test**: Can be fully tested by reviewing documentation and samples and confirming they show configuration-driven patterns, code-first patterns, predicate-based selection, and cautions about broad sharing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the configuration documentation, **When** they need to share a framework family such as Elsa, **Then** they can find an example using exact and wildcard simple-name patterns.
+2. **Given** a framework integration author reads the code-first documentation, **When** they need custom selection logic, **Then** they can find an example of predicate-based shared assembly selection.
+3. **Given** a developer reads the guidance, **When** they consider sharing implementation assemblies, **Then** the documentation explains the isolation tradeoff and recommends narrow patterns.
+
+### Edge Cases
+
+- Blank, whitespace-only, or otherwise empty shared assembly pattern entries must be rejected with a clear configuration error.
+- Duplicate patterns across configuration and code-first setup must not produce duplicate shared assembly entries or duplicate diagnostics.
+- Exact names must not behave as prefix matches unless the pattern explicitly contains a wildcard.
+- Exact names and prefix wildcard patterns must be declared through one unified host-wide shared assembly collection.
+- Wildcard patterns may only use `*` as the final character; patterns with `*` in any other position must be rejected as invalid.
+- Matching must be case-insensitive to align with common assembly-name comparison expectations.
+- Wildcards must match only simple assembly names, not assembly full names, versions, cultures, public key tokens, file names, or directory paths.
+- Patterns that match no available assemblies are valid but should remain visible in diagnostics so users can find stale or misspelled configuration.
+- Assemblies that are already loaded or contributed by multiple sources must resolve to one shared assembly decision.
+- Shared assembly selectors are host-wide and must not be scoped differently per shell.
+- Predicate-based selection that throws or cannot evaluate an assembly must fail with actionable feedback that identifies the selector source.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow shared assemblies to be selected by exact assembly simple names.
+- **FR-002**: The system MUST allow shared assemblies to be selected by prefix wildcard patterns applied to assembly simple names, with `*` allowed only as the final character.
+- **FR-003**: The system MUST support declaring host-wide exact names and prefix wildcard patterns through one root `CShells:SharedAssemblies` application configuration collection.
+- **FR-004**: The system MUST support declaring host-wide exact names and prefix wildcard patterns through one code-first builder collection.
+- **FR-005**: The system MUST provide a code-first predicate-based shared assembly selector, including a user-facing `WithSharedAssembliesWhere` experience.
+- **FR-006**: The system MUST evaluate shared assembly pattern matches against assembly simple names only.
+- **FR-007**: The system MUST NOT evaluate shared assembly patterns against assembly full names, file paths, versions, cultures, or public key tokens.
+- **FR-008**: The system MUST treat exact shared assembly names and wildcard shared assembly patterns as additive sources.
+- **FR-009**: The system MUST deduplicate shared assembly matches when an assembly is selected by multiple exact names, patterns, predicates, or configuration sources.
+- **FR-010**: The system MUST compare shared assembly simple names case-insensitively.
+- **FR-011**: The system MUST reject blank or whitespace-only shared assembly pattern entries before shell activation.
+- **FR-012**: The system MUST provide clear feedback when a configured shared assembly pattern is invalid, including the affected configuration path or source.
+- **FR-013**: The system MUST make shared assembly match decisions inspectable enough for users to troubleshoot which exact name, wildcard pattern, or predicate selected an assembly.
+- **FR-014**: The system MUST keep existing explicit shared assembly declarations supported alongside pattern-based declarations.
+- **FR-015**: Documentation MUST show configuration examples for exact and wildcard shared assembly simple-name patterns.
+- **FR-016**: Documentation MUST show code-first examples for exact names, wildcard patterns, and predicate-based shared assembly selection.
+- **FR-017**: Documentation MUST explain that broad wildcard patterns can weaken shell isolation and should normally target framework contracts or common infrastructure packages.
+
+### Key Entities *(include if feature involves data)*
+
+- **Shared Assembly Selector**: A user-declared rule that identifies assemblies to share across shells.
+- **Assembly Simple Name**: The short assembly identity used for matching, excluding version, culture, public key token, file path, and other metadata.
+- **Exact Shared Assembly Name**: A selector that matches one assembly simple name exactly.
+- **Wildcard Shared Assembly Pattern**: A selector ending in `*` that may match multiple assembly simple names by prefix.
+- **Predicate Shared Assembly Selector**: A code-first selector that decides whether an assembly simple name should be shared.
+- **Shared Assembly Match**: The resulting decision that an assembly is shared, including the selector source responsible for that decision.
+- **Shared Assembly Configuration Source**: The root `CShells:SharedAssemblies` configuration location or code-first builder registration that contributes exact names, wildcard patterns, or predicate selectors.
+
+### Assumptions
+
+- Wildcard matching is intentionally limited to assembly simple names.
+- `*` is the only required wildcard character for the initial feature and is valid only as the final character in a pattern.
+- Matching is case-insensitive.
+- Existing exact shared assembly configuration, if present, remains valid and composes with pattern-based selection.
+- Exact names and prefix wildcard patterns share one host-wide `SharedAssemblies` collection; entries without `*` are exact names and entries ending in `*` are prefix patterns.
+- Shared assembly selectors apply at the host level before per-shell activation and are not overridden per shell.
+- Pattern entries that match no assemblies are allowed because optional framework packages may not always be referenced by every host.
+- Configuration examples use `Elsa` and `Elsa.*` as representative framework-family patterns.
+- Predicate-based selection is a code-first capability only; configuration remains string-pattern based.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can replace a list of at least five related framework assembly names with two configuration entries, such as one exact name and one wildcard pattern, while selecting the same matching assemblies.
+- **SC-002**: 100% of shared assembly matching tests confirm that exact names match only identical simple names.
+- **SC-003**: 100% of shared assembly matching tests confirm that wildcard patterns match simple names only and do not use full names, versions, cultures, public key tokens, file paths, or directory paths.
+- **SC-004**: 100% of invalid blank or whitespace-only pattern entries fail before shell activation with actionable feedback.
+- **SC-005**: Shared assembly selectors contributed by configuration and code-first setup produce one deduplicated shared decision per assembly.
+- **SC-006**: A predicate-based code-first selector can include and exclude assemblies by simple name in verified tests.
+- **SC-007**: Documentation and samples include at least one configuration-driven wildcard example, one exact-name example, one code-first predicate example, and one isolation guidance note.

--- a/specs/012-pattern-shared-assemblies/tasks.md
+++ b/specs/012-pattern-shared-assemblies/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: Pattern-Based Shared Assemblies
+
+**Input**: Design documents from `/specs/012-pattern-shared-assemblies/`
+**Prerequisites**: [plan.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/plan.md), [spec.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/spec.md), [research.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/research.md), [data-model.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/data-model.md), [contracts/shared-assemblies.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/contracts/shared-assemblies.md), [quickstart.md](/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/quickstart.md)
+
+**Tests**: Included because the specification defines independent tests and 100% matching/validation success criteria.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently after the foundational selector model exists.
+
+## Phase 1: Setup
+
+**Purpose**: Prepare the work area and test files without changing behavior.
+
+- [X] T001 Review existing feature assembly resolver behavior in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`
+- [X] T002 [P] Create shared assembly pattern test file in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs`
+- [X] T003 [P] Create shared assembly configuration test file in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs`
+- [X] T004 [P] Create shared assembly builder test file in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs`
+- [X] T005 [P] Create shared assembly resolver test file in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Define shared contracts and internal selector primitives required by all stories.
+
+**Critical**: No user story implementation should start until this phase is complete.
+
+- [X] T006 [P] Add public selector kind enum in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/SharedAssemblySelectorKind.cs`
+- [X] T007 [P] Add public match diagnostics record in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/SharedAssemblyMatch.cs`
+- [X] T008 [P] Add public selector contract in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/ISharedAssemblySelector.cs`
+- [X] T009 Add internal prefix/exact parser and matcher in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblyPattern.cs`
+- [X] T010 Add internal selector representation with source metadata in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelector.cs`
+- [X] T011 Add internal selector provider and deduplication support in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+
+**Checkpoint**: Foundation ready; exact, prefix-pattern, source metadata, and diagnostics types exist.
+
+---
+
+## Phase 3: User Story 1 - Configure Shared Assemblies With Patterns (Priority: P1) MVP
+
+**Goal**: A host can declare exact names and prefix wildcard patterns in root `CShells:SharedAssemblies`.
+
+**Independent Test**: Load root configuration with `Elsa` and `Elsa.*`, then verify only `Elsa` and `Elsa.Workflows` are selected while `Contoso.Workflows` is not.
+
+### Tests for User Story 1
+
+- [X] T012 [P] [US1] Add configuration binding tests for root `CShells:SharedAssemblies` in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs`
+- [X] T013 [P] [US1] Add exact-name and prefix-pattern matcher tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs`
+- [X] T014 [P] [US1] Add resolver filtering tests for configured `Elsa` and `Elsa.*` selectors in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T015 [US1] Add `SharedAssemblies` root option to `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Configuration/CShellsOptions.cs`
+- [X] T016 [US1] Load root `CShells:SharedAssemblies` entries in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
+- [X] T017 [US1] Store configuration selectors on the builder in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs`
+- [X] T018 [US1] Apply shared assembly selectors when resolving host assemblies in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`
+- [X] T019 [US1] Wire builder selector filtering into feature assembly resolution in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs`
+
+**Checkpoint**: User Story 1 is independently functional and testable as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Configure Shared Assemblies In Code (Priority: P2)
+
+**Goal**: Library integrators can declare exact names, prefix wildcard patterns, and predicate selectors through code-first builder APIs.
+
+**Independent Test**: Configure `WithSharedAssemblies("Elsa.*")` and `WithSharedAssembliesWhere(...)`, then verify included and excluded assemblies by simple name.
+
+### Tests for User Story 2
+
+- [X] T020 [P] [US2] Add `WithSharedAssemblies` exact and prefix-pattern API tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs`
+- [X] T021 [US2] Add `WithSharedAssembliesWhere` predicate include/exclude tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs`
+- [X] T022 [P] [US2] Add configuration plus code-first deduplication tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T023 [US2] Add public `WithSharedAssemblies(params string[] patterns)` API in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
+- [X] T024 [US2] Add public `WithSharedAssembliesWhere(Func<string, bool> predicate)` API in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
+- [X] T025 [US2] Register code-first selector sources and predicate wrappers in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilder.cs`
+- [X] T026 [US2] Evaluate predicate selectors against assembly simple names in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+- [X] T027 [US2] Deduplicate configuration and code-first matches by simple name in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+
+**Checkpoint**: User Story 2 works independently with code-first selectors and continues to compose with User Story 1.
+
+---
+
+## Phase 5: User Story 3 - Keep Matching Explicit And Bounded (Priority: P3)
+
+**Goal**: Matching is limited to assembly simple names, invalid patterns fail early, and users can inspect which selector selected an assembly.
+
+**Independent Test**: Verify full names, versions, cultures, public key tokens, file paths, and non-final `*` positions never affect matching; diagnostics identify the responsible selector source.
+
+### Tests for User Story 3
+
+- [X] T028 [P] [US3] Add invalid wildcard grammar tests for `*.Contracts` and `Elsa.*.Abstractions` in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs`
+- [X] T029 [P] [US3] Add blank and whitespace selector validation tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs`
+- [X] T030 [P] [US3] Add simple-name-only matching tests for full name and path-like candidates in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs`
+- [X] T031 [P] [US3] Add predicate exception source feedback tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs`
+- [X] T032 [US3] Add match diagnostics source tests in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T033 [US3] Enforce blank selector and non-final `*` validation messages in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblyPattern.cs`
+- [X] T034 [US3] Include configuration paths and code-first source names in selector errors in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+- [X] T035 [US3] Ensure resolver extracts only `AssemblyName.Name` before matching in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/FeatureAssemblyResolver.cs`
+- [X] T036 [US3] Expose shared assembly match diagnostics from the selector provider in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+- [X] T037 [US3] Wrap predicate exceptions with actionable selector source feedback in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/Features/SharedAssemblySelectorProvider.cs`
+
+**Checkpoint**: User Story 3 confirms the isolation boundary and troubleshooting behavior.
+
+---
+
+## Phase 6: User Story 4 - Document Framework-Friendly Usage (Priority: P4)
+
+**Goal**: Developers can find examples and guidance for exact names, prefix wildcard patterns, predicate selectors, and isolation tradeoffs.
+
+**Independent Test**: Review docs and samples for root configuration, code-first examples, and broad-sharing cautions.
+
+### Tests for User Story 4
+
+- [X] T038 [P] [US4] Add documentation sample coverage checks in `/Users/sipke/Projects/ValenceWorks/cshells/main/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs`
+
+### Implementation for User Story 4
+
+- [X] T039 [P] [US4] Add root `CShells:SharedAssemblies` example to `/Users/sipke/Projects/ValenceWorks/cshells/main/README.md`
+- [X] T040 [P] [US4] Add shared assembly guidance to `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/getting-started.md`
+- [X] T041 [P] [US4] Add framework integration guidance and isolation cautions to `/Users/sipke/Projects/ValenceWorks/cshells/main/docs/integration-patterns.md`
+- [X] T042 [P] [US4] Update Workbench sample configuration with a representative shared assembly example in `/Users/sipke/Projects/ValenceWorks/cshells/main/samples/CShells.Workbench/appsettings.json`
+- [X] T043 [US4] Validate documented commands from quickstart in `/Users/sipke/Projects/ValenceWorks/cshells/main/specs/012-pattern-shared-assemblies/quickstart.md`
+
+**Checkpoint**: User Story 4 documentation is independently reviewable and matches implemented behavior.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency, cleanup, and full verification.
+
+- [X] T044 [P] Run focused shared assembly tests with `dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~SharedAssembly"` from `/Users/sipke/Projects/ValenceWorks/cshells/main`
+- [X] T045 Run full test suite with `dotnet test` from `/Users/sipke/Projects/ValenceWorks/cshells/main`
+- [X] T046 [P] Review public XML documentation for new APIs in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells.Abstractions/Features/ISharedAssemblySelector.cs`
+- [X] T047 [P] Review public XML documentation for builder APIs in `/Users/sipke/Projects/ValenceWorks/cshells/main/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs`
+- [X] T048 Verify no package versions or new third-party dependencies were added in `/Users/sipke/Projects/ValenceWorks/cshells/main/Directory.Packages.props`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational; delivers MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational and can be implemented after or alongside US1, but final composition test depends on US1 selector loading.
+- **User Story 3 (Phase 5)**: Depends on Foundational and can run alongside US1/US2 once matcher and selector provider exist.
+- **User Story 4 (Phase 6)**: Depends on implemented API names from US1/US2 and final behavior from US3.
+- **Polish (Phase 7)**: Depends on all desired user stories.
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories; recommended MVP.
+- **US2**: Independent code-first path, with one composition check against US1 configuration behavior.
+- **US3**: Independent validation/diagnostics layer over the shared selector model.
+- **US4**: Depends on settled public API and configuration shape.
+
+### Parallel Opportunities
+
+- T002-T005 can run in parallel because they create separate test files.
+- T006-T008 can run in parallel because they create separate abstraction files.
+- T012-T014 can run in parallel after T009-T011 because they target separate test concerns.
+- T020-T022 can run in parallel after US1 foundation exists.
+- T028-T032 can run in parallel because they cover separate validation and diagnostics behavior.
+- T039-T042 can run in parallel once API names and configuration shape are stable.
+- T044, T046, and T047 can run in parallel during polish after implementation.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T012 [P] [US1] Add configuration binding tests for root CShells:SharedAssemblies in tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs"
+Task: "T013 [P] [US1] Add exact-name and prefix-pattern matcher tests in tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs"
+Task: "T014 [P] [US1] Add resolver filtering tests for configured Elsa and Elsa.* selectors in tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T020 [P] [US2] Add WithSharedAssemblies exact and prefix-pattern API tests in tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs"
+Task: "T022 [P] [US2] Add configuration plus code-first deduplication tests in tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T028 [P] [US3] Add invalid wildcard grammar tests in tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs"
+Task: "T029 [P] [US3] Add blank and whitespace selector validation tests in tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs"
+Task: "T030 [P] [US3] Add simple-name-only matching tests in tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs"
+Task: "T031 [P] [US3] Add predicate exception source feedback tests in tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 for User Story 1.
+3. Run focused tests for configuration-driven exact and prefix-pattern matching.
+4. Stop and validate that root `CShells:SharedAssemblies` works without code-first APIs.
+
+### Incremental Delivery
+
+1. Deliver US1 configuration-driven selectors as the MVP.
+2. Add US2 code-first selectors and predicate support.
+3. Add US3 diagnostics and bounded failure behavior.
+4. Add US4 documentation and samples.
+5. Run focused and full test suites.
+
+### TDD Flow
+
+1. For each story, write the story's test tasks first.
+2. Confirm the new tests fail for the expected missing behavior.
+3. Implement the story tasks.
+4. Re-run the focused shared assembly test filter before moving to the next story.

--- a/specs/013-lifecycle-ordering/spec.md
+++ b/specs/013-lifecycle-ordering/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/specs/014-polymorphic-feature-config/checklists/requirements.md
+++ b/specs/014-polymorphic-feature-config/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Polymorphic Feature Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on the initial checklist review.
+- The specification intentionally treats configuration shape and precedence as the user-facing product contract for this developer-facing feature.

--- a/specs/014-polymorphic-feature-config/contracts/feature-configuration.md
+++ b/specs/014-polymorphic-feature-config/contracts/feature-configuration.md
@@ -1,0 +1,139 @@
+# Contract: Feature Configuration Values
+
+## Supported JSON Map Shape
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "DefaultAuthentication": true,
+          "Identity": false,
+          "Http": {
+            "HttpActivityOptions": {
+              "BasePath": "/workflows",
+              "BaseUrl": "http://elsa-server:8080"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Value Semantics
+
+| Value form | Meaning |
+|------------|---------|
+| `true` | Enable the feature with default settings and ignore inherited lower-priority settings for that feature. |
+| `"true"` | Same as `true`; accepted case-insensitively for string-valued providers. |
+| `false` | Disable the feature, even if lower-priority configuration or code-first defaults enabled it. |
+| `"false"` | Same as `false`; accepted case-insensitively for string-valued providers. |
+| `{}` | Enable the feature with default settings; retained for existing object-map compatibility. |
+| `{ ... }` | Enable the feature and bind object properties directly as feature settings. |
+
+## Invalid Values
+
+These forms must fail before shell activation:
+
+```json
+{
+  "Features": {
+    "Identity": null,
+    "Http": "yes",
+    "Posts": 1,
+    "Analytics": []
+  }
+}
+```
+
+## Direct Feature Settings
+
+Feature object properties bind directly under the feature name. A property named `Enabled` is feature settings, not control metadata.
+
+```json
+{
+  "Features": {
+    "Example": {
+      "Enabled": true,
+      "Limit": 10
+    }
+  }
+}
+```
+
+The example above enables `Example` and exposes settings equivalent to:
+
+```text
+Example:Enabled = true
+Example:Limit = 10
+```
+
+## Layered Override Examples
+
+Base application defaults:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": {
+            "SigningKey": "default"
+          },
+          "Http": true
+        }
+      }
+    }
+  }
+}
+```
+
+Mounted deployment override:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": false,
+          "Http": {
+            "HttpActivityOptions": {
+              "BasePath": "/custom"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Result:
+
+- `Identity` is disabled.
+- `Http` remains enabled and receives merged object settings.
+
+Environment-style override:
+
+```text
+CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY=false
+```
+
+The string value `false` disables `Identity`.
+
+## Unknown Features
+
+| Declaration | Result |
+|-------------|--------|
+| Unknown feature set to `false` | Allowed no-op disablement. |
+| Unknown feature set to `true` | Invalid attempted activation. |
+| Unknown feature set to object | Invalid attempted activation. |
+
+## Code-First Defaults
+
+Code-first feature registrations are defaults. Higher-priority configuration can disable or re-enable them using the same value semantics.

--- a/specs/014-polymorphic-feature-config/data-model.md
+++ b/specs/014-polymorphic-feature-config/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Polymorphic Feature Configuration
+
+## Feature Configuration Map
+
+Per-shell configuration section at `CShells:Shells:{ShellName}:Features`.
+
+Fields:
+
+- `FeatureName`: map key. Required, non-blank after trimming.
+- `FeatureValue`: one of native boolean, case-insensitive string boolean, or object.
+
+Validation:
+
+- Blank feature names are invalid.
+- `null` values are invalid.
+- Unsupported scalar values are invalid.
+- Arrays are not part of the primary contract.
+
+## Feature Declaration
+
+Normalized representation of one configured feature entry.
+
+Fields:
+
+- `Name`: feature name from the map key or code-first API.
+- `State`: enabled or disabled.
+- `Settings`: direct feature option values when the declaration is an object.
+- `ResetsSettings`: true when a higher-priority `true` declaration should drop lower-priority settings.
+- `Source`: optional diagnostic description such as shell name or configuration path.
+
+Validation:
+
+- Enabled declarations require the feature to exist in the runtime catalog.
+- Disabled declarations may name unknown features and become no-op disablements.
+- Object declarations are enabled declarations and preserve direct settings.
+
+State transitions:
+
+- Absent → Enabled by `true`, `{}`, object, or code-first registration.
+- Enabled → Disabled by higher-priority `false`.
+- Disabled → Enabled with defaults by higher-priority `true`.
+- Disabled → Enabled with merged settings by higher-priority object.
+
+## Shell Settings
+
+Runtime composition state for a shell.
+
+Fields:
+
+- `Id`: shell identifier.
+- `EnabledFeatures`: final enabled feature names after declaration merge.
+- `DisabledFeatures`: explicit disabled feature declarations that must remove lower-priority defaults during merge.
+- `ConfigurationData`: flattened shell and feature option settings.
+- `FeatureConfigurators`: code-first feature instance configurators.
+
+Validation:
+
+- `EnabledFeatures` should contain only features selected for dependency resolution and activation.
+- Explicit disabled features must remove matching enabled feature names before dependency resolution.
+- Configuration data for a feature reset by `true` must not keep lower-priority feature option keys.
+
+Relationships:
+
+- A shell has one feature configuration map.
+- A feature configuration map produces zero or more feature declarations.
+- Feature declarations resolve into `ShellSettings.EnabledFeatures`, `ShellSettings.DisabledFeatures`, and feature-prefixed `ConfigurationData`.
+
+## Configuration Layer
+
+Ordered source contributing shell feature declarations.
+
+Examples:
+
+- Code-first shell defaults.
+- Application settings.
+- Mounted deployment JSON.
+- Environment variables.
+
+Merge rules:
+
+- Later layers have higher priority.
+- A higher-priority `false` disables lower-priority enabled declarations and ignores lower-priority child settings.
+- A higher-priority `true` enables with defaults and removes lower-priority child settings for that feature.
+- Higher-priority object declarations enable the feature and merge object settings through normal configuration precedence.
+
+## Resolved Feature Set
+
+Final set consumed by dependency resolution and activation.
+
+Fields:
+
+- `Enabled`: catalog-known feature names ordered by dependency resolver.
+- `MissingPositive`: unknown features requested by `true` or object values.
+- `IgnoredDisabled`: unknown features requested by `false`.
+
+Validation:
+
+- `MissingPositive` fails with actionable messages.
+- `IgnoredDisabled` does not fail shell activation.
+- Disabled catalog-known features do not run configuration binding, service registration, endpoint mapping, or post-configuration hooks.

--- a/specs/014-polymorphic-feature-config/plan.md
+++ b/specs/014-polymorphic-feature-config/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Polymorphic Feature Configuration
+
+**Branch**: `014-polymorphic-feature-config` | **Date**: 2026-05-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/014-polymorphic-feature-config/spec.md`
+
+## Summary
+
+Keep per-shell `Features` as a named map while allowing each feature value to be `true`, `false`, or an object. The implementation will extend feature entry parsing to preserve explicit enable/disable declarations, merge code-first defaults with configuration declarations by precedence, reset feature settings on higher-priority `true`, and continue binding object feature settings directly under the feature name.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10; source projects multi-target `net8.0;net9.0;net10.0` per repository conventions  
+**Primary Dependencies**: Existing `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `System.Text.Json`; no new third-party packages  
+**Storage**: N/A; configuration provider inputs only  
+**Testing**: xUnit in `tests/CShells.Tests`; focused unit tests for parsing/merging plus integration-level activation behavior where needed  
+**Target Platform**: .NET library/runtime used by ASP.NET Core hosts and background workers  
+**Project Type**: Multi-package .NET library  
+**Performance Goals**: Feature parsing and merging remain linear in configured feature declarations per shell; no additional shell activation passes  
+**Constraints**: Preserve direct feature option binding paths; do not introduce `Settings`, `EnabledFeatures`, or `DisabledFeatures` configuration sections; code-first registrations are overridable defaults  
+**Scale/Scope**: Per-shell feature maps and layered configuration sources; no persistent storage or external services
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Abstraction-First Architecture**: PASS. Runtime feature declarations affect public `ShellSettings` semantics, so any required model state belongs in `CShells.Abstractions` before implementation uses it.
+- **II. Feature Modularity**: PASS. The feature remains declarative shell configuration; no feature constructor/service coupling changes.
+- **III. Modern C# Style**: PASS. Planned edits use existing C# 14 conventions, collection expressions, explicit access modifiers, nullable annotations, and XML docs for public members.
+- **IV. Explicit Error Handling**: PASS. Invalid values, nulls, blank feature names, and unknown positive feature entries will fail with actionable messages that name the feature path.
+- **V. Test Coverage**: PASS. Unit and integration tests are planned for all new value forms, merge precedence, option reset behavior, environment-style strings, and unknown-feature behavior.
+- **VI. Simplicity & Minimalism**: PASS. The design extends the existing feature entry model and parsing helpers rather than adding a separate configuration subsystem.
+- **VII. Lifecycle & Concurrency Contracts**: PASS. The feature affects composition before activation and does not add shared mutable lifecycle state or async coordination.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-polymorphic-feature-config/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── feature-configuration.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── CShells.Abstractions/
+│   └── ShellSettings.cs
+└── CShells/
+    ├── Configuration/
+    │   ├── FeatureEntry.cs
+    │   ├── FeatureEntryListJsonConverter.cs
+    │   ├── ConfigurationHelper.cs
+    │   ├── ShellBuilder.cs
+    │   └── ShellConfig.cs
+    └── Lifecycle/
+        ├── Blueprints/ConfigurationShellBlueprint.cs
+        ├── Providers/ConfiguredShellBlueprintProvider.cs
+        └── ShellProviderBuilder.cs
+
+tests/
+└── CShells.Tests/
+    ├── Unit/
+    │   ├── Configuration/
+    │   ├── Lifecycle/Blueprints/
+    │   └── ShellBuilderTests.cs
+    └── Integration/
+        └── FeatureDependency/
+```
+
+**Structure Decision**: Implement in the existing core configuration and lifecycle composition paths. `ShellSettings` carries final enabled features plus explicit disabled declarations needed for precedence merging; configuration helpers normalize all supported input forms into that model.
+
+## Complexity Tracking
+
+No constitution violations or added complexity exceptions.
+
+## Phase 0: Research
+
+Research decisions are captured in [research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+Design artifacts:
+
+- [data-model.md](./data-model.md)
+- [contracts/feature-configuration.md](./contracts/feature-configuration.md)
+- [quickstart.md](./quickstart.md)
+
+### Post-Design Constitution Check
+
+- **I. Abstraction-First Architecture**: PASS. Public composition state is represented in `CShells.Abstractions/ShellSettings.cs`; parsing and activation behavior remains in implementation projects.
+- **II. Feature Modularity**: PASS. The resolved feature set still feeds existing dependency resolution and feature activation.
+- **III. Modern C# Style**: PASS. Planned public model changes require XML documentation and existing naming/style conventions.
+- **IV. Explicit Error Handling**: PASS. The contract defines precise accepted values and actionable failures.
+- **V. Test Coverage**: PASS. Design maps every clarified behavior to focused tests.
+- **VI. Simplicity & Minimalism**: PASS. No new packages, storage, or alternate configuration section hierarchy.
+- **VII. Lifecycle & Concurrency Contracts**: PASS. No lifecycle state machine or concurrent mutation changes.

--- a/specs/014-polymorphic-feature-config/quickstart.md
+++ b/specs/014-polymorphic-feature-config/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: Polymorphic Feature Configuration
+
+## Goal
+
+Verify that per-shell features can be enabled, disabled, and configured with the compact map syntax.
+
+## Example Configuration
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "DefaultAuthentication": true,
+          "Identity": false,
+          "Http": {
+            "HttpActivityOptions": {
+              "BasePath": "/workflows",
+              "BaseUrl": "http://elsa-server:8080"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Expected result:
+
+- `DefaultAuthentication` is enabled with defaults.
+- `Identity` is disabled.
+- `Http` is enabled and receives `HttpActivityOptions` settings directly.
+
+## Docker Override Scenario
+
+Application defaults can enable features:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": {
+            "SigningKey": "default"
+          },
+          "Http": true
+        }
+      }
+    }
+  }
+}
+```
+
+A mounted deployment file can disable defaults:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": false
+        }
+      }
+    }
+  }
+}
+```
+
+Expected result: `Identity` does not participate in dependency resolution, configuration binding, service registration, endpoint mapping, or post-configuration hooks.
+
+## Environment Variable Scenario
+
+Use string-valued provider syntax:
+
+```text
+CSHELLS__SHELLS__DEFAULT__FEATURES__IDENTITY=false
+```
+
+Expected result: string `false` is interpreted case-insensitively as a disable declaration.
+
+## Validation Checklist
+
+Run focused tests during implementation:
+
+```bash
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~Configuration"
+dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~Lifecycle.Blueprints"
+dotnet test tests/CShells.Tests/
+```
+
+Verify:
+
+- `true`, `"true"`, `{}`, and object entries enable features.
+- `false` and `"false"` disable features.
+- Higher-priority `true` resets lower-priority option values.
+- Object entries preserve direct settings and normal layered merging.
+- Unknown `false` entries do not fail activation.
+- Unknown positive entries fail with actionable messages.
+- Existing object-map configuration continues to bind feature options without a `Settings` wrapper.

--- a/specs/014-polymorphic-feature-config/research.md
+++ b/specs/014-polymorphic-feature-config/research.md
@@ -1,0 +1,65 @@
+# Research: Polymorphic Feature Configuration
+
+## Decision: Extend the feature entry model with explicit declaration state
+
+**Rationale**: `EnabledFeatures` alone cannot distinguish "not mentioned" from "explicitly disabled", which is required for code-first defaults to be overridable by higher-priority configuration. Extending the normalized feature entry/declaration model lets parsing preserve `true`, `false`, and object intent until merge resolution produces the final enabled feature set.
+
+**Alternatives considered**:
+
+- Keep only `EnabledFeatures`: rejected because disabled configuration cannot remove code-first defaults.
+- Store disablement as magic keys in `ConfigurationData`: rejected because it leaks control state into feature option binding and management output.
+- Add public `DisabledFeatures` configuration sections: rejected by the spec because it worsens DX and splits one concept across two places.
+
+## Decision: Keep the public configuration contract as a named map
+
+**Rationale**: Named maps merge predictably across layered configuration providers and support stable environment-variable paths. Arrays are still present in legacy code, but the new contract should prefer map syntax and avoid recommending array feature lists.
+
+**Alternatives considered**:
+
+- Feature arrays with string entries: attractive for compact local JSON, but brittle across layered configuration because provider merging is index-based.
+- Separate `EnabledFeatures` and `DisabledFeatures`: explicit, but creates conflict rules and makes feature settings awkward.
+
+## Decision: Interpret `true` as enable-with-defaults and reset inherited child settings
+
+**Rationale**: A higher-priority `true` is a positive declaration that asks for defaults. If it inherited lower-priority settings, deployers would have no compact way to opt back into a feature while dropping packaged defaults.
+
+**Alternatives considered**:
+
+- Let configuration provider child merging leak through under `true`: rejected because it surprises users and violates the clarification.
+- Make all positive declarations replace lower-priority settings: rejected because object entries should still support ordinary partial option overrides.
+
+## Decision: Let object entries merge normally and bind directly as feature settings
+
+**Rationale**: Object entries are the configured-options form. Preserving direct binding paths avoids a migration tax and keeps common layered option override behavior.
+
+**Alternatives considered**:
+
+- Introduce a `Settings` wrapper: rejected by the spec as too verbose.
+- Treat an object property named `Enabled` as control metadata: rejected because it would break feature option names and make direct binding ambiguous.
+
+## Decision: Accept native booleans and case-insensitive string `true` / `false`
+
+**Rationale**: Environment variables and some providers surface scalar values as strings, so string booleans are needed for deployment overrides. Restricting accepted strings to `true` and `false` keeps validation precise.
+
+**Alternatives considered**:
+
+- Native booleans only: rejected because environment-variable enable/disable would be impractical.
+- Accept `yes`, `no`, `1`, and `0`: rejected because it broadens the grammar without user value and makes invalid config easier to miss.
+
+## Decision: Unknown disabled features are no-op declarations; unknown positive entries fail
+
+**Rationale**: Shared deployment configuration should be able to disable optional features across application variants. Positive declarations still need validation because they attempt to activate unavailable behavior and often indicate typos or missing assemblies.
+
+**Alternatives considered**:
+
+- Fail every unknown feature: rejected because it harms portable deployment config.
+- Ignore every unknown feature: rejected because it hides attempted activations and misspellings.
+
+## Decision: Validate before activation and preserve existing dependency failure semantics
+
+**Rationale**: Disabled features must be removed before dependency resolution and service configuration. If another enabled feature depends on a disabled feature, the system should behave as though that dependency is absent and surface the existing dependency validation error.
+
+**Alternatives considered**:
+
+- Disable dependents automatically: rejected because it would hide configuration mistakes.
+- Activate disabled dependencies to satisfy dependent features: rejected because it contradicts explicit disablement.

--- a/specs/014-polymorphic-feature-config/spec.md
+++ b/specs/014-polymorphic-feature-config/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Polymorphic Feature Configuration
+
+**Feature Branch**: `014-polymorphic-feature-config`  
+**Created**: 2026-05-11  
+**Status**: Draft  
+**Input**: User description: "Make CShells feature configuration more pleasant and override-friendly by keeping `Features` as a named feature map while allowing each feature entry to be expressed as `true`, `false`, or an object. `true` enables a feature with default settings, `false` explicitly disables a feature even if an earlier configuration source or code-first default enabled it, and an object enables the feature while binding that object directly as feature settings. Avoid `EnabledFeatures`/`DisabledFeatures` split sections and avoid an extra `Settings` nesting layer. Preserve existing `{}` feature entries as enabled-with-defaults. Define layered precedence clearly so later configuration sources can disable or re-enable earlier feature declarations, including Docker-mounted configuration overriding application defaults."
+
+## Clarifications
+
+### Session 2026-05-11
+
+- Q: Should code-first feature registrations be overridable by configuration? → A: Code-first feature registrations are overridable defaults; higher-priority configuration can disable or re-enable them.
+- Q: How should higher-priority `true` interact with lower-priority feature settings? → A: `false` disables despite inherited children; `true` enables with defaults and ignores inherited children; object entries enable with normally merged object settings.
+- Q: Which scalar boolean representations should feature entries accept? → A: Accept native booleans and case-insensitive string `true` / `false`; reject all other scalar values.
+- Q: How should disablement behave for unknown feature names? → A: Unknown feature set to `false` is allowed as a no-op and may be surfaced in diagnostics; unknown feature set to `true` or object remains invalid.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Enable Features With Compact Values (Priority: P1)
+
+As a CShells configuration author, I want to enable features with `true` when no feature-specific settings are needed so configuration files are easier to scan and do not require empty objects.
+
+**Why this priority**: This is the most visible DX improvement. It removes noisy `{}` entries while preserving the named feature map that works well with layered configuration.
+
+**Independent Test**: Can be fully tested by loading a shell configuration with feature entries set to `true`, `{}`, and configured objects, then confirming each enabled feature is present with the expected settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shell configuration contains `"DefaultAuthentication": true`, **When** shell settings are loaded, **Then** the `DefaultAuthentication` feature is enabled with default settings.
+2. **Given** a shell configuration contains `"DefaultAuthentication": {}`, **When** shell settings are loaded, **Then** the `DefaultAuthentication` feature remains enabled with default settings for backward compatibility.
+3. **Given** a shell configuration contains `"Http": { "HttpActivityOptions": { "BasePath": "/workflows" } }`, **When** shell settings are loaded, **Then** the `Http` feature is enabled and receives the configured settings directly from the object.
+
+---
+
+### User Story 2 - Disable Default Features From Later Configuration (Priority: P2)
+
+As an operator using a packaged application or Docker image, I want a mounted configuration file to disable features that were enabled by application defaults so I can tailor the runtime shell without modifying the source application.
+
+**Why this priority**: The current presence-based model can add or override feature settings but cannot express removal. Explicit disablement is the core operational need.
+
+**Independent Test**: Can be fully tested by loading base application configuration plus a higher-priority configuration source that sets an existing feature entry to `false`, then confirming the final shell does not activate that feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** base configuration enables `Identity` with settings, **When** a later configuration source sets `"Identity": false`, **Then** the final shell does not enable `Identity`.
+2. **Given** base configuration enables several features, **When** a later configuration source disables one feature, **Then** unrelated enabled features and their settings remain unchanged.
+3. **Given** an application provides code-first feature defaults for a shell, **When** deploy-time configuration explicitly sets one of those feature names to `false`, **Then** the final shell does not activate that feature.
+4. **Given** an environment variable override sets a feature entry to `"false"` using the configuration provider's string value form, **When** shell settings are loaded, **Then** the value is interpreted as an explicit feature disablement.
+5. **Given** shared deployment configuration disables a feature not present in the current application, **When** shell settings are loaded, **Then** the unknown disabled feature is ignored without preventing shell activation.
+
+---
+
+### User Story 3 - Re-Enable Or Reconfigure Features From Later Configuration (Priority: P3)
+
+As an operator or application maintainer, I want later configuration sources to be able to re-enable a feature by setting it to `true` or to an object so the highest-priority configuration expresses the final intent.
+
+**Why this priority**: Disablement must be reversible across layered configuration. Without re-enable semantics, a lower-priority `false` would be too sticky for deployment-specific customization.
+
+**Independent Test**: Can be fully tested by composing multiple configuration sources where an earlier source disables a feature and a later source enables or configures it, then confirming the later declaration wins.
+
+**Acceptance Scenarios**:
+
+1. **Given** an earlier configuration source sets `"Identity": false`, **When** a later source sets `"Identity": true`, **Then** the final shell enables `Identity` with default settings.
+2. **Given** an earlier configuration source sets `"Identity": false`, **When** a later source sets `"Identity": { "SigningKey": "configured" }`, **Then** the final shell enables `Identity` with the provided settings.
+3. **Given** an earlier configuration source provides settings for `Identity`, **When** a later source sets `"Identity": true`, **Then** the final shell enables `Identity` with default settings and does not inherit the earlier settings.
+4. **Given** multiple configuration layers declare object settings for the same feature, **When** the final shell settings are resolved, **Then** object settings merge according to normal configuration precedence.
+
+---
+
+### User Story 4 - Keep Feature Settings Direct And Familiar (Priority: P4)
+
+As a developer configuring feature options, I want configured feature objects to continue binding directly to feature settings so I do not need to add a wrapper such as `Settings`.
+
+**Why this priority**: Extra nesting would make every configured feature more verbose and would make existing configuration harder to migrate.
+
+**Independent Test**: Can be fully tested by loading existing object-based feature configuration and confirming feature options bind from the same paths as before.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing feature configuration object contains option properties directly under the feature name, **When** the new format is used, **Then** those option properties continue to bind without a `Settings` wrapper.
+2. **Given** a feature object contains a property named `Enabled`, **When** feature settings are bound, **Then** that property is treated as feature settings rather than as the feature enablement flag.
+3. **Given** documentation shows configured feature options, **When** a developer copies the example, **Then** the example uses direct option nesting under the feature name.
+
+### Edge Cases
+
+- A feature entry set to `false` must disable the feature even when lower-priority configuration still contains child settings for that feature.
+- A later `true` declaration must re-enable a feature disabled by an earlier source with default settings and without inherited lower-priority child settings.
+- A later object declaration must re-enable a feature disabled by an earlier source and merge object settings according to normal configuration precedence.
+- A feature entry set to `null` is invalid because it does not clearly express enable, disable, or settings.
+- A feature entry with an empty object remains valid and means enable with default settings.
+- Feature names with blank or whitespace-only keys are invalid and must fail before shell activation.
+- Invalid scalar values such as `"yes"`, `0`, or arbitrary strings other than case-insensitive `true` / `false` must fail with an actionable error rather than being guessed.
+- Unknown feature names set to `false` are valid no-op disablements and should remain visible for diagnostics where available.
+- Unknown feature names set to `true` or to an object are invalid because they represent attempted activation of an unavailable feature.
+- Duplicate feature declarations across configuration sources must resolve according to source priority, not by producing duplicate feature activations.
+- Disabled features must not run service configuration, endpoint mapping, dependency activation, or post-configuration hooks.
+- Disabling a feature that other enabled features depend on must produce the same dependency validation behavior as if the feature were absent.
+- Documentation must make clear that arrays are not the primary feature configuration format because named maps merge more predictably across configuration layers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST continue to represent per-shell features as a named map under each shell's `Features` section.
+- **FR-002**: The system MUST support a feature entry value of `true` to enable the named feature with default settings.
+- **FR-003**: The system MUST support a feature entry value of `false` to explicitly disable the named feature.
+- **FR-004**: The system MUST support a feature entry value of an object to enable the named feature and bind that object directly as the feature's settings.
+- **FR-005**: The system MUST preserve existing empty object entries such as `"FeatureName": {}` as enabled-with-defaults declarations.
+- **FR-006**: The system MUST NOT require or introduce `EnabledFeatures`, `DisabledFeatures`, `Enabled`, or `Settings` wrapper sections for the primary feature configuration format.
+- **FR-007**: The system MUST treat a direct feature object property named `Enabled` as ordinary feature settings, not as the feature enablement flag.
+- **FR-008**: The system MUST allow a higher-priority configuration source to disable a feature enabled by a lower-priority configuration source.
+- **FR-009**: The system MUST treat application code-first feature registrations as defaults that higher-priority configuration can disable or re-enable.
+- **FR-010**: The system MUST allow a higher-priority configuration source to re-enable a feature disabled by a lower-priority source by setting the feature entry to `true`.
+- **FR-011**: The system MUST allow a higher-priority configuration source to re-enable and configure a feature disabled by a lower-priority source by setting the feature entry to an object.
+- **FR-012**: The system MUST treat a higher-priority `true` declaration as enabled-with-defaults and MUST NOT inherit lower-priority child settings for that feature.
+- **FR-013**: The system MUST merge object feature settings according to normal configuration precedence when multiple configuration layers provide object values for the same enabled feature.
+- **FR-014**: The system MUST ensure the final resolved feature set contains only enabled features and excludes explicitly disabled features before feature dependency resolution and activation.
+- **FR-015**: The system MUST accept native boolean values and case-insensitive string values `true` and `false` as feature enablement scalars.
+- **FR-016**: The system MUST validate feature entry values and reject unsupported scalar values with a clear message that identifies the feature path and expected value forms.
+- **FR-017**: The system MUST reject `null` feature entry values with a clear message that instructs users to use `true`, `false`, or an object.
+- **FR-018**: The system MUST allow an unknown feature entry set to `false` as a no-op disablement.
+- **FR-019**: The system MUST reject an unknown feature entry set to `true` or to an object because it attempts to enable an unavailable feature.
+- **FR-020**: The system SHOULD make unknown feature no-op disablements visible in diagnostics where diagnostic output is available.
+- **FR-021**: The system MUST reject blank or whitespace-only feature names before shell activation.
+- **FR-022**: The system MUST preserve existing feature option binding paths for object-based feature entries.
+- **FR-023**: The system MUST document the three supported feature entry forms: `true`, `false`, and object.
+- **FR-024**: Documentation and samples MUST show Docker or deployment override examples where mounted configuration disables a default feature with `false`.
+- **FR-025**: Documentation MUST explain precedence behavior for disable and re-enable declarations across layered configuration sources and code-first defaults.
+- **FR-026**: Documentation MUST avoid recommending array-based feature lists as the primary configuration format.
+
+### Key Entities *(include if feature involves data)*
+
+- **Feature Configuration Map**: The per-shell collection under `Features` whose keys are feature names and whose values declare enablement, disablement, or feature settings.
+- **Feature Entry**: A single named item in the feature configuration map, represented as `true`, `false`, or an object.
+- **Enabled Feature Declaration**: A feature entry that resolves to enabled, either because its value is `true`, `{}`, or a settings object.
+- **Disabled Feature Declaration**: A feature entry whose value is `false` and which removes that feature from the final activated feature set.
+- **Feature Settings Object**: A direct object value under a feature name that both enables the feature and provides bindable settings.
+- **Configuration Layer**: A source of configuration values, such as application defaults, deployment configuration, mounted Docker configuration, environment variables, or code-first defaults, that contributes to the final feature state.
+- **Resolved Feature Set**: The final per-shell collection of features that will participate in dependency validation, service configuration, endpoint mapping, and activation.
+
+### Assumptions
+
+- The named feature map remains the preferred shape because it merges more predictably than arrays across layered configuration sources.
+- Feature object values continue to bind directly to configurable feature options.
+- `false` is the only supported disablement syntax in configuration.
+- `true` is the preferred compact enablement syntax when a feature has no settings.
+- String `true` and `false` values are supported so environment variables and other string-valued configuration providers can enable and disable features.
+- Existing object-based feature entries remain valid to avoid unnecessary migration churn.
+- The highest-priority explicit declaration for a feature determines its final enabled or disabled state.
+- A `true` declaration is intentionally a reset to feature defaults, while object declarations preserve normal layered option merging.
+- Unknown feature disablements are allowed to support reusable deployment configuration across application variants.
+- Code-first feature registrations participate as overridable defaults rather than authoritative declarations.
+- Application authors expect deployment configuration, such as a Docker-mounted file, to be able to opt out of default features supplied by the packaged application.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of tests for `true`, `{}`, and object feature entries confirm those forms enable the named feature.
+- **SC-002**: A layered configuration test confirms a higher-priority `false` disables a feature enabled by lower-priority configuration while leaving unrelated features unchanged.
+- **SC-003**: A layered configuration test confirms a higher-priority `true` re-enables a feature disabled by a lower-priority source.
+- **SC-004**: A layered configuration test confirms a higher-priority object re-enables a disabled feature and binds the object's settings directly.
+- **SC-005**: A code-first default feature can be disabled by higher-priority deployment configuration in verified tests.
+- **SC-006**: 100% of invalid value tests for `null`, blank feature names, and unsupported scalar values fail before shell activation with actionable messages.
+- **SC-007**: Existing object-based feature option binding tests continue to pass without adding a `Settings` wrapper.
+- **SC-008**: Documentation and samples include at least one compact `true` example, one `false` disablement example, one object settings example, and one Docker-mounted override example.
+- **SC-009**: A layered configuration test confirms a higher-priority `true` declaration does not inherit lower-priority feature option values.
+- **SC-010**: Environment-style string values `"true"` and `"false"` are accepted case-insensitively, while values such as `"yes"` and `"0"` are rejected in verified tests.
+- **SC-011**: Unknown feature entries set to `false` do not prevent shell activation, while unknown feature entries set to `true` or object fail with actionable messages in verified tests.

--- a/specs/014-polymorphic-feature-config/tasks.md
+++ b/specs/014-polymorphic-feature-config/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: Polymorphic Feature Configuration
+
+**Input**: Design documents from `/specs/014-polymorphic-feature-config/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/feature-configuration.md, quickstart.md
+
+**Tests**: Test tasks are included because the feature specification defines measurable test outcomes for each value form, precedence rule, and invalid case.
+
+**Organization**: Tasks are grouped by user story so compact enablement, disablement, re-enablement, and direct settings compatibility can be implemented and validated as independent increments.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the working baseline and locate affected code paths.
+
+- [x] T001 Run baseline configuration tests with `dotnet test tests/CShells.Tests/ --filter "FullyQualifiedName~Configuration"` from repository root
+- [x] T002 [P] Review existing feature configuration behavior in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T003 [P] Review current shell merge behavior in `src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared declaration state and merge helpers required by all user stories.
+
+**CRITICAL**: No user story implementation should begin until this phase is complete.
+
+- [x] T004 Add explicit enablement state, reset semantics, and XML docs to `src/CShells/Configuration/FeatureEntry.cs`
+- [x] T005 Add explicit disabled feature tracking with XML docs to `src/CShells.Abstractions/ShellSettings.cs`
+- [x] T006 Implement reusable feature add/remove/reset helper methods in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T007 Update `src/CShells/Configuration/ShellBuilder.cs` to use the shared helper methods for deduplicated feature additions
+- [x] T008 Update `src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs` to compose settings through normalized feature declarations
+
+**Checkpoint**: Feature declarations can represent enabled and disabled intent before story-specific parsing and merge behavior is added.
+
+---
+
+## Phase 3: User Story 1 - Enable Features With Compact Values (Priority: P1) MVP
+
+**Goal**: Enable features with `true`, string `"true"`, `{}`, and object values while preserving direct feature settings.
+
+**Independent Test**: Load shell configuration with `true`, `"true"`, `{}`, and object feature entries and confirm all requested features are enabled with expected settings.
+
+### Tests for User Story 1
+
+- [x] T009 [P] [US1] Add JSON converter tests for `true`, string `"true"`, `{}`, and object feature entries in `tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs`
+- [x] T010 [P] [US1] Add configuration blueprint tests for compact `true` and string `"true"` feature entries in `tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs`
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Extend object-map parsing for boolean `true` and string `"true"` values in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T012 [US1] Extend object-map JSON deserialization and serialization for enabled declarations in `src/CShells/Configuration/FeatureEntryListJsonConverter.cs`
+- [x] T013 [US1] Preserve empty object and configured object feature behavior while using declaration state in `src/CShells/Configuration/FeatureEntryListJsonConverter.cs`
+- [x] T014 [US1] Update ShellConfig feature format documentation comments for compact values in `src/CShells/Configuration/ShellConfig.cs`
+- [x] T015 [US1] Run US1 focused tests with `dotnet test tests/CShells.Tests/ --filter "ShellConfigJsonConverterTests|ConfigurationShellBlueprintTests"` from repository root
+
+**Checkpoint**: User Story 1 works independently as the MVP: compact enablement is supported without changing feature settings paths.
+
+---
+
+## Phase 4: User Story 2 - Disable Default Features From Later Configuration (Priority: P2)
+
+**Goal**: Allow later configuration to disable features from lower-priority configuration or code-first defaults, including environment-style string `"false"` and unknown-feature no-op disablements.
+
+**Independent Test**: Load defaults plus higher-priority overrides that set features to `false` or `"false"` and confirm disabled features are absent from activation while unrelated features remain enabled.
+
+### Tests for User Story 2
+
+- [x] T016 [P] [US2] Add parser tests for native `false`, string `"false"`, unsupported scalars, and `null` in `tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs`
+- [x] T017 [P] [US2] Add blueprint tests for disabling configured features and preserving unrelated features in `tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs`
+- [x] T018 [P] [US2] Add code-first default disablement tests in `tests/CShells.Tests/Unit/ShellBuilderTests.cs`
+- [x] T019 [P] [US2] Add unknown disabled feature no-op and unknown positive feature failure tests in `tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs`
+
+### Implementation for User Story 2
+
+- [x] T020 [US2] Extend object-map parsing for boolean `false` and string `"false"` values in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T021 [US2] Reject `null`, unsupported scalar values, and array feature values with actionable path messages in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T022 [US2] Apply disabled feature declarations when `ShellBuilder.FromConfiguration(IConfigurationSection)` merges into existing settings in `src/CShells/Configuration/ShellBuilder.cs`
+- [x] T023 [US2] Apply disabled feature declarations when `ShellBuilder.FromConfiguration(ShellConfig)` merges into existing settings in `src/CShells/Configuration/ShellBuilder.cs`
+- [x] T024 [US2] Update code-first default merging to let shell-specific disabled declarations remove defaults in `src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs`
+- [x] T025 [US2] Validate unknown positive feature declarations while ignoring unknown disabled declarations before activation in `src/CShells/Lifecycle/ShellProviderBuilder.cs`
+- [x] T026 [US2] Run US2 focused tests with `dotnet test tests/CShells.Tests/ --filter "ShellBuilderTests|ConfigurationShellBlueprintTests|UnknownFeatureDependencyTests"` from repository root
+
+**Checkpoint**: User Stories 1 and 2 both work independently; deployment overrides can disable defaults.
+
+---
+
+## Phase 5: User Story 3 - Re-Enable Or Reconfigure Features From Later Configuration (Priority: P3)
+
+**Goal**: Allow later `true` or object declarations to re-enable disabled features, with `true` resetting inherited settings and object entries merging settings normally.
+
+**Independent Test**: Compose multiple configuration layers where earlier sources disable or configure a feature and later sources re-enable it with `true` or object values.
+
+### Tests for User Story 3
+
+- [x] T027 [P] [US3] Add layered configuration tests for `false` followed by `true` and `false` followed by object in `tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs`
+- [x] T028 [P] [US3] Add reset-to-default tests proving higher-priority `true` drops lower-priority option keys in `tests/CShells.Tests/Unit/ShellBuilderTests.cs`
+- [x] T029 [P] [US3] Add object merge precedence tests for feature settings in `tests/CShells.Tests/Unit/Configuration/ShellConfigurationTests.cs`
+
+### Implementation for User Story 3
+
+- [x] T030 [US3] Implement feature settings reset when a higher-priority enabled-with-defaults declaration is applied in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T031 [US3] Preserve normal object feature settings merging for higher-priority object declarations in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T032 [US3] Ensure shell-specific `true` re-enables code-first disabled state without inheriting default feature option keys in `src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs`
+- [x] T033 [US3] Run US3 focused tests with `dotnet test tests/CShells.Tests/ --filter "ConfigurationShellBlueprintTests|ShellBuilderTests|ShellConfigurationTests"` from repository root
+
+**Checkpoint**: Re-enable and reconfigure precedence works independently across layered configuration.
+
+---
+
+## Phase 6: User Story 4 - Keep Feature Settings Direct And Familiar (Priority: P4)
+
+**Goal**: Preserve direct feature option binding and ensure `Enabled` inside an object remains a feature setting, not control metadata.
+
+**Independent Test**: Load object-based feature settings, including an inner `Enabled` property, and confirm options bind from the same paths as before without a `Settings` wrapper.
+
+### Tests for User Story 4
+
+- [x] T034 [P] [US4] Add direct `Enabled` setting tests in `tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs`
+- [x] T035 [P] [US4] Add direct object binding regression tests in `tests/CShells.Tests/Unit/Features/FeatureConfigurationBinderTests.cs`
+- [x] T036 [P] [US4] Add sample configuration regression coverage for direct feature settings in `tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs`
+
+### Implementation for User Story 4
+
+- [x] T037 [US4] Ensure object-map child properties including `Enabled` are always treated as settings in `src/CShells/Configuration/ConfigurationHelper.cs`
+- [x] T038 [US4] Ensure JSON object-map child properties including `Enabled` are always treated as settings in `src/CShells/Configuration/FeatureEntryListJsonConverter.cs`
+- [x] T039 [US4] Remove or update stale `Settings` wrapper guidance from XML docs in `src/CShells/Configuration/FeatureEntryJsonConverter.cs`
+- [x] T040 [US4] Run US4 focused tests with `dotnet test tests/CShells.Tests/ --filter "FeatureEntryJsonConverterTests|FeatureConfigurationBinderTests|ShellConfigJsonConverterTests"` from repository root
+
+**Checkpoint**: Existing direct object feature settings remain familiar and backward-compatible.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, samples, cleanup, and full validation across all stories.
+
+- [x] T041 [P] Update Workbench sample feature syntax to include compact `true`, `false`, and object examples in `samples/CShells.Workbench/appsettings.json`
+- [x] T042 [P] Update public configuration documentation with polymorphic feature map examples in `README.md`
+- [x] T043 [P] Update feature configuration documentation with Docker and environment override examples in `docs/feature-configuration.md`
+- [x] T044 Remove obsolete array-first or `Settings` wrapper recommendations from `src/CShells/Configuration/ShellConfig.cs`
+- [x] T045 Run quickstart validation commands from `specs/014-polymorphic-feature-config/quickstart.md`
+- [x] T046 Run full test suite with `dotnet test CShells.sln` from repository root
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **US1 (Phase 3)**: Depends on Foundational and delivers the MVP compact enablement syntax.
+- **US2 (Phase 4)**: Depends on Foundational; can start after US1 if sharing parser edits, but remains independently testable.
+- **US3 (Phase 5)**: Depends on US2 because it builds on disable/re-enable precedence.
+- **US4 (Phase 6)**: Depends on Foundational; can run after US1 because it validates object settings semantics.
+- **Polish (Phase 7)**: Depends on all desired stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Foundational only.
+- **User Story 2 (P2)**: Foundational only, but should be integrated after US1 to reduce parser conflicts.
+- **User Story 3 (P3)**: Depends on US2 disablement semantics.
+- **User Story 4 (P4)**: Foundational plus object parsing from US1.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel during setup.
+- T009 and T010 can be written in parallel for US1.
+- T016, T017, T018, and T019 can be written in parallel for US2.
+- T027, T028, and T029 can be written in parallel for US3.
+- T034, T035, and T036 can be written in parallel for US4.
+- T041, T042, and T043 can be done in parallel during polish.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T009 Add JSON converter tests for true, string true, {}, and object feature entries in tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs"
+Task: "T010 Add configuration blueprint tests for compact true and string true feature entries in tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T016 Add parser tests for native false, string false, unsupported scalars, and null in tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs"
+Task: "T018 Add code-first default disablement tests in tests/CShells.Tests/Unit/ShellBuilderTests.cs"
+Task: "T019 Add unknown disabled feature no-op and unknown positive feature failure tests in tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T027 Add layered configuration tests for false followed by true and false followed by object in tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs"
+Task: "T029 Add object merge precedence tests for feature settings in tests/CShells.Tests/Unit/Configuration/ShellConfigurationTests.cs"
+```
+
+## Parallel Example: User Story 4
+
+```text
+Task: "T034 Add direct Enabled setting tests in tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs"
+Task: "T035 Add direct object binding regression tests in tests/CShells.Tests/Unit/Features/FeatureConfigurationBinderTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 for compact enablement with `true`, `"true"`, `{}`, and object values.
+3. Run T015 and validate direct feature option settings still work.
+
+### Incremental Delivery
+
+1. US1: Compact enablement syntax.
+2. US2: Disablement across layered configuration and code-first defaults.
+3. US3: Re-enable and reset semantics.
+4. US4: Direct settings compatibility and documentation polish.
+
+### Validation Gates
+
+- After each user story, run that story's focused test command.
+- Before implementation is considered complete, run T045 and T046.
+
+## Notes
+
+- `[P]` tasks touch different files or are test-writing tasks that can be worked independently.
+- Story labels map to the four user stories in `spec.md`.
+- Tests should be written first and observed failing before implementation when practical.
+- Keep public configuration syntax as `Features` map values; do not add public `EnabledFeatures`, `DisabledFeatures`, `Enabled`, or `Settings` configuration sections.

--- a/src/CShells.Abstractions/Features/ISharedAssemblySelector.cs
+++ b/src/CShells.Abstractions/Features/ISharedAssemblySelector.cs
@@ -1,0 +1,24 @@
+namespace CShells.Features;
+
+/// <summary>
+/// Selects host assemblies that should be shared for shell feature discovery.
+/// </summary>
+/// <remarks>
+/// Implementations are evaluated against assembly simple names only. They must not inspect
+/// assembly full names, versions, cultures, public key tokens, file paths, or directory paths.
+/// </remarks>
+public interface ISharedAssemblySelector
+{
+    /// <summary>
+    /// Gets a human-readable source that can be shown in diagnostics.
+    /// </summary>
+    string Source { get; }
+
+    /// <summary>
+    /// Attempts to match an assembly simple name.
+    /// </summary>
+    /// <param name="assemblyName">The assembly simple name to evaluate.</param>
+    /// <param name="match">The match diagnostic when the selector matches.</param>
+    /// <returns><see langword="true"/> when the assembly simple name is selected.</returns>
+    bool TryMatch(string assemblyName, out SharedAssemblyMatch? match);
+}

--- a/src/CShells.Abstractions/Features/SharedAssemblyMatch.cs
+++ b/src/CShells.Abstractions/Features/SharedAssemblyMatch.cs
@@ -1,0 +1,14 @@
+namespace CShells.Features;
+
+/// <summary>
+/// Describes why an assembly simple name was selected as shared.
+/// </summary>
+/// <param name="AssemblyName">The assembly simple name that matched.</param>
+/// <param name="SelectorKind">The kind of selector responsible for the match.</param>
+/// <param name="SelectorPattern">The configured exact name or prefix pattern, when applicable.</param>
+/// <param name="SelectorSource">The configuration path or code-first API source that contributed the selector.</param>
+public sealed record SharedAssemblyMatch(
+    string AssemblyName,
+    SharedAssemblySelectorKind SelectorKind,
+    string? SelectorPattern,
+    string SelectorSource);

--- a/src/CShells.Abstractions/Features/SharedAssemblySelectorKind.cs
+++ b/src/CShells.Abstractions/Features/SharedAssemblySelectorKind.cs
@@ -1,0 +1,22 @@
+namespace CShells.Features;
+
+/// <summary>
+/// Identifies the kind of selector that chose a shared assembly.
+/// </summary>
+public enum SharedAssemblySelectorKind
+{
+    /// <summary>
+    /// The selector matched one assembly simple name exactly.
+    /// </summary>
+    Exact,
+
+    /// <summary>
+    /// The selector matched assembly simple names by prefix.
+    /// </summary>
+    PrefixPattern,
+
+    /// <summary>
+    /// The selector used code-first predicate logic.
+    /// </summary>
+    Predicate
+}

--- a/src/CShells.Abstractions/ShellSettings.cs
+++ b/src/CShells.Abstractions/ShellSettings.cs
@@ -33,6 +33,24 @@ public class ShellSettings
     } = [];
 
     /// <summary>
+    /// Gets or sets feature names that were explicitly disabled by shell configuration.
+    /// </summary>
+    public IReadOnlyList<string> DisabledFeatures
+    {
+        get;
+        set => field = [..value];
+    } = [];
+
+    /// <summary>
+    /// Gets or sets enabled feature names whose lower-priority settings should be reset to feature defaults.
+    /// </summary>
+    public IReadOnlyList<string> FeatureSettingResets
+    {
+        get;
+        set => field = [..value];
+    } = [];
+
+    /// <summary>
     /// Gets or sets shell-specific configuration data as a dictionary.
     /// Keys use colon-separated format for hierarchical data (e.g., "WebRouting:Path").
     /// </summary>
@@ -43,7 +61,7 @@ public class ShellSettings
     /// <c>WithFeature&lt;TFeature&gt;(Action&lt;TFeature&gt;)</c>.
     /// Each entry is keyed by feature name and holds a delegate that is applied to the
     /// live feature instance <em>after</em> configuration binding and <em>before</em>
-    /// <c>ConfigureServices</c> is called, so code always wins over appsettings.
+    /// <c>ConfigureServices</c> is called.
     /// </summary>
     /// <remarks>
     /// This collection is intentionally not serialized / persisted; it only exists in

--- a/src/CShells/Configuration/CShellsOptions.cs
+++ b/src/CShells/Configuration/CShellsOptions.cs
@@ -14,4 +14,9 @@ public class CShellsOptions
     /// Gets or sets shell configurations keyed by shell name.
     /// </summary>
     public Dictionary<string, ShellConfig> Shells { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets host-wide shared assembly simple-name selectors.
+    /// </summary>
+    public List<string> SharedAssemblies { get; set; } = [];
 }

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -8,7 +8,7 @@ namespace CShells.Configuration;
 /// </summary>
 internal static class ConfigurationHelper
 {
-    private const string SupportedFeatureValueForms = "true, false, or an object";
+    private const string SupportedFeatureValueForms = "true, false, string 'true'/'false', or an object";
 
     /// <summary>
     /// Converts a value to JsonElement for consistent serialization.

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -8,6 +8,8 @@ namespace CShells.Configuration;
 /// </summary>
 internal static class ConfigurationHelper
 {
+    private const string SupportedFeatureValueForms = "true, false, or an object";
+
     /// <summary>
     /// Converts a value to JsonElement for consistent serialization.
     /// </summary>
@@ -194,17 +196,93 @@ internal static class ConfigurationHelper
     public static string[] ExtractFeatureNames(IEnumerable<FeatureEntry> features)
     {
         return features
+            .Where(feature => feature.IsEnabled)
             .Select((feature, index) =>
             {
-                if (string.IsNullOrWhiteSpace(feature.Name))
-                {
-                    throw new InvalidOperationException(
-                        $"Configured feature entry at index {index} must define a non-empty feature name.");
-                }
-
+                EnsureFeatureName(feature.Name, $"Configured feature entry at index {index}");
                 return feature.Name.Trim();
             })
             .ToArray();
+    }
+
+    /// <summary>
+    /// Applies normalized feature entries to shell settings.
+    /// </summary>
+    public static void ApplyFeatureEntries(IEnumerable<FeatureEntry> features, ShellSettings settings)
+    {
+        foreach (var feature in features)
+        {
+            EnsureFeatureName(feature.Name, "Configured feature entry");
+
+            if (!feature.IsEnabled)
+            {
+                DisableFeature(settings, feature.Name);
+                continue;
+            }
+
+            AddEnabledFeature(settings, feature.Name, feature.ResetsSettings);
+            PopulateFeatureSettings([feature], settings.ConfigurationData);
+        }
+    }
+
+    /// <summary>
+    /// Adds an enabled feature declaration to shell settings.
+    /// </summary>
+    public static void AddEnabledFeature(ShellSettings settings, string featureName, bool resetSettings = false)
+    {
+        Guard.Against.Null(settings);
+        EnsureFeatureName(featureName, "Configured feature entry");
+
+        var normalizedName = featureName.Trim();
+        var features = settings.EnabledFeatures.ToList();
+        if (!features.Contains(normalizedName, StringComparer.OrdinalIgnoreCase))
+            features.Add(normalizedName);
+        settings.EnabledFeatures = [..features];
+
+        settings.DisabledFeatures = RemoveName(settings.DisabledFeatures, normalizedName);
+
+        if (resetSettings)
+        {
+            RemoveFeatureSettings(settings.ConfigurationData, normalizedName);
+            settings.FeatureSettingResets = AddName(settings.FeatureSettingResets, normalizedName);
+        }
+        else
+        {
+            settings.FeatureSettingResets = RemoveName(settings.FeatureSettingResets, normalizedName);
+        }
+    }
+
+    /// <summary>
+    /// Adds an explicit disabled feature declaration to shell settings.
+    /// </summary>
+    public static void DisableFeature(ShellSettings settings, string featureName)
+    {
+        Guard.Against.Null(settings);
+        EnsureFeatureName(featureName, "Configured feature entry");
+
+        var normalizedName = featureName.Trim();
+        settings.EnabledFeatures = RemoveName(settings.EnabledFeatures, normalizedName);
+        settings.DisabledFeatures = AddName(settings.DisabledFeatures, normalizedName);
+        settings.FeatureSettingResets = RemoveName(settings.FeatureSettingResets, normalizedName);
+        RemoveFeatureSettings(settings.ConfigurationData, normalizedName);
+    }
+
+    /// <summary>
+    /// Removes feature-prefixed configuration keys from a shell configuration dictionary.
+    /// </summary>
+    public static void RemoveFeatureSettings(IDictionary<string, object> configurationData, string featureName)
+    {
+        Guard.Against.Null(configurationData);
+        EnsureFeatureName(featureName, "Configured feature entry");
+
+        var prefix = $"{featureName.Trim()}:";
+        var keys = configurationData.Keys
+            .Where(key => key.Equals(featureName, StringComparison.OrdinalIgnoreCase) ||
+                          key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        foreach (var key in keys)
+            configurationData.Remove(key);
     }
 
     /// <summary>
@@ -267,6 +345,9 @@ internal static class ConfigurationHelper
     {
         foreach (var feature in features)
         {
+            if (!feature.IsEnabled)
+                continue;
+
             if (feature.Settings.Count == 0)
                 continue;
 
@@ -401,24 +482,35 @@ internal static class ConfigurationHelper
             var featureName = featureSection.Key;
 
             if (string.IsNullOrWhiteSpace(featureName))
-                continue;
-
-            // Reject scalar values (e.g., "Posts": "invalid")
-            if (featureSection.Value is not null && !featureSection.GetChildren().Any())
             {
                 throw new InvalidOperationException(
-                    $"Feature '{featureName}'{shellContext} in object-map syntax must have an object value, but found a scalar value '{featureSection.Value}'.");
+                    $"Feature name{shellContext} in object-map syntax must not be empty or whitespace.");
+            }
+
+            var children = featureSection.GetChildren().ToList();
+
+            if (featureSection.Value is not null)
+            {
+                if (TryParseFeatureBoolean(featureSection.Value, out var enabled))
+                {
+                    entries.Add(enabled
+                        ? FeatureEntry.EnableDefaults(featureName.Trim())
+                        : FeatureEntry.Disabled(featureName.Trim()));
+                    continue;
+                }
+
+                throw new InvalidOperationException(
+                    $"Feature '{featureName}'{shellContext} in object-map syntax must be {SupportedFeatureValueForms}, but found scalar value '{featureSection.Value}'.");
             }
 
             // Reject array-like children (e.g., "Posts": [1, 2])
-            var children = featureSection.GetChildren().ToList();
             if (children.Count > 0 && children.All(c => int.TryParse(c.Key, out _)))
             {
                 throw new InvalidOperationException(
-                    $"Feature '{featureName}'{shellContext} in object-map syntax must have an object value, but found an array.");
+                    $"Feature '{featureName}'{shellContext} in object-map syntax must be {SupportedFeatureValueForms}, but found an array.");
             }
 
-            var entry = new FeatureEntry { Name = featureName };
+            var entry = new FeatureEntry { Name = featureName.Trim() };
 
             // In object-map form, all children (including "Name") are settings
             foreach (var settingSection in children)
@@ -439,6 +531,44 @@ internal static class ConfigurationHelper
 
         return entries;
     }
+
+    private static bool TryParseFeatureBoolean(string value, out bool enabled)
+    {
+        if (value.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        {
+            enabled = true;
+            return true;
+        }
+
+        if (value.Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase))
+        {
+            enabled = false;
+            return true;
+        }
+
+        enabled = false;
+        return false;
+    }
+
+    private static void EnsureFeatureName(string name, string context)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidOperationException(
+                $"{context} must define a non-empty feature name.");
+        }
+    }
+
+    private static IReadOnlyList<string> AddName(IReadOnlyList<string> source, string name)
+    {
+        var names = source.ToList();
+        if (!names.Contains(name, StringComparer.OrdinalIgnoreCase))
+            names.Add(name);
+        return [..names];
+    }
+
+    private static IReadOnlyList<string> RemoveName(IReadOnlyList<string> source, string name) =>
+        [..source.Where(candidate => !candidate.Equals(name, StringComparison.OrdinalIgnoreCase))];
 
     private static void PopulateEntrySettings(FeatureEntry entry, IEnumerable<IConfigurationSection> settingSections)
     {

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -220,6 +220,12 @@ internal static class ConfigurationHelper
                 continue;
             }
 
+            if (feature.ResetsSettings && feature.Settings.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Feature '{feature.Name}' cannot combine reset semantics with explicit settings.");
+            }
+
             AddEnabledFeature(settings, feature.Name, feature.ResetsSettings);
             PopulateFeatureSettings([feature], settings.ConfigurationData);
         }
@@ -501,6 +507,12 @@ internal static class ConfigurationHelper
 
                 throw new InvalidOperationException(
                     $"Feature '{featureName}'{shellContext} in object-map syntax must be {SupportedFeatureValueForms}, but found scalar value '{featureSection.Value}'.");
+            }
+
+            if (children.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Feature '{featureName}'{shellContext} in object-map syntax must be {SupportedFeatureValueForms}, but found a null or empty value.");
             }
 
             // Reject array-like children (e.g., "Posts": [1, 2])

--- a/src/CShells/Configuration/FeatureEntry.cs
+++ b/src/CShells/Configuration/FeatureEntry.cs
@@ -1,9 +1,24 @@
 namespace CShells.Configuration;
 
 /// <summary>
+/// Describes whether a configured feature entry enables or disables a feature.
+/// </summary>
+public enum FeatureEntryState
+{
+    /// <summary>
+    /// The feature is enabled for the shell.
+    /// </summary>
+    Enabled,
+
+    /// <summary>
+    /// The feature is explicitly disabled for the shell.
+    /// </summary>
+    Disabled
+}
+
+/// <summary>
 /// Represents a feature entry in shell configuration.
-/// Can be created from either a simple string (feature name only) or 
-/// an object with feature name and settings.
+/// A feature entry can enable a feature, disable a feature, or enable a feature with direct settings.
 /// </summary>
 public class FeatureEntry
 {
@@ -13,10 +28,25 @@ public class FeatureEntry
     public string Name { get; set; } = "";
 
     /// <summary>
+    /// Gets or sets whether this entry enables or disables the feature.
+    /// </summary>
+    public FeatureEntryState State { get; set; } = FeatureEntryState.Enabled;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether enabling this feature should reset lower-priority feature settings.
+    /// </summary>
+    public bool ResetsSettings { get; set; }
+
+    /// <summary>
     /// Gets or sets the feature-specific settings.
-    /// All properties other than 'Name' are treated as settings.
+    /// In object-map configuration, all child properties are treated as settings.
     /// </summary>
     public Dictionary<string, object?> Settings { get; set; } = new();
+
+    /// <summary>
+    /// Gets a value indicating whether this entry enables the feature.
+    /// </summary>
+    public bool IsEnabled => State == FeatureEntryState.Enabled;
 
     /// <summary>
     /// Creates a feature entry from just a feature name (no settings).
@@ -26,8 +56,21 @@ public class FeatureEntry
     public static FeatureEntry FromName(string name) => new() { Name = name };
 
     /// <summary>
+    /// Creates an enabled feature entry that resets inherited feature settings.
+    /// </summary>
+    /// <param name="name">The feature name.</param>
+    /// <returns>A new enabled <see cref="FeatureEntry"/> with reset semantics.</returns>
+    public static FeatureEntry EnableDefaults(string name) => new() { Name = name, ResetsSettings = true };
+
+    /// <summary>
+    /// Creates a disabled feature entry.
+    /// </summary>
+    /// <param name="name">The feature name.</param>
+    /// <returns>A new disabled <see cref="FeatureEntry"/>.</returns>
+    public static FeatureEntry Disabled(string name) => new() { Name = name, State = FeatureEntryState.Disabled };
+
+    /// <summary>
     /// Returns the feature name.
     /// </summary>
     public override string ToString() => Name;
 }
-

--- a/src/CShells/Configuration/FeatureEntryJsonConverter.cs
+++ b/src/CShells/Configuration/FeatureEntryJsonConverter.cs
@@ -4,19 +4,18 @@ using System.Text.Json.Serialization;
 namespace CShells.Configuration;
 
 /// <summary>
-/// JSON converter for <see cref="FeatureEntry"/> that supports both string and object formats.
+/// JSON converter for <see cref="FeatureEntry"/> that supports legacy array item formats.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This converter enables a polymorphic Features array in configuration where each element
-/// can be either:
+/// This converter supports legacy feature arrays where each element can be either:
 /// </para>
 /// <list type="bullet">
 ///   <item><description>A simple string: <c>"FeatureName"</c></description></item>
-///   <item><description>An object with Name and settings: <c>{ "Name": "FeatureName", "Setting1": "Value1" }</c></description></item>
+///   <item><description>An object with <c>Name</c> and direct settings: <c>{ "Name": "FeatureName", "Setting1": "Value1" }</c></description></item>
 /// </list>
 /// <para>
-/// In the object format, all properties except "Name" are treated as feature settings.
+/// In the object format, all properties except <c>Name</c> are treated as feature settings.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/CShells/Configuration/FeatureEntryListJsonConverter.cs
+++ b/src/CShells/Configuration/FeatureEntryListJsonConverter.cs
@@ -40,15 +40,27 @@ public class FeatureEntryListJsonConverter : JsonConverter<List<FeatureEntry>>
         foreach (var entry in value)
         {
             writer.WritePropertyName(entry.Name);
-            writer.WriteStartObject();
 
-            foreach (var (key, settingValue) in entry.Settings)
+            if (!entry.IsEnabled)
             {
-                writer.WritePropertyName(key);
-                JsonSerializer.Serialize(writer, settingValue, options);
+                writer.WriteBooleanValue(false);
             }
+            else if (entry.ResetsSettings && entry.Settings.Count == 0)
+            {
+                writer.WriteBooleanValue(true);
+            }
+            else
+            {
+                writer.WriteStartObject();
 
-            writer.WriteEndObject();
+                foreach (var (key, settingValue) in entry.Settings)
+                {
+                    writer.WritePropertyName(key);
+                    JsonSerializer.Serialize(writer, settingValue, options);
+                }
+
+                writer.WriteEndObject();
+            }
         }
 
         writer.WriteEndObject();
@@ -86,10 +98,30 @@ public class FeatureEntryListJsonConverter : JsonConverter<List<FeatureEntry>>
                     "Feature name in object-map syntax must not be empty or whitespace.");
             }
 
+            if (property.Value.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                entries.Add(property.Value.GetBoolean()
+                    ? FeatureEntry.EnableDefaults(featureName)
+                    : FeatureEntry.Disabled(featureName));
+                continue;
+            }
+
+            if (property.Value.ValueKind == JsonValueKind.String)
+            {
+                var value = property.Value.GetString();
+                if (bool.TryParse(value, out var enabled))
+                {
+                    entries.Add(enabled
+                        ? FeatureEntry.EnableDefaults(featureName)
+                        : FeatureEntry.Disabled(featureName));
+                    continue;
+                }
+            }
+
             if (property.Value.ValueKind != JsonValueKind.Object)
             {
                 throw new JsonException(
-                    $"Feature '{featureName}' in object-map syntax must have an object value, but found {property.Value.ValueKind}.");
+                    $"Feature '{featureName}' in object-map syntax must be true, false, or an object, but found {property.Value.ValueKind}.");
             }
 
             var entry = new FeatureEntry { Name = featureName };
@@ -118,4 +150,3 @@ public class FeatureEntryListJsonConverter : JsonConverter<List<FeatureEntry>>
             _ => JsonSerializer.Deserialize<JsonElement>(element.GetRawText())
         };
 }
-

--- a/src/CShells/Configuration/FeatureEntryListJsonConverter.cs
+++ b/src/CShells/Configuration/FeatureEntryListJsonConverter.cs
@@ -45,6 +45,11 @@ public class FeatureEntryListJsonConverter : JsonConverter<List<FeatureEntry>>
             {
                 writer.WriteBooleanValue(false);
             }
+            else if (entry.ResetsSettings && entry.Settings.Count > 0)
+            {
+                throw new JsonException(
+                    $"Cannot serialize feature '{entry.Name}' with both reset semantics and explicit settings.");
+            }
             else if (entry.ResetsSettings && entry.Settings.Count == 0)
             {
                 writer.WriteBooleanValue(true);
@@ -121,7 +126,7 @@ public class FeatureEntryListJsonConverter : JsonConverter<List<FeatureEntry>>
             if (property.Value.ValueKind != JsonValueKind.Object)
             {
                 throw new JsonException(
-                    $"Feature '{featureName}' in object-map syntax must be true, false, or an object, but found {property.Value.ValueKind}.");
+                    $"Feature '{featureName}' in object-map syntax must be true, false, string 'true'/'false', or an object, but found {property.Value.ValueKind}.");
             }
 
             var entry = new FeatureEntry { Name = featureName };

--- a/src/CShells/Configuration/ShellBuilder.cs
+++ b/src/CShells/Configuration/ShellBuilder.cs
@@ -43,11 +43,8 @@ public class ShellBuilder
     public ShellBuilder WithFeatures(params string[] featureIds)
     {
         Guard.Against.Null(featureIds);
-        var current = _settings.EnabledFeatures.ToList();
         foreach (var id in featureIds)
-            if (!current.Contains(id, StringComparer.OrdinalIgnoreCase))
-                current.Add(id);
-        _settings.EnabledFeatures = [..current];
+            ConfigurationHelper.AddEnabledFeature(_settings, id);
         return this;
     }
 
@@ -102,10 +99,7 @@ public class ShellBuilder
     public ShellBuilder WithFeature(string featureId)
     {
         Guard.Against.Null(featureId);
-        var current = _settings.EnabledFeatures.ToList();
-        if (!current.Contains(featureId, StringComparer.OrdinalIgnoreCase))
-            current.Add(featureId);
-        _settings.EnabledFeatures = [..current];
+        ConfigurationHelper.AddEnabledFeature(_settings, featureId);
         return this;
     }
 
@@ -189,10 +183,7 @@ public class ShellBuilder
         Guard.Against.Null(featureId);
         Guard.Against.Null(configure);
 
-        var current = _settings.EnabledFeatures.ToList();
-        if (!current.Contains(featureId, StringComparer.OrdinalIgnoreCase))
-            current.Add(featureId);
-        _settings.EnabledFeatures = [..current];
+        ConfigurationHelper.AddEnabledFeature(_settings, featureId);
 
         var settingsBuilder = new FeatureSettingsBuilder(featureId);
         configure(settingsBuilder);
@@ -208,12 +199,7 @@ public class ShellBuilder
     {
         Guard.Against.Null(feature);
 
-        var current = _settings.EnabledFeatures.ToList();
-        if (!current.Contains(feature.Name, StringComparer.OrdinalIgnoreCase))
-            current.Add(feature.Name);
-        _settings.EnabledFeatures = [..current];
-
-        ConfigurationHelper.PopulateFeatureSettings([feature], _settings.ConfigurationData);
+        ConfigurationHelper.ApplyFeatureEntries([feature], _settings);
 
         return this;
     }
@@ -282,16 +268,7 @@ public class ShellBuilder
         var featuresSection = section.GetSection("Features");
         var features = ConfigurationHelper.ParseFeaturesFromConfiguration(featuresSection, _settings.Id.Name);
 
-        if (features.Count > 0)
-        {
-            var existingFeatures = _settings.EnabledFeatures.ToList();
-            var newFeatureNames = ConfigurationHelper.ExtractFeatureNames(features);
-            existingFeatures.AddRange(newFeatureNames);
-            _settings.EnabledFeatures = existingFeatures.Distinct().ToArray();
-
-            // Apply feature settings
-            ConfigurationHelper.PopulateFeatureSettings(features, _settings.ConfigurationData);
-        }
+        ConfigurationHelper.ApplyFeatureEntries(features, _settings);
 
         // Load shell-level configuration
         var configurationSection = section.GetSection("Configuration");
@@ -310,18 +287,7 @@ public class ShellBuilder
     {
         Guard.Against.Null(config);
 
-        // Merge features
-        var featureNames = ConfigurationHelper.ExtractFeatureNames(config.Features);
-
-        if (featureNames.Length > 0)
-        {
-            var existingFeatures = _settings.EnabledFeatures.ToList();
-            existingFeatures.AddRange(featureNames);
-            _settings.EnabledFeatures = existingFeatures.Distinct().ToArray();
-        }
-
-        // Apply feature settings
-        ConfigurationHelper.PopulateFeatureSettings(config.Features, _settings.ConfigurationData);
+        ConfigurationHelper.ApplyFeatureEntries(config.Features, _settings);
 
         // Apply shell-level configuration
         ConfigurationHelper.PopulateShellConfiguration(config.Configuration, _settings.ConfigurationData);
@@ -383,4 +349,3 @@ public class FeatureSettingsBuilder
         }
     }
 }
-

--- a/src/CShells/Configuration/ShellBuilder.cs
+++ b/src/CShells/Configuration/ShellBuilder.cs
@@ -256,7 +256,7 @@ public class ShellBuilder
 
     /// <summary>
     /// Loads configuration from an <see cref="IConfigurationSection"/> and merges it with existing settings.
-    /// Features are merged (combined), while Configuration from the section takes precedence.
+    /// Configuration is loaded first, then feature declarations are applied so disable/reset declarations win.
     /// </summary>
     /// <param name="section">The configuration section representing a shell.</param>
     /// <returns>The builder for method chaining.</returns>
@@ -264,22 +264,22 @@ public class ShellBuilder
     {
         Guard.Against.Null(section);
 
+        // Load shell-level configuration first so disable/reset feature declarations can remove feature-scoped keys.
+        var configurationSection = section.GetSection("Configuration");
+        ConfigurationHelper.LoadConfigurationFromSection(configurationSection, _settings.ConfigurationData);
+
         // Parse features from configuration (handles array and object-map forms)
         var featuresSection = section.GetSection("Features");
         var features = ConfigurationHelper.ParseFeaturesFromConfiguration(featuresSection, _settings.Id.Name);
 
         ConfigurationHelper.ApplyFeatureEntries(features, _settings);
 
-        // Load shell-level configuration
-        var configurationSection = section.GetSection("Configuration");
-        ConfigurationHelper.LoadConfigurationFromSection(configurationSection, _settings.ConfigurationData);
-
         return this;
     }
 
     /// <summary>
     /// Loads configuration from a <see cref="ShellConfig"/> and merges it with existing settings.
-    /// Features are merged (combined), while Configuration takes precedence.
+    /// Configuration is loaded first, then feature declarations are applied so disable/reset declarations win.
     /// </summary>
     /// <param name="config">The shell configuration.</param>
     /// <returns>The builder for method chaining.</returns>
@@ -287,10 +287,10 @@ public class ShellBuilder
     {
         Guard.Against.Null(config);
 
-        ConfigurationHelper.ApplyFeatureEntries(config.Features, _settings);
-
-        // Apply shell-level configuration
+        // Apply shell-level configuration first so disable/reset feature declarations can remove feature-scoped keys.
         ConfigurationHelper.PopulateShellConfiguration(config.Configuration, _settings.ConfigurationData);
+
+        ConfigurationHelper.ApplyFeatureEntries(config.Features, _settings);
 
         return this;
     }

--- a/src/CShells/Configuration/ShellConfig.cs
+++ b/src/CShells/Configuration/ShellConfig.cs
@@ -14,15 +14,18 @@ public class ShellConfig
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the list of enabled features for this shell.
-    /// Accepts two JSON shapes:
+    /// Gets or sets the configured features for this shell.
+    /// The preferred JSON shape is an object map whose property keys are feature names and whose values
+    /// are <c>true</c>, <c>false</c>, or direct feature settings objects.
+    /// Legacy array entries are still normalized to the same runtime model.
+    /// Accepted JSON shapes:
     /// <list type="bullet">
     ///   <item><description>
     ///     <b>Array form</b> — each entry is a string or <c>{ "Name": "…", … }</c> object.
     ///   </description></item>
     ///   <item><description>
-    ///     <b>Object-map form</b> — each property key is the feature name and its value is a settings object
-    ///     (use <c>{}</c> for features with no settings).
+    ///     <b>Object-map form</b> — each property key is the feature name and its value is <c>true</c> to
+    ///     enable with defaults, <c>false</c> to disable, or an object for direct feature settings.
     ///   </description></item>
     /// </list>
     /// Both forms normalize to the same runtime <see cref="FeatureEntry"/> list.
@@ -38,7 +41,8 @@ public class ShellConfig
     /// Object-map form:
     /// <code>
     /// "Features": {
-    ///   "Core": {},
+    ///   "Core": true,
+    ///   "LegacyAuth": false,
     ///   "Analytics": { "TopPostsCount": 10 }
     /// }
     /// </code>

--- a/src/CShells/DependencyInjection/CShellsBuilder.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilder.cs
@@ -15,6 +15,7 @@ namespace CShells.DependencyInjection;
 public class CShellsBuilder
 {
     private readonly List<Func<IServiceProvider, IFeatureAssemblyProvider>> _featureAssemblyProviderRegistrations = [];
+    private readonly List<ISharedAssemblySelector> sharedAssemblySelectors = [];
     private readonly List<Action<ShellBuilder>> _shellConfigurators = new();
     private readonly List<IShellBlueprint> _inlineBlueprints = [];
     private readonly List<Func<IServiceProvider, IShellBlueprintProvider>> _providerFactories = [];
@@ -49,12 +50,21 @@ public class CShellsBuilder
     /// </summary>
     internal bool UsesExplicitFeatureAssemblyProviders => _featureAssemblyProviderRegistrations.Count > 0;
 
+    internal IReadOnlyList<ISharedAssemblySelector> SharedAssemblySelectors => sharedAssemblySelectors.AsReadOnly();
+
+    internal IReadOnlyList<SharedAssemblyMatch> SharedAssemblyMatches { get; private set; } = [];
+
     /// <summary>
     /// Registers a feature assembly provider factory.
     /// </summary>
     internal void RegisterFeatureAssemblyProvider(Func<IServiceProvider, IFeatureAssemblyProvider> registration)
     {
         _featureAssemblyProviderRegistrations.Add(Guard.Against.Null(registration));
+    }
+
+    internal void AddSharedAssemblySelector(ISharedAssemblySelector selector)
+    {
+        sharedAssemblySelectors.Add(Guard.Against.Null(selector));
     }
 
     /// <summary>
@@ -86,9 +96,19 @@ public class CShellsBuilder
     {
         Guard.Against.Null(serviceProvider);
 
-        return UsesExplicitFeatureAssemblyProviders
-            ? await CShells.Features.FeatureAssemblyResolver.ResolveAssembliesAsync(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider, cancellationToken)
-            : CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies();
+        var selectorProvider = new SharedAssemblySelectorProvider(sharedAssemblySelectors);
+        var resolvedAssemblies = UsesExplicitFeatureAssemblyProviders
+            ? [.. await CShells.Features.FeatureAssemblyResolver.ResolveAssembliesAsync(BuildFeatureAssemblyProviders(serviceProvider), serviceProvider, cancellationToken)]
+            : new List<Assembly>();
+
+        if (selectorProvider.HasSelectors)
+            resolvedAssemblies.AddRange(CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies(selectorProvider.IsMatch));
+        else if (!UsesExplicitFeatureAssemblyProviders)
+            resolvedAssemblies.AddRange(CShells.Features.FeatureAssemblyResolver.ResolveHostAssemblies());
+
+        SharedAssemblyMatches = selectorProvider.Matches;
+
+        return CShells.Features.FeatureAssemblyResolver.DeduplicateAssemblies(resolvedAssemblies);
     }
 
     /// <summary>

--- a/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
+++ b/src/CShells/DependencyInjection/CShellsBuilderExtensions.cs
@@ -36,9 +36,47 @@ public static class CShellsBuilderExtensions
         Guard.Against.Null(builder);
         Guard.Against.Null(configuration);
 
-        var shellsSection = configuration.GetSection(sectionName).GetSection("Shells");
+        var rootSection = configuration.GetSection(sectionName);
+        var sharedAssembliesSection = rootSection.GetSection("SharedAssemblies");
+        foreach (var child in sharedAssembliesSection.GetChildren())
+            builder.AddSharedAssemblySelector(SharedAssemblySelector.FromPattern(child.Value!, child.Path));
+
+        var shellsSection = rootSection.GetSection("Shells");
         var provider = new ConfigurationShellBlueprintProvider(shellsSection);
         builder.AddBlueprintProvider(_ => provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds host-wide shared assembly simple-name selectors for feature discovery.
+    /// </summary>
+    /// <remarks>
+    /// Entries without <c>*</c> match exact assembly simple names. Entries ending in <c>*</c>
+    /// match assembly simple-name prefixes. The wildcard is valid only as the final character.
+    /// </remarks>
+    public static CShellsBuilder WithSharedAssemblies(this CShellsBuilder builder, params string[] patterns)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(patterns);
+
+        foreach (var (pattern, index) in patterns.Select((pattern, index) => (pattern, index)))
+            builder.AddSharedAssemblySelector(SharedAssemblySelector.FromPattern(pattern, $"{nameof(WithSharedAssemblies)}[{index}]"));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a host-wide predicate selector for shared assembly feature discovery.
+    /// </summary>
+    /// <param name="builder">The CShells builder.</param>
+    /// <param name="predicate">A predicate evaluated against assembly simple names only.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static CShellsBuilder WithSharedAssembliesWhere(this CShellsBuilder builder, Func<string, bool> predicate)
+    {
+        Guard.Against.Null(builder);
+        Guard.Against.Null(predicate);
+
+        builder.AddSharedAssemblySelector(SharedAssemblySelector.FromPredicate(predicate, nameof(WithSharedAssembliesWhere)));
         return builder;
     }
 

--- a/src/CShells/Features/FeatureAssemblyResolver.cs
+++ b/src/CShells/Features/FeatureAssemblyResolver.cs
@@ -36,6 +36,23 @@ internal static class FeatureAssemblyResolver
         return resolvedAssemblies.AsReadOnly();
     }
 
+    public static IReadOnlyCollection<Assembly> DeduplicateAssemblies(IEnumerable<Assembly> assemblies)
+    {
+        var resolvedAssemblies = new List<Assembly>();
+        var seenAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var assembly in Guard.Against.Null(assemblies))
+        {
+            if (assembly is null)
+                throw new InvalidOperationException("Assembly sequences must not contain null assembly entries.");
+
+            if (seenAssemblies.Add(GetAssemblyIdentity(assembly)))
+                resolvedAssemblies.Add(assembly);
+        }
+
+        return resolvedAssemblies.AsReadOnly();
+    }
+
     public static IReadOnlyCollection<Assembly> ResolveHostAssemblies(Func<AssemblyName, bool>? filter = null)
     {
         var entry = Assembly.GetEntryAssembly();

--- a/src/CShells/Features/SharedAssemblyPattern.cs
+++ b/src/CShells/Features/SharedAssemblyPattern.cs
@@ -1,0 +1,54 @@
+namespace CShells.Features;
+
+internal sealed class SharedAssemblyPattern
+{
+    private readonly string value;
+    private readonly StringComparison comparison;
+
+    private SharedAssemblyPattern(string value, SharedAssemblySelectorKind kind)
+    {
+        this.value = value;
+        Kind = kind;
+        comparison = StringComparison.OrdinalIgnoreCase;
+    }
+
+    public SharedAssemblySelectorKind Kind { get; }
+
+    public string Pattern => Kind is SharedAssemblySelectorKind.PrefixPattern
+        ? $"{value}*"
+        : value;
+
+    public static SharedAssemblyPattern Parse(string? pattern, string source)
+    {
+        Guard.Against.NullOrWhiteSpace(source);
+
+        if (pattern is null)
+            throw new ArgumentNullException(nameof(pattern), $"Shared assembly selector from '{source}' cannot be null.");
+
+        if (string.IsNullOrWhiteSpace(pattern))
+            throw new ArgumentException($"Shared assembly selector from '{source}' cannot be blank or whitespace-only.", nameof(pattern));
+
+        var trimmed = pattern.Trim();
+        var wildcardIndex = trimmed.IndexOf('*', StringComparison.Ordinal);
+        if (wildcardIndex < 0)
+            return new(trimmed, SharedAssemblySelectorKind.Exact);
+
+        if (wildcardIndex != trimmed.Length - 1 || trimmed.LastIndexOf('*') != wildcardIndex)
+            throw new ArgumentException($"Shared assembly selector '{trimmed}' from '{source}' is invalid. The '*' wildcard is allowed only as the final character.", nameof(pattern));
+
+        if (trimmed.Length == 1)
+            throw new ArgumentException($"Shared assembly selector '{trimmed}' from '{source}' is invalid. Prefix wildcard patterns must include a non-empty prefix before '*'.", nameof(pattern));
+
+        return new(trimmed[..^1], SharedAssemblySelectorKind.PrefixPattern);
+    }
+
+    public bool IsMatch(string? assemblyName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyName))
+            return false;
+
+        return Kind is SharedAssemblySelectorKind.Exact
+            ? string.Equals(assemblyName, value, comparison)
+            : assemblyName.StartsWith(value, comparison);
+    }
+}

--- a/src/CShells/Features/SharedAssemblySelector.cs
+++ b/src/CShells/Features/SharedAssemblySelector.cs
@@ -1,0 +1,55 @@
+namespace CShells.Features;
+
+internal sealed class SharedAssemblySelector : ISharedAssemblySelector
+{
+    private readonly SharedAssemblyPattern? pattern;
+    private readonly Func<string, bool>? predicate;
+
+    private SharedAssemblySelector(SharedAssemblyPattern? pattern, Func<string, bool>? predicate, string source)
+    {
+        this.pattern = pattern;
+        this.predicate = predicate;
+        Source = Guard.Against.NullOrWhiteSpace(source);
+    }
+
+    public string Source { get; }
+
+    public static SharedAssemblySelector FromPattern(string pattern, string source) =>
+        new(SharedAssemblyPattern.Parse(pattern, source), null, source);
+
+    public static SharedAssemblySelector FromPredicate(Func<string, bool> predicate, string source) =>
+        new(null, Guard.Against.Null(predicate), source);
+
+    public bool TryMatch(string assemblyName, out SharedAssemblyMatch? match)
+    {
+        Guard.Against.Null(assemblyName);
+
+        if (pattern is not null)
+        {
+            if (!pattern.IsMatch(assemblyName))
+            {
+                match = null;
+                return false;
+            }
+
+            match = new(assemblyName, pattern.Kind, pattern.Pattern, Source);
+            return true;
+        }
+
+        try
+        {
+            if (predicate?.Invoke(assemblyName) is not true)
+            {
+                match = null;
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"The shared assembly selector from '{Source}' threw while evaluating assembly simple name '{assemblyName}'. Ensure predicate selectors can evaluate every candidate assembly.", ex);
+        }
+
+        match = new(assemblyName, SharedAssemblySelectorKind.Predicate, null, Source);
+        return true;
+    }
+}

--- a/src/CShells/Features/SharedAssemblySelectorProvider.cs
+++ b/src/CShells/Features/SharedAssemblySelectorProvider.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+
+namespace CShells.Features;
+
+internal sealed class SharedAssemblySelectorProvider
+{
+    private readonly IReadOnlyList<ISharedAssemblySelector> selectors;
+    private readonly List<SharedAssemblyMatch> matches = [];
+    private readonly HashSet<string> matchedAssemblyNames = new(StringComparer.OrdinalIgnoreCase);
+
+    public SharedAssemblySelectorProvider(IEnumerable<ISharedAssemblySelector> selectors)
+    {
+        this.selectors = Guard.Against.Null(selectors)
+            .Select(selector => selector ?? throw new ArgumentException("Shared assembly selector entries cannot be null.", nameof(selectors)))
+            .ToArray();
+    }
+
+    public bool HasSelectors => selectors.Count > 0;
+
+    public IReadOnlyList<SharedAssemblyMatch> Matches => matches.AsReadOnly();
+
+    public bool IsMatch(AssemblyName assemblyName)
+    {
+        Guard.Against.Null(assemblyName);
+
+        var simpleName = assemblyName.Name;
+        if (string.IsNullOrWhiteSpace(simpleName))
+            return false;
+
+        foreach (var selector in selectors)
+        {
+            if (!selector.TryMatch(simpleName, out var match) || match is null)
+                continue;
+
+            if (matchedAssemblyNames.Add(simpleName))
+                matches.Add(match);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
+++ b/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
@@ -42,8 +42,7 @@ public sealed class ConfigurationShellBlueprint : IShellBlueprint
 
         var featuresSection = _section.GetSection("Features");
         var features = ConfigurationHelper.ParseFeaturesFromConfiguration(featuresSection, Name);
-        settings.EnabledFeatures = ConfigurationHelper.ExtractFeatureNames(features);
-        ConfigurationHelper.PopulateFeatureSettings(features, settings.ConfigurationData);
+        ConfigurationHelper.ApplyFeatureEntries(features, settings);
 
         var configurationSection = _section.GetSection("Configuration");
         ConfigurationHelper.LoadConfigurationFromSection(configurationSection, settings.ConfigurationData);

--- a/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
+++ b/src/CShells/Lifecycle/Blueprints/ConfigurationShellBlueprint.cs
@@ -40,12 +40,12 @@ public sealed class ConfigurationShellBlueprint : IShellBlueprint
     {
         var settings = new ShellSettings(new ShellId(Name));
 
+        var configurationSection = _section.GetSection("Configuration");
+        ConfigurationHelper.LoadConfigurationFromSection(configurationSection, settings.ConfigurationData);
+
         var featuresSection = _section.GetSection("Features");
         var features = ConfigurationHelper.ParseFeaturesFromConfiguration(featuresSection, Name);
         ConfigurationHelper.ApplyFeatureEntries(features, settings);
-
-        var configurationSection = _section.GetSection("Configuration");
-        ConfigurationHelper.LoadConfigurationFromSection(configurationSection, settings.ConfigurationData);
 
         return Task.FromResult(settings);
     }

--- a/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
@@ -57,14 +57,15 @@ internal sealed class ConfiguredShellBlueprintProvider(
         {
             var merged = new ShellSettings(shellSpecific.Id)
             {
-                EnabledFeatures = MergeFeatures(defaults.EnabledFeatures, shellSpecific.EnabledFeatures),
+                EnabledFeatures = defaults.EnabledFeatures,
+                DisabledFeatures = defaults.DisabledFeatures,
+                FeatureSettingResets = defaults.FeatureSettingResets,
                 ConfigurationData = new Dictionary<string, object>(
                     defaults.ConfigurationData,
                     StringComparer.OrdinalIgnoreCase)
             };
 
-            foreach (var (key, value) in shellSpecific.ConfigurationData)
-                merged.ConfigurationData[key] = value;
+            ApplyFeatureDeclarations(merged, shellSpecific);
 
             foreach (var (featureName, configure) in defaults.FeatureConfigurators)
                 merged.FeatureConfigurators[featureName] = configure;
@@ -80,6 +81,21 @@ internal sealed class ConfiguredShellBlueprintProvider(
             return merged;
         }
 
+        private static void ApplyFeatureDeclarations(ShellSettings target, ShellSettings shellSpecific)
+        {
+            foreach (var featureName in shellSpecific.DisabledFeatures)
+                ConfigurationHelper.DisableFeature(target, featureName);
+
+            foreach (var featureName in shellSpecific.EnabledFeatures)
+                ConfigurationHelper.AddEnabledFeature(
+                    target,
+                    featureName,
+                    shellSpecific.FeatureSettingResets.Contains(featureName, StringComparer.OrdinalIgnoreCase));
+
+            foreach (var (key, value) in shellSpecific.ConfigurationData)
+                target.ConfigurationData[key] = value;
+        }
+
         private static Action<T> ChainConfigurators<T>(Action<T> first, Action<T> second) =>
             target =>
             {
@@ -87,22 +103,5 @@ internal sealed class ConfiguredShellBlueprintProvider(
                 second(target);
             };
 
-        private static IReadOnlyList<string> MergeFeatures(
-            IReadOnlyList<string> defaults,
-            IReadOnlyList<string> shellSpecific)
-        {
-            var merged = new List<string>(defaults.Count + shellSpecific.Count);
-            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var feature in defaults)
-                if (seen.Add(feature))
-                    merged.Add(feature);
-
-            foreach (var feature in shellSpecific)
-                if (seen.Add(feature))
-                    merged.Add(feature);
-
-            return [.. merged];
-        }
     }
 }

--- a/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
+++ b/src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs
@@ -65,6 +65,9 @@ internal sealed class ConfiguredShellBlueprintProvider(
                     StringComparer.OrdinalIgnoreCase)
             };
 
+            foreach (var (key, value) in shellSpecific.ConfigurationData)
+                merged.ConfigurationData[key] = value;
+
             ApplyFeatureDeclarations(merged, shellSpecific);
 
             foreach (var (featureName, configure) in defaults.FeatureConfigurators)
@@ -91,9 +94,6 @@ internal sealed class ConfiguredShellBlueprintProvider(
                     target,
                     featureName,
                     shellSpecific.FeatureSettingResets.Contains(featureName, StringComparer.OrdinalIgnoreCase));
-
-            foreach (var (key, value) in shellSpecific.ConfigurationData)
-                target.ConfigurationData[key] = value;
         }
 
         private static Action<T> ChainConfigurators<T>(Action<T> first, Action<T> second) =>

--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -51,10 +51,6 @@ internal sealed class ShellProviderBuilder(
 
         // Explicit disabled entries are already excluded from EnabledFeatures. Unknown positive entries
         // are configuration errors because they attempt to activate unavailable features.
-        var availableEnabled = settings.EnabledFeatures
-            .Where(id => catalog.FeatureMap.ContainsKey(id))
-            .ToList();
-
         var missing = settings.EnabledFeatures
             .Where(id => !catalog.FeatureMap.ContainsKey(id))
             .ToList();
@@ -62,8 +58,8 @@ internal sealed class ShellProviderBuilder(
         if (missing.Count > 0)
             throw new FeatureNotFoundException(missing[0]);
 
-        var orderedFeatures = availableEnabled.Count > 0
-            ? _dependencyResolver.GetOrderedFeatures(availableEnabled, catalog.FeatureMap)
+        var orderedFeatures = settings.EnabledFeatures.Count > 0
+            ? _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, catalog.FeatureMap)
             : [];
 
         // Dependencies are effective shell features too.
@@ -79,7 +75,7 @@ internal sealed class ShellProviderBuilder(
 
         var provider = services.BuildServiceProvider();
 
-        return new BuildResult(provider, holder, orderedFeatures.AsReadOnly(), missing.AsReadOnly());
+        return new BuildResult(provider, holder, orderedFeatures.AsReadOnly());
     }
 
     private void CopyRootServices(IServiceCollection shellServices)
@@ -204,6 +200,5 @@ internal sealed class ShellProviderBuilder(
     public sealed record BuildResult(
         ServiceProvider Provider,
         ShellHolder Holder,
-        IReadOnlyList<string> EnabledFeatures,
-        IReadOnlyList<string> MissingFeatures);
+        IReadOnlyList<string> EnabledFeatures);
 }

--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -49,7 +49,8 @@ internal sealed class ShellProviderBuilder(
         await _featureCatalog.EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         var catalog = _featureCatalog.CurrentSnapshot;
 
-        // Filter enabled features to those present in the catalog; keep the missing list for diagnostics.
+        // Explicit disabled entries are already excluded from EnabledFeatures. Unknown positive entries
+        // are configuration errors because they attempt to activate unavailable features.
         var availableEnabled = settings.EnabledFeatures
             .Where(id => catalog.FeatureMap.ContainsKey(id))
             .ToList();
@@ -58,13 +59,15 @@ internal sealed class ShellProviderBuilder(
             .Where(id => !catalog.FeatureMap.ContainsKey(id))
             .ToList();
 
+        if (missing.Count > 0)
+            throw new FeatureNotFoundException(missing[0]);
+
         var orderedFeatures = availableEnabled.Count > 0
             ? _dependencyResolver.GetOrderedFeatures(availableEnabled, catalog.FeatureMap)
             : [];
 
-        // Dependencies are effective shell features too. Preserve configured-but-undiscovered
-        // feature names for diagnostics and management APIs instead of dropping them.
-        settings.EnabledFeatures = [..orderedFeatures, ..missing];
+        // Dependencies are effective shell features too.
+        settings.EnabledFeatures = [..orderedFeatures];
 
         var services = new ServiceCollection();
         CopyRootServices(services);

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -528,8 +528,8 @@ internal sealed class ShellRegistry : IShellRegistry
         slot.Active = shell;
         slot.All = slot.All.Add(shell);
 
-        _logger.LogInformation("Activated shell {Descriptor} with {FeatureCount} feature(s); {MissingCount} missing",
-            descriptor, buildResult.EnabledFeatures.Count, buildResult.MissingFeatures.Count);
+        _logger.LogInformation("Activated shell {Descriptor} with {FeatureCount} feature(s)",
+            descriptor, buildResult.EnabledFeatures.Count);
 
         return shell;
     }

--- a/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
+++ b/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
@@ -1,5 +1,10 @@
 using CShells.Features;
+using CShells.Configuration;
+using CShells.DependencyInjection;
+using CShells.Lifecycle;
 using CShells.Tests.TestHelpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CShells.Tests.Integration.FeatureDependency;
 
@@ -36,5 +41,51 @@ public class UnknownFeatureDependencyTests
         var ex = Assert.Throws<FeatureNotFoundException>(() => _resolver.ResolveDependencies(missingFeature, features));
         Assert.Contains(missingFeature, ex.Message);
         Assert.Contains("not found", ex.Message);
+    }
+
+    [Fact(DisplayName = "Activation ignores unknown disabled feature declarations")]
+    public async Task ActivateAsync_UnknownDisabledFeature_DoesNotPreventActivation()
+    {
+        await using var host = BuildHost(cshells => cshells
+            .WithAssemblyContaining<UnknownFeatureDependencyTests>()
+            .AddShell("payments", shell => shell
+                .WithFeature<KnownFeature>()
+                .WithFeature(FeatureEntry.Disabled("MissingFeature"))));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        var shell = await registry.ActivateAsync("payments");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Equal(["Known"], settings.EnabledFeatures);
+        Assert.Equal(["MissingFeature"], settings.DisabledFeatures);
+    }
+
+    [Fact(DisplayName = "Activation rejects unknown positive feature declarations")]
+    public async Task ActivateAsync_UnknownEnabledFeature_ThrowsFeatureNotFoundException()
+    {
+        await using var host = BuildHost(cshells => cshells
+            .WithAssemblyContaining<UnknownFeatureDependencyTests>()
+            .AddShell("payments", shell => shell.WithFeature("MissingFeature")));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        var ex = await Assert.ThrowsAsync<FeatureNotFoundException>(() => registry.ActivateAsync("payments"));
+        Assert.Equal("MissingFeature", ex.FeatureName);
+    }
+
+    private static ServiceProvider BuildHost(Action<CShellsBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShells(configure);
+        return services.BuildServiceProvider();
+    }
+
+}
+
+[ShellFeature("Known")]
+public sealed class KnownFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
     }
 }

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -121,20 +121,16 @@ public class ShellRegistryActivateTests
         Assert.NotNull(shell.ServiceProvider.GetService<DependencyExpansionMarker>());
     }
 
-    [Fact(DisplayName = "Activation preserves missing feature names in ShellSettings")]
-    public async Task ActivateAsync_MissingFeatures_ArePreservedInShellSettings()
+    [Fact(DisplayName = "Activation rejects missing positive feature names")]
+    public async Task ActivateAsync_MissingFeatures_ThrowsFeatureNotFoundException()
     {
         await using var host = BuildHost(cshells => cshells
             .WithAssemblyContaining<ShellRegistryActivateTests>()
             .AddShell("payments", shell => shell.WithFeatures("DependencyExpansionDependent", "MissingFeature")));
         var registry = host.GetRequiredService<IShellRegistry>();
 
-        var shell = await registry.ActivateAsync("payments");
-        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
-
-        Assert.Equal(
-            ["DependencyExpansionDependency", "DependencyExpansionDependent", "MissingFeature"],
-            settings.EnabledFeatures);
+        var ex = await Assert.ThrowsAsync<FeatureNotFoundException>(() => registry.ActivateAsync("payments"));
+        Assert.Equal("MissingFeature", ex.FeatureName);
     }
 
     internal static ServiceProvider BuildHost(Action<CShellsBuilder> configure)

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
@@ -109,6 +109,56 @@ public class ShellRegistryConfigureAllShellsTests
         Assert.Equal("Global", settings.ConfigurationData["Region"]);
     }
 
+    [Fact(DisplayName = "Configuration-based shell disable removes ConfigureAllShells feature configuration")]
+    public async Task ConfigureAllShells_ConfigBasedDisableRemovesFeatureConfiguration()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["CShells:Shells:catalog:Features:CommonFeature"] = "false",
+            ["CShells:Shells:catalog:Configuration:CommonFeature:Token"] = "shell",
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        await using var host = BuildHostWithConfiguration(configuration, cshells => cshells
+            .ConfigureAllShells(shell => shell
+                .WithFeature("CommonFeature", feature => feature.WithSetting("Token", "default"))));
+
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("catalog");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Empty(settings.EnabledFeatures);
+        Assert.Equal(["CommonFeature"], settings.DisabledFeatures);
+        Assert.False(settings.ConfigurationData.ContainsKey("CommonFeature:Token"));
+    }
+
+    [Fact(DisplayName = "Configuration-based shell true reset removes ConfigureAllShells feature configuration")]
+    public async Task ConfigureAllShells_ConfigBasedTrueResetRemovesFeatureConfiguration()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["CShells:Shells:catalog:Features:CommonFeature"] = "true",
+            ["CShells:Shells:catalog:Configuration:CommonFeature:Token"] = "shell",
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        await using var host = BuildHostWithConfiguration(configuration, cshells => cshells
+            .ConfigureAllShells(shell => shell
+                .WithFeature("CommonFeature", feature => feature.WithSetting("Token", "default"))));
+
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("catalog");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Equal(["CommonFeature"], settings.EnabledFeatures);
+        Assert.Equal(["CommonFeature"], settings.FeatureSettingResets);
+        Assert.False(settings.ConfigurationData.ContainsKey("CommonFeature:Token"));
+    }
+
     private static ServiceProvider BuildHostWithConfiguration(
         IConfiguration configuration,
         Action<CShellsBuilder> configure)

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryConfigureAllShellsTests.cs
@@ -1,4 +1,5 @@
 using CShells.DependencyInjection;
+using CShells.Features;
 using CShells.Lifecycle;
 using CShells.Lifecycle.Blueprints;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +13,7 @@ public class ShellRegistryConfigureAllShellsTests
     public async Task ConfigureAllShells_AppliedTo_CodeSeededShell()
     {
         await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
-            .WithAssemblies()
+            .WithAssemblyContaining<ShellRegistryConfigureAllShellsTests>()
             .ConfigureAllShells(shell => shell.WithFeatures("CommonFeature"))
             .AddShell("payments", shell => shell.WithFeatures("PaymentsFeature")));
 
@@ -31,7 +32,7 @@ public class ShellRegistryConfigureAllShellsTests
         // Build a minimal IConfiguration that defines a shell with one feature.
         var configData = new Dictionary<string, string?>
         {
-            ["CShells:Shells:catalog:Features:ShellSpecificFeature:Enabled"] = "true",
+            ["CShells:Shells:catalog:Features:ShellSpecificFeature"] = "true",
         };
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(configData)
@@ -53,7 +54,7 @@ public class ShellRegistryConfigureAllShellsTests
     public async Task ConfigureAllShells_DeduplicatesFeatures()
     {
         await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
-            .WithAssemblies()
+            .WithAssemblyContaining<ShellRegistryConfigureAllShellsTests>()
             .ConfigureAllShells(shell => shell.WithFeatures("Shared"))
             .AddShell("payments", shell => shell.WithFeatures("Shared", "Extra")));
 
@@ -116,10 +117,50 @@ public class ShellRegistryConfigureAllShellsTests
         services.AddSingleton<IConfiguration>(configuration);
         services.AddCShells(cshells =>
         {
-            cshells.WithAssemblies();
+            cshells.WithAssemblyContaining<ShellRegistryConfigureAllShellsTests>();
             cshells.WithConfigurationProvider(configuration);
             configure(cshells);
         });
         return services.BuildServiceProvider();
+    }
+}
+
+[ShellFeature("CommonFeature")]
+public sealed class CommonConfigureAllShellsFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+}
+
+[ShellFeature("PaymentsFeature")]
+public sealed class PaymentsConfigureAllShellsFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+}
+
+[ShellFeature("ShellSpecificFeature")]
+public sealed class ShellSpecificConfigureAllShellsFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+}
+
+[ShellFeature("Shared")]
+public sealed class SharedConfigureAllShellsFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+}
+
+[ShellFeature("Extra")]
+public sealed class ExtraConfigureAllShellsFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
     }
 }

--- a/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/FeatureEntryJsonConverterTests.cs
@@ -254,6 +254,19 @@ public class FeatureEntryJsonConverterTests
         Assert.Equal(false, entry.Settings["Debug"]);
     }
 
+    [Fact(DisplayName = "Deserialize treats Enabled as direct feature setting")]
+    public void Deserialize_EnabledProperty_IsDirectFeatureSetting()
+    {
+        var json = """{ "Name": "Feature", "Enabled": true }""";
+
+        var entry = JsonSerializer.Deserialize<FeatureEntry>(json, Options);
+
+        Assert.NotNull(entry);
+        Assert.True(entry.IsEnabled);
+        Assert.False(entry.ResetsSettings);
+        Assert.Equal(true, entry.Settings["Enabled"]);
+    }
+
     [Fact(DisplayName = "Deserialize handles string settings")]
     public void Deserialize_StringSettings_Works()
     {

--- a/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/SharedAssemblyConfigurationTests.cs
@@ -1,0 +1,95 @@
+using CShells.Configuration;
+using CShells.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Configuration;
+
+public class SharedAssemblyConfigurationTests
+{
+    [Fact]
+    public void CShellsOptions_BindsRootSharedAssembliesCollection()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["CShells:SharedAssemblies:0"] = "Elsa",
+            ["CShells:SharedAssemblies:1"] = "Elsa.*"
+        });
+
+        var options = configuration.GetSection("CShells").Get<CShellsOptions>();
+
+        Assert.NotNull(options);
+        Assert.Equal(["Elsa", "Elsa.*"], options.SharedAssemblies);
+    }
+
+    [Fact]
+    public void WithConfigurationProvider_LoadsRootSharedAssembliesAsSelectors()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["CShells:SharedAssemblies:0"] = "Elsa",
+            ["CShells:SharedAssemblies:1"] = "Elsa.*"
+        });
+
+        builder.WithConfigurationProvider(configuration);
+
+        Assert.Equal(2, builder.SharedAssemblySelectors.Count);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithConfigurationProvider_WithBlankSharedAssembly_ThrowsConfigurationPath(string pattern)
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["CShells:SharedAssemblies:0"] = pattern
+        });
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithConfigurationProvider(configuration));
+
+        Assert.Contains("CShells:SharedAssemblies:0", exception.Message);
+    }
+
+    [Fact]
+    public void WithConfigurationProvider_WithInvalidWildcard_ThrowsConfigurationPath()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["CShells:SharedAssemblies:0"] = "*.Contracts"
+        });
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithConfigurationProvider(configuration));
+
+        Assert.Contains("CShells:SharedAssemblies:0", exception.Message);
+        Assert.Contains("final character", exception.Message);
+    }
+
+    [Fact]
+    public void DocumentationSamples_UseRootSharedAssembliesCollection()
+    {
+        var readme = File.ReadAllText(Path.Combine(RepositoryRoot, "README.md"));
+        var quickstart = File.ReadAllText(Path.Combine(RepositoryRoot, "specs", "012-pattern-shared-assemblies", "quickstart.md"));
+
+        Assert.Contains("CShells:SharedAssemblies", quickstart);
+        Assert.DoesNotContain("CShells:Shells:<Name>:SharedAssemblies", readme);
+    }
+
+    private static IConfiguration BuildConfiguration(IDictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static string RepositoryRoot
+    {
+        get
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "CShells.sln")))
+                directory = directory.Parent;
+
+            return directory?.FullName ?? throw new InvalidOperationException("Could not locate repository root.");
+        }
+    }
+}

--- a/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
@@ -98,6 +98,34 @@ public class ShellConfigJsonConverterTests
         Assert.Equal("{}", features.GetProperty("Posts").GetRawText());
     }
 
+    [Fact(DisplayName = "ShellConfig serialization emits true for enabled reset declarations")]
+    public void Serialization_EmitsTrue_ForEnabledResetDeclarations()
+    {
+        var config = new ShellConfig
+        {
+            Features = [FeatureEntry.EnableDefaults("Core")]
+        };
+
+        var json = JsonSerializer.Serialize(config, Options);
+
+        var features = ParseFeatures(json);
+        Assert.True(features.GetProperty("Core").GetBoolean());
+    }
+
+    [Fact(DisplayName = "ShellConfig serialization emits false for disabled declarations")]
+    public void Serialization_EmitsFalse_ForDisabledDeclarations()
+    {
+        var config = new ShellConfig
+        {
+            Features = [FeatureEntry.Disabled("Identity")]
+        };
+
+        var json = JsonSerializer.Serialize(config, Options);
+
+        var features = ParseFeatures(json);
+        Assert.False(features.GetProperty("Identity").GetBoolean());
+    }
+
     [Fact(DisplayName = "ShellConfig deserialization handles object-map with nested settings")]
     public void Deserialization_ObjectMap_NestedSettings()
     {
@@ -121,6 +149,92 @@ public class ShellConfigJsonConverterTests
         var connection = Assert.IsType<JsonElement>(config.Features[0].Settings["Connection"]);
         Assert.Equal("localhost", connection.GetProperty("Server").GetString());
         Assert.Equal(5432, connection.GetProperty("Port").GetInt32());
+    }
+
+    [Fact(DisplayName = "ShellConfig deserialization supports compact enabled feature values")]
+    public void Deserialization_ObjectMap_CompactEnabledValues()
+    {
+        var json = """
+        {
+            "Features": {
+                "Core": true,
+                "Posts": "true",
+                "Analytics": {},
+                "Http": { "BasePath": "/workflows" }
+            }
+        }
+        """;
+
+        var config = Deserialize(json);
+
+        Assert.Equal(4, config.Features.Count);
+        Assert.Equal("Core", config.Features[0].Name);
+        Assert.True(config.Features[0].IsEnabled);
+        Assert.True(config.Features[0].ResetsSettings);
+        Assert.Equal("Posts", config.Features[1].Name);
+        Assert.True(config.Features[1].IsEnabled);
+        Assert.True(config.Features[1].ResetsSettings);
+        Assert.Equal("Analytics", config.Features[2].Name);
+        Assert.True(config.Features[2].IsEnabled);
+        Assert.False(config.Features[2].ResetsSettings);
+        Assert.Empty(config.Features[2].Settings);
+        Assert.Equal("Http", config.Features[3].Name);
+        Assert.Equal("/workflows", config.Features[3].Settings["BasePath"]);
+    }
+
+    [Fact(DisplayName = "ShellConfig object-map treats inner Enabled as setting")]
+    public void Deserialization_ObjectMap_InnerEnabledIsSetting()
+    {
+        var json = """
+        {
+            "Features": {
+                "Example": {
+                    "Enabled": true,
+                    "Limit": 10
+                }
+            }
+        }
+        """;
+
+        var config = Deserialize(json);
+        var feature = Assert.Single(config.Features);
+
+        Assert.True(feature.IsEnabled);
+        Assert.False(feature.ResetsSettings);
+        Assert.Equal(true, feature.Settings["Enabled"]);
+        Assert.Equal(10, feature.Settings["Limit"]);
+    }
+
+    [Fact(DisplayName = "ShellConfig deserialization supports disabled feature values")]
+    public void Deserialization_ObjectMap_DisabledValues()
+    {
+        var json = """
+        {
+            "Features": {
+                "Identity": false,
+                "LegacyAuth": "FALSE"
+            }
+        }
+        """;
+
+        var config = Deserialize(json);
+
+        Assert.Equal(2, config.Features.Count);
+        Assert.Equal("Identity", config.Features[0].Name);
+        Assert.False(config.Features[0].IsEnabled);
+        Assert.Equal("LegacyAuth", config.Features[1].Name);
+        Assert.False(config.Features[1].IsEnabled);
+    }
+
+    [Theory(DisplayName = "ShellConfig deserialization rejects unsupported object-map values")]
+    [InlineData("""{ "Features": { "Identity": null } }""")]
+    [InlineData("""{ "Features": { "Identity": "yes" } }""")]
+    [InlineData("""{ "Features": { "Identity": 0 } }""")]
+    [InlineData("""{ "Features": { "Identity": [] } }""")]
+    public void Deserialization_ObjectMap_UnsupportedValuesThrow(string json)
+    {
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("Identity", ex.Message);
     }
 
     [Fact(DisplayName = "ShellConfig serialization rejects duplicate feature names")]

--- a/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs
@@ -112,6 +112,21 @@ public class ShellConfigJsonConverterTests
         Assert.True(features.GetProperty("Core").GetBoolean());
     }
 
+    [Fact(DisplayName = "ShellConfig serialization rejects reset declarations with explicit settings")]
+    public void Serialization_ResetDeclarationWithSettings_Throws()
+    {
+        var feature = FeatureEntry.EnableDefaults("Core");
+        feature.Settings["Setting"] = "Value";
+        var config = new ShellConfig
+        {
+            Features = [feature]
+        };
+
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(config, Options));
+        Assert.Contains("reset semantics", ex.Message);
+        Assert.Contains("Core", ex.Message);
+    }
+
     [Fact(DisplayName = "ShellConfig serialization emits false for disabled declarations")]
     public void Serialization_EmitsFalse_ForDisabledDeclarations()
     {

--- a/tests/CShells.Tests/Unit/Configuration/ShellConfigurationTests.cs
+++ b/tests/CShells.Tests/Unit/Configuration/ShellConfigurationTests.cs
@@ -164,6 +164,49 @@ public class ShellConfigurationTests
         Assert.Equal("true", feature1["Enabled"]);
     }
 
+    [Fact(DisplayName = "Feature object settings merge with later values taking precedence")]
+    public void FeatureObjectSettings_MergeWithLaterValuesTakingPrecedence()
+    {
+        var first = """
+        {
+            "Shell": {
+                "Features": {
+                    "Http": {
+                        "BasePath": "/workflows",
+                        "Timeout": "30"
+                    }
+                }
+            }
+        }
+        """;
+        var second = """
+        {
+            "Shell": {
+                "Features": {
+                    "Http": {
+                        "Timeout": "60"
+                    }
+                }
+            }
+        }
+        """;
+
+        using var firstStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(first));
+        using var secondStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(second));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(firstStream)
+            .AddJsonStream(secondStream)
+            .Build();
+
+        var settings = new ShellBuilder("TestShell")
+            .FromConfiguration(config.GetSection("Shell"))
+            .Build();
+
+        Assert.Equal(["Http"], settings.EnabledFeatures);
+        Assert.Equal("/workflows", settings.ConfigurationData["Http:BasePath"]);
+        Assert.Equal("60", settings.ConfigurationData["Http:Timeout"]);
+    }
+
     [Fact(DisplayName = "ShellConfiguration with empty ConfigurationData returns root values")]
     public void ShellConfiguration_WithEmptyConfigurationData_ReturnsRootValues()
     {

--- a/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs
+++ b/tests/CShells.Tests/Unit/DependencyInjection/CShellsBuilderSharedAssemblyTests.cs
@@ -1,0 +1,63 @@
+using CShells.DependencyInjection;
+using CShells.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.DependencyInjection;
+
+public class CShellsBuilderSharedAssemblyTests
+{
+    [Fact]
+    public void WithSharedAssemblies_AppendsExactAndPrefixSelectors()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        builder.WithSharedAssemblies("Elsa", "Elsa.*");
+
+        Assert.Equal(2, builder.SharedAssemblySelectors.Count);
+    }
+
+    [Fact]
+    public void WithSharedAssemblies_WithNullPatterns_ThrowsArgumentNullException()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.WithSharedAssemblies(patterns: null!));
+
+        Assert.Equal("patterns", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSharedAssembliesWhere_AppendsPredicateSelector()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        builder.WithSharedAssembliesWhere(name => name.StartsWith("Elsa.", StringComparison.OrdinalIgnoreCase));
+
+        var selector = Assert.Single(builder.SharedAssemblySelectors);
+        Assert.True(selector.TryMatch("Elsa.Workflows", out var match));
+        Assert.NotNull(match);
+        Assert.Equal(SharedAssemblySelectorKind.Predicate, match.SelectorKind);
+    }
+
+    [Fact]
+    public void WithSharedAssembliesWhere_WithNullPredicate_ThrowsArgumentNullException()
+    {
+        var builder = new CShellsBuilder(new ServiceCollection());
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.WithSharedAssembliesWhere(null!));
+
+        Assert.Equal("predicate", exception.ParamName);
+    }
+
+    [Fact]
+    public void PredicateSelector_WhenPredicateThrows_WrapsSourceFeedback()
+    {
+        var selector = SharedAssemblySelector.FromPredicate(_ => throw new InvalidOperationException("boom"), "WithSharedAssembliesWhere");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => selector.TryMatch("Elsa.Workflows", out _));
+
+        Assert.Contains("WithSharedAssembliesWhere", exception.Message);
+        Assert.Contains("Elsa.Workflows", exception.Message);
+        Assert.NotNull(exception.InnerException);
+    }
+}

--- a/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs
+++ b/tests/CShells.Tests/Unit/Features/FeatureAssemblyResolverSharedAssemblyTests.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using CShells.DependencyInjection;
+using CShells.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Features;
+
+public class FeatureAssemblyResolverSharedAssemblyTests
+{
+    [Fact]
+    public void SharedAssemblySelectorProvider_WithConfiguredSelectors_MatchesExpectedSimpleNames()
+    {
+        var provider = CreateProvider("Elsa", "Elsa.*");
+
+        var matches =
+            new[]
+            {
+                new AssemblyName("Elsa"),
+                new AssemblyName("Elsa.Workflows"),
+                new AssemblyName("Contoso.Workflows")
+            }
+            .Where(provider.IsMatch)
+            .Select(name => name.Name!)
+            .ToArray();
+
+        Assert.Equal(["Elsa", "Elsa.Workflows"], matches);
+    }
+
+    [Fact]
+    public async Task BuildFeatureAssembliesAsync_WithConfigurationAndCodeFirst_DeduplicatesMatches()
+    {
+        var services = new ServiceCollection();
+        var builder = new CShellsBuilder(services);
+        var assembly = typeof(FeatureAssemblyResolverSharedAssemblyTests).Assembly;
+        using var serviceProvider = services.BuildServiceProvider();
+
+        builder.WithAssemblies(assembly);
+        builder.WithSharedAssemblies(assembly.GetName().Name!);
+
+        var assemblies = await builder.BuildFeatureAssembliesAsync(serviceProvider);
+
+        Assert.Equal(assembly, Assert.Single(assemblies, item => item == assembly));
+    }
+
+    [Fact]
+    public void SharedAssemblySelectorProvider_UsesAssemblySimpleNameOnly()
+    {
+        var provider = CreateProvider("Elsa.*");
+        var assemblyName = new AssemblyName("Elsa.Workflows")
+        {
+            Version = new(1, 2, 3, 4),
+            CultureName = "en-US"
+        };
+
+        Assert.True(provider.IsMatch(assemblyName));
+        Assert.False(CreateProvider("1.2.3.*").IsMatch(assemblyName));
+        Assert.False(CreateProvider("plugins/Elsa.*").IsMatch(assemblyName));
+    }
+
+    [Fact]
+    public void SharedAssemblySelectorProvider_DeduplicatesMatchDiagnosticsBySimpleName()
+    {
+        var provider = CreateProvider("Elsa.*", "Elsa.Workflows");
+
+        Assert.True(provider.IsMatch(new("Elsa.Workflows")));
+        Assert.True(provider.IsMatch(new("elsa.workflows")));
+
+        var match = Assert.Single(provider.Matches);
+        Assert.Equal("Elsa.Workflows", match.AssemblyName);
+        Assert.Equal("CShells:SharedAssemblies:0", match.SelectorSource);
+    }
+
+    [Fact]
+    public async Task BuildFeatureAssembliesAsync_WithPredicateSelector_FiltersHostAssemblies()
+    {
+        var services = new ServiceCollection();
+        var builder = new CShellsBuilder(services);
+        var assemblyName = typeof(CShellsBuilder).Assembly.GetName().Name!;
+        using var serviceProvider = services.BuildServiceProvider();
+
+        builder.WithSharedAssembliesWhere(name => name.Equals(assemblyName, StringComparison.OrdinalIgnoreCase));
+
+        var assemblies = await builder.BuildFeatureAssembliesAsync(serviceProvider);
+
+        Assert.Contains(assemblies, assembly => assembly.GetName().Name == assemblyName);
+        Assert.Contains(builder.SharedAssemblyMatches, match => match.AssemblyName == assemblyName);
+    }
+
+    private static SharedAssemblySelectorProvider CreateProvider(params string[] patterns) =>
+        new(patterns.Select((pattern, index) => SharedAssemblySelector.FromPattern(pattern, $"CShells:SharedAssemblies:{index}")));
+}

--- a/tests/CShells.Tests/Unit/Features/FeatureConfigurationBinderTests.cs
+++ b/tests/CShells.Tests/Unit/Features/FeatureConfigurationBinderTests.cs
@@ -47,6 +47,21 @@ public class FeatureConfigurationBinderTests
         Assert.Equal(7, feature.Settings.MaxItems);
     }
 
+    [Fact(DisplayName = "BindAndConfigure binds Enabled as feature property")]
+    public void BindAndConfigure_WithEnabledProperty_BindsValue()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Toggle:Enabled"] = "true"
+        });
+        var binder = new FeatureConfigurationBinder(configuration, new NoOpFeatureConfigurationValidator());
+        var feature = new ToggleFeature();
+
+        binder.BindAndConfigure(feature, "Toggle");
+
+        Assert.True(feature.Enabled);
+    }
+
     private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
         new ConfigurationBuilder().AddInMemoryCollection(values).Build();
 
@@ -75,6 +90,15 @@ public class FeatureConfigurationBinderTests
         }
     }
 
+    private sealed class ToggleFeature : IShellFeature
+    {
+        public bool Enabled { get; set; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+    }
+
     private sealed class FeatureSettings
     {
         public string? Mode { get; set; }
@@ -82,5 +106,4 @@ public class FeatureConfigurationBinderTests
         public int MaxItems { get; set; }
     }
 }
-
 

--- a/tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs
+++ b/tests/CShells.Tests/Unit/Features/SharedAssemblyPatternTests.cs
@@ -1,0 +1,52 @@
+using CShells.Features;
+
+namespace CShells.Tests.Unit.Features;
+
+public class SharedAssemblyPatternTests
+{
+    [Theory]
+    [InlineData("Elsa", "Elsa", true)]
+    [InlineData("Elsa", "Elsa.Workflows", false)]
+    [InlineData("Elsa.*", "Elsa.Workflows", true)]
+    [InlineData("Elsa.*", "Contoso.Workflows", false)]
+    [InlineData("elsa.*", "Elsa.Workflows", true)]
+    public void IsMatch_WithExactAndPrefixPatterns_MatchesExpectedSimpleNames(string pattern, string assemblyName, bool expected)
+    {
+        var selector = SharedAssemblyPattern.Parse(pattern, "test");
+
+        var actual = selector.IsMatch(assemblyName);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("*.Contracts")]
+    [InlineData("Elsa.*.Abstractions")]
+    [InlineData("Elsa**")]
+    public void Parse_WithNonFinalWildcard_ThrowsArgumentException(string pattern)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => SharedAssemblyPattern.Parse(pattern, "CShells:SharedAssemblies:0"));
+
+        Assert.Contains("final character", exception.Message);
+        Assert.Contains("CShells:SharedAssemblies:0", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_WithMissingPattern_ThrowsActionableException(string? pattern)
+    {
+        var exception = Assert.ThrowsAny<ArgumentException>(() => SharedAssemblyPattern.Parse(pattern, "CShells:SharedAssemblies:0"));
+
+        Assert.Contains("CShells:SharedAssemblies:0", exception.Message);
+    }
+
+    [Fact]
+    public void Parse_WithBareWildcard_ThrowsArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => SharedAssemblyPattern.Parse("*", "CShells:SharedAssemblies:0"));
+
+        Assert.Contains("non-empty prefix", exception.Message);
+    }
+}

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -58,6 +58,7 @@ public class ConfigurationShellBlueprintTests
         {
             ["Features:Identity"] = "false",
             ["Features:Identity:SigningKey"] = "secret",
+            ["Configuration:Identity:SigningKey"] = "configuration-secret",
             ["Features:Http:BasePath"] = "/workflows",
         };
         var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -32,6 +32,86 @@ public class ConfigurationShellBlueprintTests
         Assert.Equal("Enterprise", settings.ConfigurationData["Plan"]);
     }
 
+    [Fact(DisplayName = "ComposeAsync enables compact true map features")]
+    public async Task ComposeAsync_CompactTrueMapFeature_EnablesFeatureWithDefaults()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:Core"] = "true",
+            ["Features:Posts"] = "TRUE",
+            ["Features:Http:BasePath"] = "/workflows",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Core", "Http", "Posts"], settings.EnabledFeatures.Order(StringComparer.OrdinalIgnoreCase));
+        Assert.Equal(["Core", "Posts"], settings.FeatureSettingResets.Order(StringComparer.OrdinalIgnoreCase));
+        Assert.Equal("/workflows", settings.ConfigurationData["Http:BasePath"]);
+    }
+
+    [Fact(DisplayName = "ComposeAsync disables map feature and ignores inherited child settings")]
+    public async Task ComposeAsync_DisabledMapFeature_RemovesFeatureAndSettings()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Features:Identity"] = "false",
+            ["Features:Identity:SigningKey"] = "secret",
+            ["Features:Http:BasePath"] = "/workflows",
+        };
+        var root = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Http"], settings.EnabledFeatures);
+        Assert.Equal(["Identity"], settings.DisabledFeatures);
+        Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
+        Assert.Equal("/workflows", settings.ConfigurationData["Http:BasePath"]);
+    }
+
+    [Fact(DisplayName = "ComposeAsync later true re-enables disabled feature")]
+    public async Task ComposeAsync_LaterTrue_ReEnablesDisabledFeature()
+    {
+        var root = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Features:Identity"] = "false",
+            })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Features:Identity"] = "true",
+            })
+            .Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Empty(settings.DisabledFeatures);
+        Assert.Equal(["Identity"], settings.FeatureSettingResets);
+    }
+
+    [Fact(DisplayName = "ComposeAsync object feature enables feature with settings")]
+    public async Task ComposeAsync_ObjectFeature_EnablesFeatureWithSettings()
+    {
+        var root = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Features:Identity:SigningKey"] = "configured",
+            })
+            .Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Empty(settings.DisabledFeatures);
+        Assert.Empty(settings.FeatureSettingResets);
+        Assert.Equal("configured", settings.ConfigurationData["Identity:SigningKey"]);
+    }
+
     [Fact(DisplayName = "ComposeAsync reflects runtime changes to the underlying IConfiguration")]
     public async Task ComposeAsync_ReflectsRuntimeConfigChanges()
     {

--- a/tests/CShells.Tests/Unit/ShellBuilderTests.cs
+++ b/tests/CShells.Tests/Unit/ShellBuilderTests.cs
@@ -48,6 +48,19 @@ public class ShellBuilderTests
         Assert.Equal(["Feature1", "Feature2"], settings.EnabledFeatures);
     }
 
+    [Fact(DisplayName = "WithFeature rejects reset feature entries with settings")]
+    public void WithFeature_ResetEntryWithSettings_Throws()
+    {
+        var feature = FeatureEntry.EnableDefaults("Feature1");
+        feature.Settings["Setting"] = "Value";
+        var builder = new ShellBuilder("TestShell");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.WithFeature(feature));
+
+        Assert.Contains("reset semantics", ex.Message);
+        Assert.Contains("Feature1", ex.Message);
+    }
+
     [Fact(DisplayName = "WithConfiguration adds configuration entry")]
     public void WithConfiguration_AddsConfigurationEntry()
     {
@@ -284,6 +297,23 @@ public class ShellBuilderTests
         Assert.Equal(["Identity"], settings.EnabledFeatures);
         Assert.Empty(settings.DisabledFeatures);
         Assert.Equal("configured", settings.ConfigurationData["Identity:SigningKey"]);
+    }
+
+    [Fact(DisplayName = "FromConfiguration rejects null object-map feature values")]
+    public void FromConfiguration_NullObjectMapFeatureValue_Throws()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Shell:Features:Identity"] = null,
+            })
+            .Build();
+        var builder = new ShellBuilder("TestShell");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.FromConfiguration(config.GetSection("Shell")));
+
+        Assert.Contains("Identity", ex.Message);
+        Assert.Contains("null or empty value", ex.Message);
     }
 
     [Fact(DisplayName = "FromConfiguration with IConfigurationSection merges configuration with precedence")]

--- a/tests/CShells.Tests/Unit/ShellBuilderTests.cs
+++ b/tests/CShells.Tests/Unit/ShellBuilderTests.cs
@@ -186,6 +186,69 @@ public class ShellBuilderTests
         Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
     }
 
+    [Fact(DisplayName = "FromConfiguration disable removes same-section shell configuration feature settings")]
+    public void FromConfiguration_Disable_RemovesSameSectionShellConfigurationFeatureSettings()
+    {
+        var json = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": false
+                },
+                "Configuration": {
+                    "Identity": {
+                        "SigningKey": "configured"
+                    }
+                }
+            }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var settings = new ShellBuilder("TestShell")
+            .FromConfiguration(config.GetSection("Shell"))
+            .Build();
+
+        Assert.Equal(["Identity"], settings.DisabledFeatures);
+        Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
+    }
+
+    [Fact(DisplayName = "FromConfiguration true reset removes same-section shell configuration feature settings")]
+    public void FromConfiguration_TrueReset_RemovesSameSectionShellConfigurationFeatureSettings()
+    {
+        var json = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": true
+                },
+                "Configuration": {
+                    "Identity": {
+                        "SigningKey": "configured"
+                    }
+                }
+            }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var settings = new ShellBuilder("TestShell")
+            .FromConfiguration(config.GetSection("Shell"))
+            .Build();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Equal(["Identity"], settings.FeatureSettingResets);
+        Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
+    }
+
     [Fact(DisplayName = "FromConfiguration object re-enables disabled feature with settings")]
     public void FromConfiguration_Object_ReEnablesDisabledFeatureWithSettings()
     {

--- a/tests/CShells.Tests/Unit/ShellBuilderTests.cs
+++ b/tests/CShells.Tests/Unit/ShellBuilderTests.cs
@@ -126,6 +126,103 @@ public class ShellBuilderTests
         Assert.Equal(["Feature1", "Feature2", "Feature3"], settings.EnabledFeatures);
     }
 
+    [Fact(DisplayName = "FromConfiguration disables existing code-first feature")]
+    public void FromConfiguration_DisablesExistingCodeFirstFeature()
+    {
+        var json = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": false,
+                    "Http": true
+                }
+            }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var builder = new ShellBuilder("TestShell")
+            .WithFeature("Identity", settings => settings.WithSetting("SigningKey", "default"))
+            .WithFeature("Posts");
+
+        builder.FromConfiguration(config.GetSection("Shell"));
+        var settings = builder.Build();
+
+        Assert.Equal(["Posts", "Http"], settings.EnabledFeatures);
+        Assert.Equal(["Identity"], settings.DisabledFeatures);
+        Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
+    }
+
+    [Fact(DisplayName = "FromConfiguration true reset drops lower-priority feature settings")]
+    public void FromConfiguration_TrueReset_DropsLowerPriorityFeatureSettings()
+    {
+        var json = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": true
+                }
+            }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var builder = new ShellBuilder("TestShell")
+            .WithFeature("Identity", settings => settings.WithSetting("SigningKey", "default"));
+
+        builder.FromConfiguration(config.GetSection("Shell"));
+        var settings = builder.Build();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Equal(["Identity"], settings.FeatureSettingResets);
+        Assert.False(settings.ConfigurationData.ContainsKey("Identity:SigningKey"));
+    }
+
+    [Fact(DisplayName = "FromConfiguration object re-enables disabled feature with settings")]
+    public void FromConfiguration_Object_ReEnablesDisabledFeatureWithSettings()
+    {
+        var disabledJson = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": false
+                }
+            }
+        }
+        """;
+        var enabledJson = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": { "SigningKey": "configured" }
+                }
+            }
+        }
+        """;
+
+        using var disabledStream = new MemoryStream(Encoding.UTF8.GetBytes(disabledJson));
+        using var enabledStream = new MemoryStream(Encoding.UTF8.GetBytes(enabledJson));
+        var disabledConfig = new ConfigurationBuilder().AddJsonStream(disabledStream).Build();
+        var enabledConfig = new ConfigurationBuilder().AddJsonStream(enabledStream).Build();
+
+        var settings = new ShellBuilder("TestShell")
+            .FromConfiguration(disabledConfig.GetSection("Shell"))
+            .FromConfiguration(enabledConfig.GetSection("Shell"))
+            .Build();
+
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Empty(settings.DisabledFeatures);
+        Assert.Equal("configured", settings.ConfigurationData["Identity:SigningKey"]);
+    }
+
     [Fact(DisplayName = "FromConfiguration with IConfigurationSection merges configuration with precedence")]
     public void FromConfiguration_MergesConfiguration_WithPrecedence()
     {


### PR DESCRIPTION
## Summary

Adds polymorphic feature configuration entries so feature map values can be `true`, `false`, string booleans, or objects with direct settings. Higher-priority configuration can now disable inherited defaults, re-enable features with clean defaults, or provide merged object settings without introducing EnabledFeatures/DisabledFeatures sections.

## Details

- Adds feature entry state/reset semantics and merge helpers for configuration and code-first composition.
- Updates shell blueprint/provider activation so disabled features override lower-priority defaults while unknown disabled features remain a no-op.
- Preserves direct feature option binding, including an `Enabled` option property.
- Updates sample configuration, README, feature configuration docs, and the 014 spec artifacts.
- Expands unit and integration coverage for compact entries, disables, reset behavior, object settings, serialization, and unknown features.

## Validation

- `dotnet test CShells.sln`
- 014 requirements checklist: 16/16 passed
