### PR TITLE
[codex] Fix shell FastEndpoints authorization policies

### DIFF
--- a/src/CShells.AspNetCore/Authorization/ShellAuthorizationPolicyProvider.cs
+++ b/src/CShells.AspNetCore/Authorization/ShellAuthorizationPolicyProvider.cs
@@ -25,6 +25,7 @@ namespace CShells.AspNetCore.Authorization;
 /// - Implements IAuthorizationPolicyProvider to intercept policy lookups
 /// - Uses IHttpContextAccessor to get the current request's HttpContext
 /// - Resolves IAuthorizationPolicyProvider from HttpContext.RequestServices (which is shell-scoped by ShellMiddleware)
+/// - Reads shell AuthorizationOptions directly when a shell provider is not available
 /// - Falls back to the default policy provider for app-level policies
 /// </para>
 /// </remarks>
@@ -41,7 +42,12 @@ public class ShellAuthorizationPolicyProvider(
     {
         // Try to get from shell provider first
         var shellProvider = GetShellPolicyProvider();
-        return shellProvider != null ? shellProvider.GetDefaultPolicyAsync() : _fallbackProvider.GetDefaultPolicyAsync();
+        if (shellProvider != null)
+            return shellProvider.GetDefaultPolicyAsync();
+
+        var policy = GetShellAuthorizationOptions()?.DefaultPolicy;
+
+        return policy != null ? Task.FromResult(policy) : _fallbackProvider.GetDefaultPolicyAsync();
     }
 
     /// <inheritdoc />
@@ -49,7 +55,12 @@ public class ShellAuthorizationPolicyProvider(
     {
         // Try to get from shell provider first
         var shellProvider = GetShellPolicyProvider();
-        return shellProvider != null ? shellProvider.GetFallbackPolicyAsync() : _fallbackProvider.GetFallbackPolicyAsync();
+        if (shellProvider != null)
+            return shellProvider.GetFallbackPolicyAsync();
+
+        var policy = GetShellAuthorizationOptions()?.FallbackPolicy;
+
+        return policy != null ? Task.FromResult<AuthorizationPolicy?>(policy) : _fallbackProvider.GetFallbackPolicyAsync();
     }
 
     /// <inheritdoc />
@@ -67,6 +78,13 @@ public class ShellAuthorizationPolicyProvider(
             }
         }
 
+        var shellOptionsPolicy = GetShellAuthorizationOptions()?.GetPolicy(policyName);
+        if (shellOptionsPolicy != null)
+        {
+            _logger.LogTrace("Found policy '{PolicyName}' in shell authorization options", policyName);
+            return shellOptionsPolicy;
+        }
+
         // Fall back to root provider
         var rootPolicy = await _fallbackProvider.GetPolicyAsync(policyName);
         if (rootPolicy != null)
@@ -77,6 +95,12 @@ public class ShellAuthorizationPolicyProvider(
 
         _logger.LogDebug("Policy '{PolicyName}' not found in shell or root authorization providers", policyName);
         return null;
+    }
+
+    private AuthorizationOptions? GetShellAuthorizationOptions()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        return httpContext?.RequestServices.GetService<IOptions<AuthorizationOptions>>()?.Value;
     }
 
     /// <summary>

--- a/src/CShells.FastEndpoints/Features/FastEndpointsFeature.cs
+++ b/src/CShells.FastEndpoints/Features/FastEndpointsFeature.cs
@@ -43,6 +43,8 @@ public class FastEndpointsFeature(
             options.EndpointRoutePrefix = EndpointRoutePrefix;
         });
 
