### PR TITLE
[codex] Allow empty object feature declarations

### DIFF
--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -61,7 +61,7 @@ Do not repeat the feature name inside an object-map entry. If a `Name` property 
 
 - **No duplicates**: Each feature name must appear exactly once per shell.
 - **No mixing**: A shell's `Features` value must be entirely array syntax or entirely object-map syntax. Mixing both styles is rejected with an error that identifies the affected shell.
-- **Values must be boolean or object**: In object-map syntax, every feature value must be `true`, `false`, string `"true"` / `"false"`, or a JSON object. Values such as `"yes"`, `0`, `null`, and arrays are rejected.
+- **Values must be boolean or object**: In object-map syntax, every feature value must be `true`, `false`, string `"true"` / `"false"`, or a JSON object. Empty objects enable the feature with no settings. Values such as `"yes"`, `0`, and arrays are rejected. Direct JSON model deserialization also rejects `null`; configuration-provider loading treats provider null/empty sections as empty object declarations because `IConfiguration` does not preserve that distinction.
 - **Unknown features**: Unknown feature names set to `false` are ignored as no-op disablements; unknown feature names set to `true` or to an object are rejected before activation.
 - **No silent skips**: Blank array entries and array objects with missing or blank `Name` values are rejected before the shell is activated.
 

--- a/src/CShells/Configuration/ConfigurationHelper.cs
+++ b/src/CShells/Configuration/ConfigurationHelper.cs
@@ -511,8 +511,8 @@ internal static class ConfigurationHelper
 
             if (children.Count == 0)
             {
-                throw new InvalidOperationException(
-                    $"Feature '{featureName}'{shellContext} in object-map syntax must be {SupportedFeatureValueForms}, but found a null or empty value.");
+                entries.Add(FeatureEntry.FromName(featureName.Trim()));
+                continue;
             }
 
             // Reject array-like children (e.g., "Posts": [1, 2])

--- a/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using CShells.Lifecycle.Blueprints;
 using CShells.Configuration;
 using Microsoft.Extensions.Configuration;
@@ -49,6 +50,27 @@ public class ConfigurationShellBlueprintTests
         Assert.Equal(["Core", "Http", "Posts"], settings.EnabledFeatures.Order(StringComparer.OrdinalIgnoreCase));
         Assert.Equal(["Core", "Posts"], settings.FeatureSettingResets.Order(StringComparer.OrdinalIgnoreCase));
         Assert.Equal("/workflows", settings.ConfigurationData["Http:BasePath"]);
+    }
+
+    [Fact(DisplayName = "ComposeAsync enables empty object map features")]
+    public async Task ComposeAsync_EmptyObjectMapFeature_EnablesFeatureWithoutSettings()
+    {
+        var json = """
+        {
+            "Features": {
+                "DefaultAuthentication": {}
+            }
+        }
+        """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var root = new ConfigurationBuilder().AddJsonStream(stream).Build();
+        var bp = new ConfigurationShellBlueprint("Default", root);
+
+        var settings = await bp.ComposeAsync();
+
+        Assert.Equal(["DefaultAuthentication"], settings.EnabledFeatures);
+        Assert.Empty(settings.FeatureSettingResets);
+        Assert.Empty(settings.ConfigurationData);
     }
 
     [Fact(DisplayName = "ComposeAsync disables map feature and ignores inherited child settings")]

--- a/tests/CShells.Tests/Unit/ShellBuilderTests.cs
+++ b/tests/CShells.Tests/Unit/ShellBuilderTests.cs
@@ -299,21 +299,30 @@ public class ShellBuilderTests
         Assert.Equal("configured", settings.ConfigurationData["Identity:SigningKey"]);
     }
 
-    [Fact(DisplayName = "FromConfiguration rejects null object-map feature values")]
-    public void FromConfiguration_NullObjectMapFeatureValue_Throws()
+    [Fact(DisplayName = "FromConfiguration enables empty object-map feature values")]
+    public void FromConfiguration_EmptyObjectMapFeatureValue_EnablesFeatureWithoutSettings()
     {
+        var json = """
+        {
+            "Shell": {
+                "Features": {
+                    "Identity": {}
+                }
+            }
+        }
+        """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Shell:Features:Identity"] = null,
-            })
+            .AddJsonStream(stream)
             .Build();
         var builder = new ShellBuilder("TestShell");
 
-        var ex = Assert.Throws<InvalidOperationException>(() => builder.FromConfiguration(config.GetSection("Shell")));
+        builder.FromConfiguration(config.GetSection("Shell"));
+        var settings = builder.Build();
 
-        Assert.Contains("Identity", ex.Message);
-        Assert.Contains("null or empty value", ex.Message);
+        Assert.Equal(["Identity"], settings.EnabledFeatures);
+        Assert.Empty(settings.FeatureSettingResets);
+        Assert.Empty(settings.ConfigurationData);
     }
 
     [Fact(DisplayName = "FromConfiguration with IConfigurationSection merges configuration with precedence")]


### PR DESCRIPTION
## Summary

- Treat empty object-map feature declarations from `IConfiguration` as enabled features with no settings.
- Add runtime parser coverage through `ConfigurationShellBlueprint` and `ShellBuilder` JSON configuration paths.
- Clarify docs around empty objects and the `IConfiguration` null/empty-section limitation.

## Why

The direct JSON `ShellConfig` converter already accepts `{}` and serialization emits `{}` for features without settings, but the `IConfiguration` path rejected the same shape because JSON empty objects arrive as value-less sections with no children. This made valid appsettings declarations such as `"DefaultAuthentication": {}` fail route-index composition.

## Validation

- `dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ConfigurationShellBlueprintTests|FullyQualifiedName~ShellBuilderTests|FullyQualifiedName~ShellConfigJsonConverterTests"`
- `dotnet test`
