### PR TITLE
[codex] Warn on missing shell features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.suo
 *.user
 *.userosscache
+*.lscache
 *.sln.docstates
 *.env
 .idea/

--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -62,7 +62,7 @@ Do not repeat the feature name inside an object-map entry. If a `Name` property 
 - **No duplicates**: Each feature name must appear exactly once per shell.
 - **No mixing**: A shell's `Features` value must be entirely array syntax or entirely object-map syntax. Mixing both styles is rejected with an error that identifies the affected shell.
 - **Values must be boolean or object**: In object-map syntax, every feature value must be `true`, `false`, string `"true"` / `"false"`, or a JSON object. Empty objects enable the feature with no settings. Values such as `"yes"`, `0`, and arrays are rejected. Direct JSON model deserialization also rejects `null`; configuration-provider loading treats provider null/empty sections as empty object declarations because `IConfiguration` does not preserve that distinction.
-- **Unknown features**: Unknown feature names set to `false` are ignored as no-op disablements; unknown feature names set to `true` or to an object are rejected before activation.
+- **Unknown features**: Unknown feature names set to `false` are ignored as no-op disablements; unknown feature names set to `true` or to an object are logged as warnings and skipped so the shell can activate with the features that are available.
 - **No silent skips**: Blank array entries and array objects with missing or blank `Name` values are rejected before the shell is activated.
 
 ## Legacy Inline Configuration (Array Syntax)

--- a/specs/014-polymorphic-feature-config/data-model.md
+++ b/specs/014-polymorphic-feature-config/data-model.md
@@ -90,11 +90,11 @@ Final set consumed by dependency resolution and activation.
 Fields:
 
 - `Enabled`: catalog-known feature names ordered by dependency resolver.
-- `MissingPositive`: unknown features requested by `true` or object values.
+- `MissingPositive`: unknown features requested by `true` or object values; these are recorded for diagnostics and skipped during activation when absent from the runtime feature catalog.
 - `IgnoredDisabled`: unknown features requested by `false`.
 
 Validation:
 
-- `MissingPositive` fails with actionable messages.
+- `MissingPositive` does not fail activation; it produces actionable warning/status diagnostics and the shell activates with available features.
 - `IgnoredDisabled` does not fail shell activation.
 - Disabled catalog-known features do not run configuration binding, service registration, endpoint mapping, or post-configuration hooks.

--- a/specs/014-polymorphic-feature-config/plan.md
+++ b/specs/014-polymorphic-feature-config/plan.md
@@ -26,7 +26,7 @@ Keep per-shell `Features` as a named map while allowing each feature value to be
 - **I. Abstraction-First Architecture**: PASS. Runtime feature declarations affect public `ShellSettings` semantics, so any required model state belongs in `CShells.Abstractions` before implementation uses it.
 - **II. Feature Modularity**: PASS. The feature remains declarative shell configuration; no feature constructor/service coupling changes.
 - **III. Modern C# Style**: PASS. Planned edits use existing C# 14 conventions, collection expressions, explicit access modifiers, nullable annotations, and XML docs for public members.
-- **IV. Explicit Error Handling**: PASS. Invalid values, nulls, blank feature names, and unknown positive feature entries will fail with actionable messages that name the feature path.
+- **IV. Explicit Error Handling**: PASS. Invalid values, nulls, and blank feature names fail with actionable messages that name the feature path; unknown positive feature entries are handled by the later deferred-activation behavior as non-blocking missing features with diagnostics.
 - **V. Test Coverage**: PASS. Unit and integration tests are planned for all new value forms, merge precedence, option reset behavior, environment-style strings, and unknown-feature behavior.
 - **VI. Simplicity & Minimalism**: PASS. The design extends the existing feature entry model and parsing helpers rather than adding a separate configuration subsystem.
 - **VII. Lifecycle & Concurrency Contracts**: PASS. The feature affects composition before activation and does not add shared mutable lifecycle state or async coordination.

--- a/specs/014-polymorphic-feature-config/research.md
+++ b/specs/014-polymorphic-feature-config/research.md
@@ -46,14 +46,14 @@
 - Native booleans only: rejected because environment-variable enable/disable would be impractical.
 - Accept `yes`, `no`, `1`, and `0`: rejected because it broadens the grammar without user value and makes invalid config easier to miss.
 