+        services.AddAuthorization();
+
         // Register FastEndpoints with the discovered assemblies
         services.AddFastEndpoints(options =>
         {

--- a/tests/CShells.Tests/CShells.Tests.csproj
+++ b/tests/CShells.Tests/CShells.Tests.csproj
@@ -3,6 +3,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\CShells\CShells.csproj"/>
         <ProjectReference Include="..\..\src\CShells.AspNetCore\CShells.AspNetCore.csproj"/>
+        <ProjectReference Include="..\..\src\CShells.FastEndpoints\CShells.FastEndpoints.csproj"/>
         <ProjectReference Include="..\..\src\CShells.Management.Api\CShells.Management.Api.csproj"/>
     </ItemGroup>
 

--- a/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
@@ -1,0 +1,45 @@
+using CShells.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace CShells.Tests.AspNetCore.Authorization;
+
+public class ShellAuthorizationPolicyProviderTests
+{
+    private const string ShellPolicyName = "epPolicy:Test.Endpoint";
+    private readonly HttpContextAccessor _httpContextAccessor = new();
+    private readonly ShellAuthorizationPolicyProvider _provider;
+    private readonly AuthorizationPolicy _shellPolicy;
+
+    public ShellAuthorizationPolicyProviderTests()
+    {
+        var rootOptions = new AuthorizationOptions();
+        _provider = new(Options.Create(rootOptions), _httpContextAccessor);
+
+        _shellPolicy = new AuthorizationPolicyBuilder()
+            .RequireClaim("permissions", "read:test")
+            .Build();
+
+        var shellOptions = new AuthorizationOptions();
+        shellOptions.AddPolicy(ShellPolicyName, _shellPolicy);
+
+        var shellServices = new ServiceCollection()
+            .AddSingleton<IOptions<AuthorizationOptions>>(Options.Create(shellOptions))
+            .BuildServiceProvider();
+
+        _httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            RequestServices = shellServices
+        };
+    }
+
+    [Fact]
+    public async Task GetPolicyAsync_UsesShellAuthorizationOptions_WhenShellProviderIsUnavailable()
+    {
+        var policy = await _provider.GetPolicyAsync(ShellPolicyName);
+
+        Assert.Same(_shellPolicy, policy);
+    }
+}

--- a/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace CShells.Tests.AspNetCore.Authorization;
+namespace CShells.Tests.Unit.AspNetCore.Authorization;
 
 public class ShellAuthorizationPolicyProviderTests
 {

--- a/tests/CShells.Tests/Unit/FastEndpoints/FastEndpointsFeatureTests.cs
+++ b/tests/CShells.Tests/Unit/FastEndpoints/FastEndpointsFeatureTests.cs
@@ -1,0 +1,60 @@
+using CShells.FastEndpoints.Features;
+using CShells.Features;
+using FastEndpoints;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.FastEndpoints;
+
+public class FastEndpointsFeatureTests
+{
+    private readonly ServiceCollection _services = [];
+    private readonly FastEndpointsFeature _feature;
+
+    public FastEndpointsFeatureTests()
+    {
+        var settings = new ShellSettings(new("Default"), ["TestApi"]);
+        var descriptors = new[]
+        {
+            new ShellFeatureDescriptor("TestApi")
+            {
+                StartupType = typeof(TestApiFeature)
+            }
+        };
+        var context = new ShellFeatureContext(settings, descriptors);
+        _feature = new(context);
+    }
+
+    [Fact]
+    public void ConfigureServices_RegistersAuthorizationPolicyProvider()
+    {
+        _feature.ConfigureServices(_services);
+
+        using var serviceProvider = _services.BuildServiceProvider();
+
+        var policyProvider = serviceProvider.GetService<IAuthorizationPolicyProvider>();
+
+        Assert.IsType<DefaultAuthorizationPolicyProvider>(policyProvider);
+    }
+
+    private class TestApiFeature : IFastEndpointsShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+    }
+
+    private class TestEndpoint : EndpointWithoutRequest
+    {
+        public override void Configure()
+        {
+            Get("/test");
+            AllowAnonymous();
+        }
+
+        public override Task HandleAsync(CancellationToken ct)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/CShells.Tests/Unit/FastEndpoints/FastEndpointsFeatureTests.cs
+++ b/tests/CShells.Tests/Unit/FastEndpoints/FastEndpointsFeatureTests.cs
@@ -1,10 +1,11 @@
+using CShells.AspNetCore.Authorization;
 using CShells.FastEndpoints.Features;
 using CShells.Features;
 using FastEndpoints;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace CShells.Tests.FastEndpoints;
+namespace CShells.Tests.Unit.FastEndpoints;
 
 public class FastEndpointsFeatureTests
 {
@@ -32,9 +33,10 @@ public class FastEndpointsFeatureTests
 
         using var serviceProvider = _services.BuildServiceProvider();
 
-        var policyProvider = serviceProvider.GetService<IAuthorizationPolicyProvider>();
+        var policyProvider = serviceProvider.GetRequiredService<IAuthorizationPolicyProvider>();
 
-        Assert.IsType<DefaultAuthorizationPolicyProvider>(policyProvider);
+        Assert.NotNull(policyProvider);
+        Assert.IsNotType<ShellAuthorizationPolicyProvider>(policyProvider);
     }
 
     private class TestApiFeature : IFastEndpointsShellFeature


### PR DESCRIPTION
## Summary

Fixes shell-scoped FastEndpoints authorization policy resolution for endpoints that use FastEndpoints-generated `epPolicy:*` policies.

## Root Cause

`CShells.FastEndpoints` calls `AddFastEndpoints()` and `MapFastEndpoints()` per shell. FastEndpoints registers endpoint-specific authorization policies into the shell's `AuthorizationOptions`, but the FastEndpoints integration did not ensure authorization services were registered for the shell. In some host setups, the root `ShellAuthorizationPolicyProvider` could not resolve those shell-scoped policies and ASP.NET Core threw: `The AuthorizationPolicy named: 'epPolicy:...' was not found.`

## Changes

- Register authorization services from `FastEndpointsFeature.ConfigureServices()`.
- Make `ShellAuthorizationPolicyProvider` fall back to the current shell's `AuthorizationOptions` when a distinct shell `IAuthorizationPolicyProvider` is not available.
- Add regression coverage for FastEndpoints authorization registration and shell-options policy lookup.

## Validation

- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`
