### PR TITLE
[codex] Stabilize scope wait deadline test

### DIFF
--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryScopeWaitTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryScopeWaitTests.cs
@@ -75,7 +75,6 @@ public class ShellRegistryScopeWaitTests
         // With no handlers, status is Completed even when scope-wait elapses (no handler
         // was running to report a timeout). The AbandonedScopeCount surfaces the fact.
         Assert.Equal(1, result.AbandonedScopeCount);
-        Assert.True(result.ScopeWaitElapsed >= TimeSpan.FromMilliseconds(50));
         Assert.Equal(ShellLifecycleState.Disposed, shell.State);
 
         // Releasing the (now orphaned) scope handle is still safe.


### PR DESCRIPTION
## Summary

Stabilizes the failing post-merge CI test from the `Packages` workflow run https://github.com/valence-works/cshells/actions/runs/25868789375/job/76018043609.

The failing assertion required `ScopeWaitElapsed` to be at least 50 ms. That is timing-sensitive because `DrainOperation` starts phase 1 on a background task. On a busy CI runner, the drain task can start after the 100 ms deadline has already elapsed; in that case the contract still reports `AbandonedScopeCount == 1`, but the stopwatch for phase 1 can be near zero.

## Changes

- Removes the minimum elapsed-time assertion from `ScopesOutstandingAtDeadline_AreAbandoned`.
- Keeps assertions for the durable behavior: the outstanding scope is counted as abandoned and the shell is disposed.

## Validation

- `dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ShellRegistryScopeWaitTests.ScopesOutstandingAtDeadline_AreAbandoned"`
- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`
- `dotnet build src/CShells/CShells.csproj`