-## Decision: Unknown disabled features are no-op declarations; unknown positive entries fail
+## Decision: Unknown disabled features are no-op declarations; unknown positive entries are missing features
 
-**Rationale**: Shared deployment configuration should be able to disable optional features across application variants. Positive declarations still need validation because they attempt to activate unavailable behavior and often indicate typos or missing assemblies.
+**Rationale**: Shared deployment configuration should be able to disable optional features across application variants. Positive declarations still need operator visibility because they attempt to activate unavailable behavior and often indicate typos or missing assemblies, but `005-deferred-shell-activation` supersedes the original fail-fast behavior: missing configured features are warnings/status, not activation blockers.
 
 **Alternatives considered**:
 
 - Fail every unknown feature: rejected because it harms portable deployment config.
-- Ignore every unknown feature: rejected because it hides attempted activations and misspellings.
+- Ignore every unknown feature silently: rejected because it hides attempted activations and misspellings.
 
 ## Decision: Validate before activation and preserve existing dependency failure semantics
 

--- a/specs/014-polymorphic-feature-config/spec.md
+++ b/specs/014-polymorphic-feature-config/spec.md
@@ -12,7 +12,7 @@
 - Q: Should code-first feature registrations be overridable by configuration? → A: Code-first feature registrations are overridable defaults; higher-priority configuration can disable or re-enable them.
 - Q: How should higher-priority `true` interact with lower-priority feature settings? → A: `false` disables despite inherited children; `true` enables with defaults and ignores inherited children; object entries enable with normally merged object settings.
 - Q: Which scalar boolean representations should feature entries accept? → A: Accept native booleans and case-insensitive string `true` / `false`; reject all other scalar values.
-- Q: How should disablement behave for unknown feature names? → A: Unknown feature set to `false` is allowed as a no-op and may be surfaced in diagnostics; unknown feature set to `true` or object remains invalid.
+- Q: How should disablement behave for unknown feature names? → A: Unknown feature set to `false` is allowed as a no-op and may be surfaced in diagnostics; later deferred-activation behavior also treats unknown feature entries set to `true` or object as non-blocking missing features with warnings.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -91,7 +91,7 @@ As a developer configuring feature options, I want configured feature objects to
 - Feature names with blank or whitespace-only keys are invalid and must fail before shell activation.
 - Invalid scalar values such as `"yes"`, `0`, or arbitrary strings other than case-insensitive `true` / `false` must fail with an actionable error rather than being guessed.
 - Unknown feature names set to `false` are valid no-op disablements and should remain visible for diagnostics where available.
-- Unknown feature names set to `true` or to an object are invalid because they represent attempted activation of an unavailable feature.
+- Unknown feature names set to `true` or to an object are missing-feature declarations: activation must continue with available features and log/report the missing names, per `005-deferred-shell-activation`.
 - Duplicate feature declarations across configuration sources must resolve according to source priority, not by producing duplicate feature activations.
 - Disabled features must not run service configuration, endpoint mapping, dependency activation, or post-configuration hooks.
 - Disabling a feature that other enabled features depend on must produce the same dependency validation behavior as if the feature were absent.
@@ -119,8 +119,8 @@ As a developer configuring feature options, I want configured feature objects to
 - **FR-016**: The system MUST validate feature entry values and reject unsupported scalar values with a clear message that identifies the feature path and expected value forms.
 - **FR-017**: The system MUST reject `null` feature entry values with a clear message that instructs users to use `true`, `false`, or an object.
 - **FR-018**: The system MUST allow an unknown feature entry set to `false` as a no-op disablement.
-- **FR-019**: The system MUST reject an unknown feature entry set to `true` or to an object because it attempts to enable an unavailable feature.
-- **FR-020**: The system SHOULD make unknown feature no-op disablements visible in diagnostics where diagnostic output is available.
+- **FR-019**: The system MUST NOT reject an unknown feature entry set to `true` or to an object during shell activation; it MUST treat it as a missing configured feature, activate with available features, and emit operator-visible diagnostics as specified by `005-deferred-shell-activation`.
+- **FR-020**: The system SHOULD make unknown feature no-op disablements and missing positive feature declarations visible in diagnostics where diagnostic output is available.
 - **FR-021**: The system MUST reject blank or whitespace-only feature names before shell activation.
 - **FR-022**: The system MUST preserve existing feature option binding paths for object-based feature entries.
 - **FR-023**: The system MUST document the three supported feature entry forms: `true`, `false`, and object.
