### PR TITLE
Fix shell endpoint teardown during shutdown

### DIFF
--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -44,7 +44,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
     /// <inheritdoc />
     public Task OnStateChangedAsync(IShell shell, ShellLifecycleState previous, ShellLifecycleState current, CancellationToken cancellationToken = default)
     {
-        // Register when a shell becomes Active, tear down when it starts deactivating.
+        // Register when a shell becomes Active, tear down when it starts deactivating or draining.
         if (previous == ShellLifecycleState.Initializing && current == ShellLifecycleState.Active)
         {
             if (_endpointRouteBuilderAccessor.EndpointRouteBuilder is null)
@@ -63,7 +63,9 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             return Task.CompletedTask;
         }
 
-        if (current == ShellLifecycleState.Deactivating || current == ShellLifecycleState.Disposed)
+        if (current == ShellLifecycleState.Deactivating ||
+            current == ShellLifecycleState.Draining ||
+            current == ShellLifecycleState.Disposed)
         {
             _logger.LogInformation("Removing endpoints for shell '{Shell}' generation {Generation} ({State})",
                 shell.Descriptor, shell.Descriptor.Generation, current);

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -38,6 +38,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         lock (_lock)
         {
             var newEndpoints = endpoints.ToList();
+            if (newEndpoints.Count == 0)
+                return;
+
             DetectPathConflicts(newEndpoints);
             _endpoints.AddRange(newEndpoints);
             NotifyChanged();
@@ -51,8 +54,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_lock)
         {
-            _endpoints.RemoveAll(e => e.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) ?? false);
-            NotifyChanged();
+            var removed = _endpoints.RemoveAll(e => e.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) ?? false);
+            if (removed > 0)
+                NotifyChanged();
         }
     }
 
@@ -63,12 +67,13 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_lock)
         {
-            _endpoints.RemoveAll(e =>
+            var removed = _endpoints.RemoveAll(e =>
             {
                 var meta = e.Metadata.GetMetadata<ShellEndpointMetadata>();
                 return meta is not null && meta.ShellId.Equals(shellId) && meta.Generation == generation;
             });
-            NotifyChanged();
+            if (removed > 0)
+                NotifyChanged();
         }
     }
 
@@ -79,6 +84,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_lock)
         {
+            if (_endpoints.Count == 0)
+                return;
+
             _endpoints.Clear();
             NotifyChanged();
         }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,4 +1,7 @@
 using CShells.AspNetCore.Routing;
+using CShells.AspNetCore.Notifications;
+using CShells.Features;
+using CShells.Lifecycle;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -71,6 +74,44 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Equal(2, survivor.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
     }
 
+    [Fact(DisplayName = "No-op endpoint removal does not notify routing")]
+    public void RemoveEndpoints_WhenNoEndpointsRemoved_DoesNotNotify()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+        var changes = 0;
+
+        dataSource.AddEndpoints([CreateEndpoint("default/api/items", shellId, 1, settings)]);
+
+        using var registration = dataSource.GetChangeToken().RegisterChangeCallback(_ => changes++, null);
+
+        dataSource.RemoveEndpoints(shellId, generation: 2);
+
+        Assert.Equal(0, changes);
+        Assert.Single(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "Endpoint registration handler removes endpoints when drain begins")]
+    public async Task Handler_OnDraining_RemovesGenerationEndpoints()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+        var shell = new FakeShell(ShellDescriptor.Create("default", 1));
+        var handler = new ShellEndpointRegistrationHandler(
+            dataSource,
+            new NoopFeatureFactory(),
+            new EndpointRouteBuilderAccessor(),
+            new ApplicationBuilderAccessor());
+
+        dataSource.AddEndpoints([CreateEndpoint("default/api/items", shellId, 1, settings)]);
+
+        await handler.OnStateChangedAsync(shell, ShellLifecycleState.Active, ShellLifecycleState.Draining);
+
+        Assert.Empty(dataSource.Endpoints);
+    }
+
     private static RouteEndpoint CreateEndpoint(string pattern, ShellId shellId, int generation, ShellSettings settings)
     {
         return new RouteEndpoint(
@@ -81,5 +122,25 @@ public class DynamicShellEndpointDataSourceTests
                 new ShellEndpointMetadata(shellId, generation, settings),
                 new HttpMethodMetadata(["GET"])),
             displayName: $"{pattern} (gen {generation})");
+    }
+
+    private sealed class FakeShell(ShellDescriptor descriptor) : IShell
+    {
+        public ShellDescriptor Descriptor { get; } = descriptor;
+
+        public ShellLifecycleState State => ShellLifecycleState.Active;
+
+        public IServiceProvider ServiceProvider => throw new NotSupportedException();
+
+        public IDrainOperation? Drain => null;
+
+        public IShellScope BeginScope() => throw new NotSupportedException();
+    }
+
+    private sealed class NoopFeatureFactory : IShellFeatureFactory
+    {
+        public T CreateFeature<T>(Type featureType, ShellSettings? shellSettings = null, ShellFeatureContext? featureContext = null)
+            where T : class =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -98,7 +98,7 @@ public class DynamicShellEndpointDataSourceTests
         var dataSource = new DynamicShellEndpointDataSource();
         var shellId = new ShellId("default");
         var settings = new ShellSettings();
-        var shell = new FakeShell(ShellDescriptor.Create("default", 1));
+        var shell = new FakeShell(ShellDescriptor.Create("default", 1), ShellLifecycleState.Draining);
         var handler = new ShellEndpointRegistrationHandler(
             dataSource,
             new NoopFeatureFactory(),
@@ -124,11 +124,11 @@ public class DynamicShellEndpointDataSourceTests
             displayName: $"{pattern} (gen {generation})");
     }
 
-    private sealed class FakeShell(ShellDescriptor descriptor) : IShell
+    private sealed class FakeShell(ShellDescriptor descriptor, ShellLifecycleState state) : IShell
     {
         public ShellDescriptor Descriptor { get; } = descriptor;
 
-        public ShellLifecycleState State => ShellLifecycleState.Active;
+        public ShellLifecycleState State { get; } = state;
 
         public IServiceProvider ServiceProvider => throw new NotSupportedException();
 


### PR DESCRIPTION
## Summary
- remove shell endpoints when a shell enters Draining so shutdown paths tear down routes before disposal
- suppress dynamic endpoint change notifications for no-op add/remove/clear operations
- add regression tests for drain-time endpoint removal and no-op removal notifications

## Validation
- dotnet test tests/CShells.Tests/
- dotnet test tests/CShells.Tests.EndToEnd/