### PR TITLE
Ensure shell authorization provider replaces default provider

### DIFF
--- a/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
@@ -293,8 +293,10 @@ public static class CShellsBuilderExtensions
         {
             Guard.Against.Null(builder);
 
-            // Register the shell-aware authorization policy provider
-            builder.Services.TryAddSingleton<IAuthorizationPolicyProvider, ShellAuthorizationPolicyProvider>();
+            // Register the shell-aware authorization policy provider.
+            // Replace is intentional: AddAuthorization() may already have registered the default provider
+            // before this extension runs, depending on how AddShells callbacks are ordered.
+            builder.Services.Replace(ServiceDescriptor.Singleton<IAuthorizationPolicyProvider, ShellAuthorizationPolicyProvider>());
 
             return builder;
         }
@@ -335,4 +337,3 @@ public static class CShellsBuilderExtensions
         }
     }
 }
-

--- a/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
+++ b/tests/CShells.Tests/Unit/AspNetCore/Authorization/ShellAuthorizationPolicyProviderTests.cs
@@ -1,4 +1,6 @@
 using CShells.AspNetCore.Authorization;
+using CShells.AspNetCore.Configuration;
+using CShells.DependencyInjection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,5 +43,18 @@ public class ShellAuthorizationPolicyProviderTests
         var policy = await _provider.GetPolicyAsync(ShellPolicyName);
 
         Assert.Same(_shellPolicy, policy);
+    }
+
+    [Fact]
+    public void WithAuthorization_ReplacesExistingDefaultAuthorizationPolicyProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddAuthorization();
+        var builder = new CShellsBuilder(services);
+
+        builder.WithAuthorization();
+
+        var descriptor = Assert.Single(services, x => x.ServiceType == typeof(IAuthorizationPolicyProvider));
+        Assert.Equal(typeof(ShellAuthorizationPolicyProvider), descriptor.ImplementationType);
     }
 }


### PR DESCRIPTION
## Summary
- replace any existing root IAuthorizationPolicyProvider when enabling shell authorization
- add regression coverage for the case where AddAuthorization() already registered DefaultAuthorizationPolicyProvider

## Validation
- dotnet test tests/CShells.Tests/CShells.Tests.csproj
- Elsa.ModularServer.Web with CShells project references built successfully
- GET /elsa/api/features/installed and /elsa/api/features/installed/Elsa.Workflows.Api.ShellFeatures.WorkflowsApiFeature returned 401 Unauthorized instead of the previous 500 missing epPolicy exception

## Context
The merged 0.0.24-preview.131 packages still resolved the shell FastEndpoints epPolicy entries into shell AuthorizationOptions, but the root authorization middleware was using Microsoft.AspNetCore.Authorization.DefaultAuthorizationPolicyProvider. Replacing the root provider fixes that remaining ordering issue.