@@ -166,4 +166,4 @@ As a developer configuring feature options, I want configured feature objects to
 - **SC-008**: Documentation and samples include at least one compact `true` example, one `false` disablement example, one object settings example, and one Docker-mounted override example.
 - **SC-009**: A layered configuration test confirms a higher-priority `true` declaration does not inherit lower-priority feature option values.
 - **SC-010**: Environment-style string values `"true"` and `"false"` are accepted case-insensitively, while values such as `"yes"` and `"0"` are rejected in verified tests.
-- **SC-011**: Unknown feature entries set to `false` do not prevent shell activation, while unknown feature entries set to `true` or object fail with actionable messages in verified tests.
+- **SC-011**: Unknown feature entries set to `false` do not prevent shell activation, and unknown feature entries set to `true` or object activate with available features while producing actionable diagnostics in verified tests.

--- a/specs/014-polymorphic-feature-config/tasks.md
+++ b/specs/014-polymorphic-feature-config/tasks.md
@@ -67,7 +67,7 @@
 - [x] T016 [P] [US2] Add parser tests for native `false`, string `"false"`, unsupported scalars, and `null` in `tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs`
 - [x] T017 [P] [US2] Add blueprint tests for disabling configured features and preserving unrelated features in `tests/CShells.Tests/Unit/Lifecycle/Blueprints/ConfigurationShellBlueprintTests.cs`
 - [x] T018 [P] [US2] Add code-first default disablement tests in `tests/CShells.Tests/Unit/ShellBuilderTests.cs`
-- [x] T019 [P] [US2] Add unknown disabled feature no-op and unknown positive feature failure tests in `tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs`
+- [x] T019 [P] [US2] Add unknown disabled feature no-op and unknown positive missing-feature diagnostics tests in `tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs`
 
 ### Implementation for User Story 2
 
@@ -76,7 +76,7 @@
 - [x] T022 [US2] Apply disabled feature declarations when `ShellBuilder.FromConfiguration(IConfigurationSection)` merges into existing settings in `src/CShells/Configuration/ShellBuilder.cs`
 - [x] T023 [US2] Apply disabled feature declarations when `ShellBuilder.FromConfiguration(ShellConfig)` merges into existing settings in `src/CShells/Configuration/ShellBuilder.cs`
 - [x] T024 [US2] Update code-first default merging to let shell-specific disabled declarations remove defaults in `src/CShells/Lifecycle/Providers/ConfiguredShellBlueprintProvider.cs`
-- [x] T025 [US2] Validate unknown positive feature declarations while ignoring unknown disabled declarations before activation in `src/CShells/Lifecycle/ShellProviderBuilder.cs`
+- [x] T025 [US2] Warn for unknown positive feature declarations while ignoring unknown disabled declarations before activation in `src/CShells/Lifecycle/ShellProviderBuilder.cs`
 - [x] T026 [US2] Run US2 focused tests with `dotnet test tests/CShells.Tests/ --filter "ShellBuilderTests|ConfigurationShellBlueprintTests|UnknownFeatureDependencyTests"` from repository root
 
 **Checkpoint**: User Stories 1 and 2 both work independently; deployment overrides can disable defaults.
@@ -184,7 +184,7 @@ Task: "T010 Add configuration blueprint tests for compact true and string true f
 ```text
 Task: "T016 Add parser tests for native false, string false, unsupported scalars, and null in tests/CShells.Tests/Unit/Configuration/ShellConfigJsonConverterTests.cs"
 Task: "T018 Add code-first default disablement tests in tests/CShells.Tests/Unit/ShellBuilderTests.cs"
-Task: "T019 Add unknown disabled feature no-op and unknown positive feature failure tests in tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs"
+Task: "T019 Add unknown disabled feature no-op and unknown positive missing-feature diagnostics tests in tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs"
 ```
 
 ## Parallel Example: User Story 3

--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -62,7 +62,7 @@ internal sealed class ShellProviderBuilder(
                 "Shell '{ShellName}' requested {MissingFeatureCount} feature(s) that are not available in the runtime feature catalog: {MissingFeatures}. The shell will activate with available features only.",
                 settings.Id.Name,
                 missingFeatures.Count,
-                string.Join(", ", missingFeatures));
+                missingFeatures);
         }
 
         var availableFeatures = settings.EnabledFeatures

