### PR TITLE
Fix shell reload destroying new generation's endpoints

### DIFF
--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -65,8 +65,9 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
 
         if (current == ShellLifecycleState.Deactivating || current == ShellLifecycleState.Disposed)
         {
-            _logger.LogInformation("Removing endpoints for shell '{Shell}' ({State})", shell.Descriptor, current);
-            _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name));
+            _logger.LogInformation("Removing endpoints for shell '{Shell}' generation {Generation} ({State})",
+                shell.Descriptor, shell.Descriptor.Generation, current);
+            _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
         }
 
         return Task.CompletedTask;
@@ -95,6 +96,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var shellEndpointBuilder = new ShellEndpointRouteBuilder(
             endpointRouteBuilder,
             settings.Id,
+            shell.Descriptor.Generation,
             settings,
             shell.ServiceProvider,
             combinedPrefix);

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -57,6 +57,22 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     /// <summary>
+    /// Removes endpoints for a specific shell generation only, leaving newer generations intact.
+    /// </summary>
+    public void RemoveEndpoints(ShellId shellId, int generation)
+    {
+        lock (_lock)
+        {
+            _endpoints.RemoveAll(e =>
+            {
+                var meta = e.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return meta is not null && meta.ShellId.Equals(shellId) && meta.Generation == generation;
+            });
+            NotifyChanged();
+        }
+    }
+
+    /// <summary>
     /// Clears all endpoints.
     /// </summary>
     public void Clear()

--- a/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
@@ -4,5 +4,6 @@ namespace CShells.AspNetCore.Routing;
 /// Metadata attached to endpoints to identify which shell they belong to.
 /// </summary>
 /// <param name="ShellId">The ID of the shell that owns this endpoint.</param>
+/// <param name="Generation">The shell generation that registered this endpoint.</param>
 /// <param name="ShellSettings">The shell settings for this endpoint.</param>
-public record ShellEndpointMetadata(ShellId ShellId, ShellSettings ShellSettings);
+public record ShellEndpointMetadata(ShellId ShellId, int Generation, ShellSettings ShellSettings);

--- a/src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs
@@ -12,6 +12,7 @@ namespace CShells.AspNetCore.Routing;
 public class ShellEndpointRouteBuilder(
     IEndpointRouteBuilder inner,
     ShellId shellId,
+    int generation,
     ShellSettings shellSettings,
     IServiceProvider shellContextServiceProvider,
     string? pathPrefix)