--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -50,16 +50,27 @@ internal sealed class ShellProviderBuilder(
         var catalog = _featureCatalog.CurrentSnapshot;
 
         // Explicit disabled entries are already excluded from EnabledFeatures. Unknown positive entries
-        // are configuration errors because they attempt to activate unavailable features.
-        var missing = settings.EnabledFeatures
+        // are tolerated so hosts can share configuration across deployments that do not reference
+        // every optional feature package.
+        var missingFeatures = settings.EnabledFeatures
             .Where(id => !catalog.FeatureMap.ContainsKey(id))
             .ToList();
 
-        if (missing.Count > 0)
-            throw new FeatureNotFoundException(missing[0]);
+        if (missingFeatures.Count > 0)
+        {
+            _logger.LogWarning(
+                "Shell '{ShellName}' requested {MissingFeatureCount} feature(s) that are not available in the runtime feature catalog: {MissingFeatures}. The shell will activate with available features only.",
+                settings.Id.Name,
+                missingFeatures.Count,
+                string.Join(", ", missingFeatures));
+        }
 
-        var orderedFeatures = settings.EnabledFeatures.Count > 0
-            ? _dependencyResolver.GetOrderedFeatures(settings.EnabledFeatures, catalog.FeatureMap)
+        var availableFeatures = settings.EnabledFeatures
+            .Where(id => catalog.FeatureMap.ContainsKey(id))
+            .ToList();
+
+        var orderedFeatures = availableFeatures.Count > 0
+            ? _dependencyResolver.GetOrderedFeatures(availableFeatures, catalog.FeatureMap)
             : [];
 
         // Dependencies are effective shell features too.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
         <LangVersion>latest</LangVersion>
 
         <!-- Central base version for all packages; preview builds will append a suffix like -preview.{runNumber} -->
-        <Version>0.0.23</Version>
+        <Version>0.0.24</Version>
 
         <!-- NuGet Package Metadata -->
         <Authors>Sipke Schoorstra</Authors>

--- a/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
+++ b/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
@@ -5,6 +5,7 @@ using CShells.Lifecycle;
 using CShells.Tests.TestHelpers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CShells.Tests.Integration.FeatureDependency;
 
@@ -63,25 +64,46 @@ public class UnknownFeatureDependencyTests
     [Fact(DisplayName = "Activation ignores unknown positive feature declarations")]
     public async Task ActivateAsync_UnknownEnabledFeature_DoesNotPreventActivation()
     {
-        await using var host = BuildHost(cshells => cshells
-            .WithAssemblyContaining<UnknownFeatureDependencyTests>()
-            .AddShell("payments", shell => shell.WithFeature("MissingFeature")));
+        var logs = new List<(LogLevel Level, string Message)>();
+        await using var host = BuildHost(
+            cshells => cshells
+                .WithAssemblyContaining<UnknownFeatureDependencyTests>()
+                .AddShell("payments", shell => shell.WithFeature("MissingFeature")),
+            services => services.AddSingleton<ILogger<ShellProviderBuilder>>(new CapturingLogger<ShellProviderBuilder>(logs)));
         var registry = host.GetRequiredService<IShellRegistry>();
 
         var shell = await registry.ActivateAsync("payments");
         var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
 
         Assert.Empty(settings.EnabledFeatures);
+        Assert.Contains(logs, entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("MissingFeature", StringComparison.Ordinal) &&
+            entry.Message.Contains("available features only", StringComparison.Ordinal));
     }
 
-    private static ServiceProvider BuildHost(Action<CShellsBuilder> configure)
+    private static ServiceProvider BuildHost(Action<CShellsBuilder> configure, Action<IServiceCollection>? configureServices = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        configureServices?.Invoke(services);
         services.AddCShells(configure);
         return services.BuildServiceProvider();
     }
 
+    private sealed class CapturingLogger<T>(List<(LogLevel Level, string Message)> sink) : ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            sink.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
 }
 
 [ShellFeature("Known")]

--- a/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
+++ b/tests/CShells.Tests/Integration/FeatureDependency/UnknownFeatureDependencyTests.cs
@@ -60,16 +60,18 @@ public class UnknownFeatureDependencyTests
         Assert.Equal(["MissingFeature"], settings.DisabledFeatures);
     }
 
-    [Fact(DisplayName = "Activation rejects unknown positive feature declarations")]
-    public async Task ActivateAsync_UnknownEnabledFeature_ThrowsFeatureNotFoundException()
+    [Fact(DisplayName = "Activation ignores unknown positive feature declarations")]
+    public async Task ActivateAsync_UnknownEnabledFeature_DoesNotPreventActivation()
     {
         await using var host = BuildHost(cshells => cshells
             .WithAssemblyContaining<UnknownFeatureDependencyTests>()
             .AddShell("payments", shell => shell.WithFeature("MissingFeature")));
         var registry = host.GetRequiredService<IShellRegistry>();
 
-        var ex = await Assert.ThrowsAsync<FeatureNotFoundException>(() => registry.ActivateAsync("payments"));
-        Assert.Equal("MissingFeature", ex.FeatureName);
+        var shell = await registry.ActivateAsync("payments");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Empty(settings.EnabledFeatures);
     }
 
     private static ServiceProvider BuildHost(Action<CShellsBuilder> configure)

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -5,6 +5,7 @@ using CShells.Lifecycle.Blueprints;
 using CShells.Lifecycle.Providers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CShells.Tests.Integration.Lifecycle;
 
@@ -121,22 +122,34 @@ public class ShellRegistryActivateTests
         Assert.NotNull(shell.ServiceProvider.GetService<DependencyExpansionMarker>());
     }
 
-    [Fact(DisplayName = "Activation rejects missing positive feature names")]
-    public async Task ActivateAsync_MissingFeatures_ThrowsFeatureNotFoundException()
+    [Fact(DisplayName = "Activation warns about missing positive feature names and uses available features")]
+    public async Task ActivateAsync_MissingFeatures_WarnsAndUsesAvailableFeatures()
     {
-        await using var host = BuildHost(cshells => cshells
-            .WithAssemblyContaining<ShellRegistryActivateTests>()
-            .AddShell("payments", shell => shell.WithFeatures("DependencyExpansionDependent", "MissingFeature")));
+        var logs = new List<(LogLevel Level, string Message)>();
+        await using var host = BuildHost(
+            cshells => cshells
+                .WithAssemblyContaining<ShellRegistryActivateTests>()
+                .AddShell("payments", shell => shell.WithFeatures("DependencyExpansionDependent", "MissingFeature")),
+            services => services.AddSingleton<ILogger<ShellProviderBuilder>>(new CapturingLogger<ShellProviderBuilder>(logs)));
         var registry = host.GetRequiredService<IShellRegistry>();
 
-        var ex = await Assert.ThrowsAsync<FeatureNotFoundException>(() => registry.ActivateAsync("payments"));
-        Assert.Equal("MissingFeature", ex.FeatureName);
+        var shell = await registry.ActivateAsync("payments");
+        var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
+
+        Assert.Equal(
+            ["DependencyExpansionDependency", "DependencyExpansionDependent"],
+            settings.EnabledFeatures);
+        Assert.Contains(logs, entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("MissingFeature", StringComparison.Ordinal) &&
+            entry.Message.Contains("available features only", StringComparison.Ordinal));
     }
 
-    internal static ServiceProvider BuildHost(Action<CShellsBuilder> configure)
+    internal static ServiceProvider BuildHost(Action<CShellsBuilder> configure, Action<IServiceCollection>? configureServices = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        configureServices?.Invoke(services);
         services.AddCShells(configure);
         return services.BuildServiceProvider();
     }
@@ -157,6 +170,20 @@ public class ShellRegistryActivateTests
 
         public Task<ShellSettings> ComposeAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(new ShellSettings(new ShellId("other-name")));
+    }
+
+    private sealed class CapturingLogger<T>(List<(LogLevel Level, string Message)> sink) : ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            sink.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Treat configured feature names that are absent from the runtime feature catalog as non-blocking missing features.
- Log a warning and activate shells with the available features instead of throwing `FeatureNotFoundException`.
- Update tests plus the older polymorphic feature configuration spec/docs to match the deferred shell activation rule.

## Root Cause

`ShellProviderBuilder` still enforced an older fail-fast rule for unknown positive feature entries. That conflicted with the later deferred activation behavior, so a shell containing an optional feature such as `SampleEndpoint` failed activation when the feature assembly was not referenced.

## Validation

- `dotnet test tests/CShells.Tests/CShells.Tests.csproj --no-restore`