@@ -65,7 +66,7 @@ public class ShellEndpointRouteBuilder(
 
         // Add shell metadata
         var metadata = new EndpointMetadataCollection(
-            routeEndpoint.Metadata.Concat([new ShellEndpointMetadata(shellId, shellSettings)]));
+            routeEndpoint.Metadata.Concat([new ShellEndpointMetadata(shellId, generation, shellSettings)]));
 
         return new RouteEndpoint(
             routeEndpoint.RequestDelegate!,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
         <LangVersion>latest</LangVersion>
 
         <!-- Central base version for all packages; preview builds will append a suffix like -preview.{runNumber} -->
-        <Version>0.0.26</Version>
+        <Version>0.0.27</Version>
 
         <!-- NuGet Package Metadata -->
         <Authors>Sipke Schoorstra</Authors>

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,0 +1,85 @@
+using CShells.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace CShells.Tests.Integration.AspNetCore;
+
+public class DynamicShellEndpointDataSourceTests
+{
+    [Fact(DisplayName = "RemoveEndpoints by generation preserves endpoints from other generations")]
+    public void RemoveByGeneration_PreservesOtherGenerations()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+
+        var gen1Endpoint = CreateEndpoint("default/api/hello", shellId, generation: 1, settings);
+        var gen2Endpoint = CreateEndpoint("default/api/hello", shellId, generation: 2, settings);
+
+        dataSource.AddEndpoints([gen1Endpoint]);
+        dataSource.AddEndpoints([gen2Endpoint]);
+        Assert.Equal(2, dataSource.Endpoints.Count);
+
+        // Remove only generation 1 — simulates old shell deactivating after reload.
+        dataSource.RemoveEndpoints(shellId, generation: 1);
+
+        Assert.Single(dataSource.Endpoints);
+        var remaining = (RouteEndpoint)dataSource.Endpoints[0];
+        Assert.Equal(2, remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    [Fact(DisplayName = "RemoveEndpoints by ShellId removes all generations")]
+    public void RemoveByShellId_RemovesAllGenerations()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+
+        dataSource.AddEndpoints([CreateEndpoint("default/api/a", shellId, 1, settings)]);
+        dataSource.AddEndpoints([CreateEndpoint("default/api/a", shellId, 2, settings)]);
+        Assert.Equal(2, dataSource.Endpoints.Count);
+
+        dataSource.RemoveEndpoints(shellId);
+
+        Assert.Empty(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "Reload sequence: new generation endpoints survive old generation teardown")]
+    public void ReloadSequence_NewEndpointsSurviveOldTeardown()
+    {
+        // Simulates the exact reload sequence from ShellRegistry.ReloadAsync:
+        // 1. New shell (gen 2) transitions Initializing→Active → register gen 2 endpoints
+        // 2. Old shell (gen 1) transitions Active→Deactivating → remove gen 1 endpoints only
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+
+        // Step 0: Initial activation — gen 1 endpoints registered.
+        dataSource.AddEndpoints([CreateEndpoint("default/api/items", shellId, 1, settings)]);
+
+        // Step 1: Reload creates gen 2, which removes-then-adds (as the handler does).
+        dataSource.RemoveEndpoints(shellId);
+        dataSource.AddEndpoints([CreateEndpoint("default/api/items", shellId, 2, settings)]);
+
+        // Step 2: Old gen 1 deactivates — only removes its own generation.
+        dataSource.RemoveEndpoints(shellId, generation: 1);
+
+        // Gen 2 endpoint must survive.
+        Assert.Single(dataSource.Endpoints);
+        var survivor = (RouteEndpoint)dataSource.Endpoints[0];
+        Assert.Equal(2, survivor.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    private static RouteEndpoint CreateEndpoint(string pattern, ShellId shellId, int generation, ShellSettings settings)
+    {
+        return new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            new EndpointMetadataCollection(
+                new ShellEndpointMetadata(shellId, generation, settings),
+                new HttpMethodMetadata(["GET"])),
+            displayName: $"{pattern} (gen {generation})");
+    }
+}

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -98,7 +98,7 @@ public class ShellMiddlewareLazyActivationTests
 
         var settings = new ShellSettings();
         var shellId = new ShellId("acme");
-        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+        var shellMetadata = new ShellEndpointMetadata(shellId, 1, settings);
 
         // Add the int-constrained endpoint FIRST, so structural-only matching would pick it.
         var intHandlerInvoked = false;
@@ -149,7 +149,7 @@ public class ShellMiddlewareLazyActivationTests
         var dataSource = new DynamicShellEndpointDataSource();
         var shellId = new ShellId("Default");
         var settings = new ShellSettings();
-        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+        var shellMetadata = new ShellEndpointMetadata(shellId, 1, settings);
 
         var shellEndpointInvoked = false;
         var shellEndpoint = new RouteEndpoint(
@@ -197,7 +197,7 @@ public class ShellMiddlewareLazyActivationTests
         var dataSource = new DynamicShellEndpointDataSource();
         var shellId = new ShellId("Default");
         var settings = new ShellSettings();
-        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+        var shellMetadata = new ShellEndpointMetadata(shellId, 1, settings);
 
         var shellEndpointInvoked = false;
         var shellEndpoint = new RouteEndpoint(
@@ -245,7 +245,7 @@ public class ShellMiddlewareLazyActivationTests
         var dataSource = new DynamicShellEndpointDataSource();
         var shellId = new ShellId("Default");
         var settings = new ShellSettings();
-        var shellMetadata = new ShellEndpointMetadata(shellId, settings);
+        var shellMetadata = new ShellEndpointMetadata(shellId, 1, settings);
 
         var shellEndpointInvoked = false;
         var shellEndpoint = new RouteEndpoint(


### PR DESCRIPTION
## Summary

- During `ReloadAsync`, the old shell's `Deactivating` transition called `RemoveEndpoints(shellId)` which matched by shell name only, wiping the endpoints the new generation had just registered
- All routes returned 404 after calling `/_admin/shells/reload-all`
- Added `Generation` field to `ShellEndpointMetadata` and a generation-scoped `RemoveEndpoints(shellId, generation)` overload
- The deactivation path now removes only its own generation's endpoints, leaving the new generation's routes intact

## Test plan

- [x] New `DynamicShellEndpointDataSourceTests` covering generation-scoped removal, full removal, and the exact reload sequence
- [x] All 18 existing middleware tests still pass
- [ ] Manual verification: run Elsa.Server, call `POST /_admin/shells/reload-all`, confirm endpoints still respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)