### PR TITLE
[codex] Update shell lifecycle docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ CShells is a multi-package library. Package separation is intentional and enforc
 | Main ASP.NET Core app | `CShells` + `CShells.AspNetCore` |
 
 **Data flow at startup:**
-`AddShells()`/`AddCShellsAspNetCore()` → `IShellSettingsProvider` loads `ShellSettings` into `ShellSettingsCache` → `DefaultShellHost` (lazy) builds a per-shell `IServiceProvider` from root services + feature `ConfigureServices` calls → `ShellMiddleware` resolves the shell per request via `IShellResolverStrategy` and swaps `HttpContext.RequestServices` to the shell's scoped provider.
+`AddCShells()`/`AddCShellsAspNetCore()` → a single `IShellBlueprintProvider` owns shell blueprints → `IShellRegistry` lazily activates shell generations → `ShellProviderBuilder` builds a per-shell `IServiceProvider` from root services + feature `ConfigureServices` calls → `ShellMiddleware` resolves the shell per request via `IShellResolverStrategy` and swaps `HttpContext.RequestServices` to the shell's scoped provider.
 
-Root service descriptors are **bulk-copied** into each shell's `IServiceCollection`. CShells infrastructure types (`IShellHost`, `IShellContextScopeFactory`, `IRootServiceCollectionAccessor`, `IShellManager`) are excluded from this copy — see `DefaultShellServiceExclusionProvider`.
+Root service descriptors are **bulk-copied** into each shell's `IServiceCollection`. CShells infrastructure types such as `IRootServiceCollectionAccessor`, `IShellRegistry`, lifecycle services, and feature discovery/build services are excluded from this copy — see `DefaultShellServiceExclusionProvider`. `IShellRegistry` is re-registered inside shell providers as a root delegation.
 
 ## Feature System
 
@@ -83,15 +83,15 @@ Register custom strategies with `.ConfigureResolverPipeline(pipeline => pipeline
 
 ## Runtime Shell Management
 
-`IShellManager` supports hot add/remove/update/reload without app restart. `DynamicShellEndpointDataSource` signals ASP.NET Core routing to re-enumerate endpoints via `IChangeToken`. Lifecycle events are published as notifications (`ShellActivated`, `ShellDeactivating`, `ShellAdded`, `ShellRemoved`, `ShellReloaded`, etc.) — subscribe by implementing `INotificationHandler<T>`.
+`IShellRegistry` supports lazy activation, reload, unregister, drain, and active-shell enumeration without app restart. Mutable blueprint sources expose `IShellBlueprintManager` for persisted create/update/delete operations. `DynamicShellEndpointDataSource` signals ASP.NET Core routing to re-enumerate endpoints via `IChangeToken`. Lifecycle changes are published through `IShellLifecycleSubscriber`.
 
 ## Background Workers
 
-Use `IShellContextScopeFactory` to work within a shell's DI scope outside an HTTP request:
+Use `IShellRegistry` to select shells and `IShell.BeginScope()` to work within a shell's DI scope outside an HTTP request:
 ```csharp
-foreach (var shell in shellHost.AllShells)
+foreach (var shell in registry.GetActiveShells())
 {
-    using var scope = scopeFactory.CreateScope(shell);
+    await using var scope = shell.BeginScope();
     var svc = scope.ServiceProvider.GetRequiredService<IMyService>();
 }
 ```
@@ -120,7 +120,7 @@ When asked to review or address PR review comments, think critically about each 
 ## Testing Patterns
 
 - Unit tests → `tests/CShells.Tests/Unit/`
-- Integration tests → `tests/CShells.Tests/Integration/`; use `DefaultShellHostFixture` (in `TestHelpers/`) to construct `DefaultShellHost` instances
+- Integration tests → `tests/CShells.Tests/Integration/`; use focused fixtures in `TestHelpers/` and `ManagementApiFixture` for management endpoint coverage
 - E2E tests → `tests/CShells.Tests.EndToEnd/` via `WebApplicationFactory<Program>`
 - `TestFixtures.CreateRootServices()` produces a minimal root `IServiceCollection`/`IServiceProvider` for test isolation
 - Test file names mirror the class under test with a `Tests` suffix
@@ -138,11 +138,11 @@ When asked to review or address PR review comments, think critically about each 
 | Purpose | Path |
 |---|---|
 | Feature interfaces | `src/CShells.Abstractions/Features/` |
-| Shell host (core orchestrator) | `src/CShells/Hosting/DefaultShellHost.cs` |
+| Shell registry (core orchestrator) | `src/CShells/Lifecycle/ShellRegistry.cs` |
 | Feature discovery (reflection) | `src/CShells/Features/FeatureDiscovery.cs` |
 | ASP.NET Core wiring | `src/CShells.AspNetCore/Extensions/ApplicationBuilderExtensions.cs` |
 | Reference feature implementations | `samples/CShells.Workbench.Features/` |
-| Integration test helper | `tests/CShells.Tests/TestHelpers/DefaultShellHostFixture.cs` |
+| Integration test helpers | `tests/CShells.Tests/TestHelpers/` |
 
 
 ## Active Technologies

--- a/README.md
+++ b/README.md
@@ -481,55 +481,55 @@ builder.AddShells(cshells =>
 });
 ```
 
-#### 4. Custom Provider
+#### 4. Custom Blueprint Provider
 
 ```csharp
-public class DatabaseShellSettingsProvider : IShellSettingsProvider
+public class DatabaseShellBlueprintProvider : IShellBlueprintProvider
 {
-    public async Task<IEnumerable<ShellSettings>> GetAllAsync()
+    public async Task<ProvidedBlueprint?> GetAsync(string name, CancellationToken cancellationToken = default)
     {
         // Load from database, API, etc.
-        return Enumerable.Empty<ShellSettings>();
+        var settings = await LoadSettingsAsync(name, cancellationToken);
+        return settings is null ? null : new ProvidedBlueprint(new DatabaseShellBlueprint(settings));
     }
+
+    public Task<BlueprintPage> ListAsync(BlueprintListQuery query, CancellationToken cancellationToken = default) =>
+        // Return paged BlueprintSummary rows for your source.
+        throw new NotImplementedException();
 }
 
 builder.AddShells(cshells =>
 {
-    cshells.WithProvider<DatabaseShellSettingsProvider>();
+    cshells.AddBlueprintProvider(sp => sp.GetRequiredService<DatabaseShellBlueprintProvider>());
 });
 ```
 
-## Shell Context Scopes & Background Work
+`DatabaseShellBlueprint` is your `IShellBlueprint` implementation that composes fresh `ShellSettings` for a tenant.
 
-Shell context scopes provide a way to create scoped services within a shell's service provider. This is particularly useful for background workers or other services that need to execute work in the context of each shell.
+## Shell Scopes & Background Work
 
-### Creating Shell Context Scopes
+Shell scopes provide a way to create scoped services within a shell's service provider. This is particularly useful for background workers or other services that need to execute work in the context of each shell.
 
-Use `IShellContextScopeFactory` to create scopes for shell contexts:
+### Creating Shell Scopes
+
+Use `IShellRegistry` to select active shells, then call `IShell.BeginScope()` to create a tracked scope for a shell:
 
 ```csharp
 using CShells;
+using CShells.Lifecycle;
+using Microsoft.Extensions.DependencyInjection;
 
-public class MyService
+public class MyService(IShellRegistry registry)
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellContextScopeFactory _scopeFactory;
-
-    public MyService(IShellHost shellHost, IShellContextScopeFactory scopeFactory)
+    public async Task DoWorkAsync()
     {
-        _shellHost = shellHost;
-        _scopeFactory = scopeFactory;
-    }
-
-    public void DoWork()
-    {
-        foreach (var shell in _shellHost.AllShells)
+        foreach (var shell in registry.GetActiveShells())
         {
-            using var scope = _scopeFactory.CreateScope(shell);
+            await using var scope = shell.BeginScope();
 
             // Resolve scoped services from the shell's service provider
             var myService = scope.ServiceProvider.GetRequiredService<IMyService>();
-            myService.Execute();
+            await myService.ExecuteAsync();
         }
     }
 }
@@ -541,40 +541,30 @@ Here's an example of a background service that executes work for each shell:
 
 ```csharp
 using CShells;
+using CShells.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-public class ShellBackgroundWorker : BackgroundService
+public class ShellBackgroundWorker(
+    IShellRegistry registry,
+    ILogger<ShellBackgroundWorker> logger) : BackgroundService
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellContextScopeFactory _scopeFactory;
-    private readonly ILogger<ShellBackgroundWorker> _logger;
-
-    public ShellBackgroundWorker(
-        IShellHost shellHost,
-        IShellContextScopeFactory scopeFactory,
-        ILogger<ShellBackgroundWorker> logger)
-    {
-        _shellHost = shellHost;
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-    }
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            foreach (var shell in _shellHost.AllShells)
+            foreach (var shell in registry.GetActiveShells())
             {
-                using var scope = _scopeFactory.CreateScope(shell);
+                await using var scope = shell.BeginScope();
 
                 // Execute work in the shell's context
-                _logger.LogInformation("Background work executed for shell '{ShellId}'", shell.Id.Name);
+                logger.LogInformation("Background work executed for shell '{Shell}'", shell.Descriptor);
 
                 // Resolve and use scoped services
                 var service = scope.ServiceProvider.GetService<IMyService>();
-                service?.Execute();
+                if (service is not null)
+                    await service.ExecuteAsync(stoppingToken);
             }
 
             await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -10,18 +10,15 @@ This page describes the internal design of CShells: how shells are hosted, how f
 ┌─────────────────────────────────────────────────────────────────┐
 │  Application (ASP.NET Core / Generic Host)                      │
 │                                                                 │
-│  AddShells() ──► IShellSettingsProvider(s)                      │
+│  AddCShells() ──► IShellBlueprintProvider                       │
 │                        │                                        │
 │                        ▼                                        │
-│                  ShellSettingsCache                             │
-│                        │                                        │
-│                        ▼                                        │
-│                    IShellHost                                   │
-│                  (DefaultShellHost)                             │
+│                   IShellRegistry                                │
+│                 (lazy activation)                               │
 │            ┌──────────┴──────────┐                             │
 │            ▼                     ▼                             │
-│       ShellContext           ShellContext                       │
-│   (Shell A: IServiceProvider) (Shell B: IServiceProvider)      │
+│        IShell A              IShell B                           │
+│   (Shell A: IServiceProvider) (Shell B: IServiceProvider)       │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -34,9 +31,10 @@ This page describes the internal design of CShells: how shells are hosted, how f
 A **Shell** is an isolated execution context. It owns:
 
 - A `ShellId` (unique string identifier)
+- A generation descriptor (`ShellDescriptor`)
 - A list of enabled feature names
 - A `ShellSettings` object with configuration data
-- A `ShellContext` containing the shell's built `IServiceProvider`
+- An `IShell` containing the shell's built `IServiceProvider`
 
 Shells do **not** share service instances. Each shell's container starts from a copy of the root application services and then applies its own feature registrations on top.
 
@@ -49,19 +47,19 @@ A **Feature** is a class that implements `IShellFeature` (or a sub-interface). I
 - Can declare dependencies on other features
 - Can optionally register HTTP endpoints (`IWebShellFeature`), middleware (`IMiddlewareShellFeature`), or post-configuration hooks (`IPostConfigureShellServices`)
 
-### Shell Host
+### Shell Registry
 
-`IShellHost` (implemented by `DefaultShellHost`) manages the lifecycle of all shells:
+`IShellRegistry` manages active shell generations:
 
-1. Reads `ShellSettings` from the `ShellSettingsCache`.
-2. Discovers features by scanning assemblies for `IShellFeature` implementations.
+1. Looks up shell blueprints from the configured `IShellBlueprintProvider`.
+2. Composes fresh `ShellSettings` when a shell is activated or reloaded.
 3. Resolves feature dependencies (topological sort).
-4. Builds an `IServiceProvider` per shell.
-5. Caches the resulting `ShellContext` instances.
+4. Builds an `IServiceProvider` per shell generation.
+5. Tracks active generations and coordinates drain/disposal for replaced generations.
 
-### Shell Settings Cache
+### Shell Blueprint Provider
 
-`ShellSettingsCache` is the central store for all shell configurations. It is populated at startup by the registered `IShellSettingsProvider` implementations. `IShellManager` writes to it at runtime to add, remove, or update shells.
+`IShellBlueprintProvider` is the source of shell blueprints. Code-defined shells use the built-in in-memory provider populated by `AddShell(...)`; external sources register a single provider with `AddBlueprintProvider(...)` or a provider-specific extension. Mutable sources can attach an `IShellBlueprintManager` for persisted create/update/delete operations.
 
 ---
 
@@ -70,10 +68,13 @@ A **Feature** is a class that implements `IShellFeature` (or a sub-interface). I
 ### `ShellId`
 
 ```csharp
-public readonly record struct ShellId(string Value);
+public readonly record struct ShellId
+{
+    public string Name { get; }
+}
 ```
 
-Unique identifier for a shell. Equality is case-sensitive.
+Unique identifier for a shell. Equality is case-insensitive.
 
 ### `ShellSettings`
 
@@ -89,17 +90,19 @@ public class ShellSettings
 
 `ConfigurationData` holds configuration key/value pairs for the shell (e.g., `"WebRouting:Path"` → `""`) which are used to build the shell's `IConfiguration`. `FeatureConfigurators` stores code-first delegates applied to feature instances at build time.
 
-### `ShellContext`
+### `IShell`
 
 ```csharp
-public class ShellContext
+public interface IShell
 {
-    public ShellSettings Settings { get; }
-    public IServiceProvider Services { get; }
+    ShellDescriptor Descriptor { get; }
+    ShellLifecycleState State { get; }
+    IServiceProvider ServiceProvider { get; }
+    IShellScope BeginScope();
 }
 ```
 
-The runtime representation of a shell. Access it via `IShellHost`.
+The runtime representation of a shell generation. Access active generations through `IShellRegistry` or inject `IShell` from a shell-scoped service provider.
 
 ### `ShellFeatureAttribute`
 
@@ -134,7 +137,7 @@ public class ShellFeatureContext
 
 ## Feature Discovery
 
-At startup, `DefaultShellHost` scans the provided assemblies (all loaded assemblies by default) for:
+At activation time, the runtime feature catalog scans the configured feature assemblies for:
 
 - Any non-abstract class implementing `IShellFeature` or a sub-interface
 
@@ -166,7 +169,7 @@ Features are instantiated with the **root** `IServiceProvider` (not the shell's)
 Each shell's `IServiceProvider` is built by:
 
 1. Copying all registrations from the root `IServiceCollection`.
-2. Adding `ShellSettings` and `ShellFeatureContext` as singleton registrations.
+2. Adding `ShellSettings`, `ShellId`, `IShell`, and shell feature descriptors as singleton registrations.
 3. Building a shell-specific `IConfiguration` from `ShellSettings.ConfigurationData`.
 4. Calling `ConfigureServices(services)` on each feature in topological order.
 5. Calling `PostConfigureServices(services)` on features implementing `IPostConfigureShellServices`.
@@ -183,8 +186,8 @@ Services registered in the root application (e.g., `ILogger<T>`, `IHttpClientFac
 `MapShells()` inserts `ShellMiddleware` into the pipeline. For each request, the middleware:
 
 1. Runs the registered `IShellResolver` strategies in priority order.
-2. Finds the matching `ShellContext`.
-3. Creates a scoped `IServiceProvider` from the shell's container.
+2. Gets or activates the matching `IShell` from `IShellRegistry`.
+3. Creates a tracked scope from the shell with `IShell.BeginScope()`.
 4. Sets `HttpContext.RequestServices` to the shell-scoped provider.
 5. Passes control to the next middleware (endpoint routing).
 
@@ -205,18 +208,7 @@ Services registered in the root application (e.g., `ILogger<T>`, `IHttpClientFac
 
 ## Notification System
 
-CShells publishes `INotification` records during shell lifecycle events:
-
-| Notification | Trigger |
-|---|---|
-| `ShellActivated` | Shell DI container built |
-| `ShellDeactivating` | Shell about to be shut down |
-| `ShellAdded` | Shell added via `IShellManager` |
-| `ShellRemoved` | Shell removed via `IShellManager` |
-| `ShellUpdated` | Shell updated via `IShellManager` |
-| `ShellsReloaded` | All shells reloaded |
-
-Register `INotificationHandler<TNotification>` implementations to react to these events.
+CShells publishes lifecycle transitions to registered `IShellLifecycleSubscriber` implementations. Use subscribers for cross-cutting runtime reactions such as logging, telemetry, endpoint registration, and cleanup coordination.
 
 ---
 
@@ -224,9 +216,9 @@ Register `INotificationHandler<TNotification>` implementations to react to these
 
 | Extension Point | Interface | Purpose |
 |---|---|---|
-| Shell settings source | `IShellSettingsProvider` | Load shell configs from any backend |
+| Shell blueprint source | `IShellBlueprintProvider` | Load shell blueprints from any backend |
 | Shell resolution | `IShellResolverStrategy` | Custom per-request shell matching |
 | Service exclusions | `IShellServiceExclusionProvider` | Prevent root services from being copied into shells |
-| Lifecycle events | `INotificationHandler<T>` | React to shell lifecycle transitions |
+| Lifecycle events | `IShellLifecycleSubscriber` | React to shell lifecycle transitions |
 | Post-build config | `IPostConfigureShellServices` | Finalize DI registrations after all features run |
 | Dependency inference | `IInfersDependenciesFrom<T>` | Automatically inherit another feature's dependencies |

--- a/wiki/Background-Workers.md
+++ b/wiki/Background-Workers.md
@@ -1,21 +1,21 @@
 # Background Workers
 
-CShells provides `IShellContextScopeFactory` to execute work within the context of a specific shell. Use it in background services, scheduled jobs, or any non-HTTP workload that needs access to shell-scoped services.
+CShells exposes active shell generations through `IShellRegistry`. Use `IShell.BeginScope()` in background services, scheduled jobs, or any non-HTTP workload that needs access to shell-scoped services.
 
 ---
 
-## `IShellContextScopeFactory`
+## `IShell.BeginScope()`
 
-`IShellContextScopeFactory` creates a `IShellContextScope` — a lightweight scope wrapping a shell's `IServiceProvider`.
+`IShell.BeginScope()` creates a tracked `IShellScope` wrapping a shell's `IServiceProvider`.
 
 ```csharp
-public interface IShellContextScopeFactory
+public interface IShell
 {
-    IShellContextScope CreateScope(ShellContext shell);
+    IShellScope BeginScope();
 }
 ```
 
-The scope is `IDisposable`. Always dispose it when you're done to release scoped resources.
+The scope is `IAsyncDisposable`. Always dispose it when you're done to release scoped resources and decrement the shell's active-scope counter.
 
 ---
 
@@ -25,38 +25,26 @@ The most common pattern is iterating over all shells and performing work for eac
 
 ```csharp
 using CShells;
-using CShells.Hosting;
+using CShells.Lifecycle;
 using Microsoft.Extensions.Hosting;
 
-public class DataSyncWorker : BackgroundService
+public class DataSyncWorker(
+    IShellRegistry registry,
+    ILogger<DataSyncWorker> logger) : BackgroundService
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellContextScopeFactory _scopeFactory;
-    private readonly ILogger<DataSyncWorker> _logger;
-
-    public DataSyncWorker(
-        IShellHost shellHost,
-        IShellContextScopeFactory scopeFactory,
-        ILogger<DataSyncWorker> logger)
-    {
-        _shellHost = shellHost;
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-    }
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            foreach (var shell in _shellHost.AllShells)
+            foreach (var shell in registry.GetActiveShells())
             {
-                using var scope = _scopeFactory.CreateScope(shell);
+                await using var scope = shell.BeginScope();
 
                 var syncService = scope.ServiceProvider.GetService<IDataSyncService>();
                 if (syncService is not null)
                     await syncService.SyncAsync(stoppingToken);
                 else
-                    _logger.LogDebug("Shell '{Shell}' does not have IDataSyncService", shell.Settings.Id.Value);
+                    logger.LogDebug("Shell '{Shell}' does not have IDataSyncService", shell.Descriptor);
             }
 
             await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
@@ -78,22 +66,15 @@ builder.Services.AddHostedService<DataSyncWorker>();
 If you need to target one specific shell:
 
 ```csharp
-public class TenantReportGenerator
+using CShells.Lifecycle;
+
+public class TenantReportGenerator(IShellRegistry registry)
 {
-    private readonly IShellHost _shellHost;
-    private readonly IShellContextScopeFactory _scopeFactory;
-
-    public TenantReportGenerator(IShellHost shellHost, IShellContextScopeFactory scopeFactory)
-    {
-        _shellHost = shellHost;
-        _scopeFactory = scopeFactory;
-    }
-
     public async Task GenerateReportAsync(string tenantId, CancellationToken ct)
     {
-        var shell = _shellHost.GetShell(new ShellId(tenantId));
+        var shell = await registry.GetOrActivateAsync(tenantId, ct);
 
-        using var scope = _scopeFactory.CreateScope(shell);
+        await using var scope = shell.BeginScope();
 
         var reportService = scope.ServiceProvider.GetRequiredService<IReportService>();
         await reportService.GenerateAsync(ct);
@@ -108,9 +89,9 @@ public class TenantReportGenerator
 A shell may or may not have a particular feature enabled. Use `GetService<T>()` (nullable) instead of `GetRequiredService<T>()` when a service is optional:
 
 ```csharp
-foreach (var shell in _shellHost.AllShells)
+foreach (var shell in registry.GetActiveShells())
 {
-    using var scope = _scopeFactory.CreateScope(shell);
+    await using var scope = shell.BeginScope();
 
     var processor = scope.ServiceProvider.GetService<IQueueProcessor>();
     if (processor is null)
@@ -134,7 +115,7 @@ public class NotificationsFeature : IShellFeature
     {
         services.AddSingleton<INotificationSender, EmailNotificationSender>();
         // The worker is registered in the root DI container (not shell-scoped)
-        // and uses IShellContextScopeFactory to access shell services
+        // and uses IShellRegistry + IShell.BeginScope() to access shell services
     }
 }
 ```
@@ -149,7 +130,7 @@ builder.Services.AddHostedService<NotificationDispatchWorker>();
 
 ## Tips
 
-- **Always dispose scopes** — `IShellContextScope` is `IDisposable`. Use `using` or `await using` as appropriate.
+- **Always dispose scopes** — `IShellScope` is `IAsyncDisposable`. Use `await using`.
 - **Use `GetService<T>()` for optional services** — not all shells will have all features enabled.
-- **Re-query `IShellHost.AllShells` on each iteration** — the shell list can change at runtime when shells are added or removed.
-- **Access `IShellHost` via injection, not closure** — always use the injected `IShellHost` reference; do not capture it in a static variable.
+- **Re-query `IShellRegistry.GetActiveShells()` on each iteration** — the shell list can change at runtime when shells are added, removed, or reloaded.
+- **Access `IShellRegistry` via injection, not closure** — always use the injected `IShellRegistry` reference; do not capture it in a static variable.

--- a/wiki/Configuring-Shells.md
+++ b/wiki/Configuring-Shells.md
@@ -148,31 +148,36 @@ The FluentStorage provider supports Azure Blob Storage, AWS S3, and other backen
 
 ---
 
-## Option D: Custom Provider
+## Option D: Custom Blueprint Provider
 
-Implement `IShellSettingsProvider` to load shells from any source (database, API, etc.):
+Implement `IShellBlueprintProvider` to load shell blueprints from any source (database, API, etc.):
 
 ```csharp
-public class DatabaseShellSettingsProvider : IShellSettingsProvider
+using CShells.Lifecycle;
+
+public class DatabaseShellBlueprintProvider : IShellBlueprintProvider
 {
     private readonly AppDbContext _dbContext;
 
-    public DatabaseShellSettingsProvider(AppDbContext dbContext)
+    public DatabaseShellBlueprintProvider(AppDbContext dbContext)
     {
         _dbContext = dbContext;
     }
 
-    public async Task<IEnumerable<ShellSettings>> GetShellSettingsAsync(
-        CancellationToken cancellationToken = default)
+    public async Task<ProvidedBlueprint?> GetAsync(string name, CancellationToken cancellationToken = default)
     {
-        var tenants = await _dbContext.Tenants
-            .Where(t => t.IsActive)
-            .ToListAsync(cancellationToken);
+        var tenant = await _dbContext.Tenants
+            .SingleOrDefaultAsync(t => t.Id == name && t.IsActive, cancellationToken);
 
-        return tenants.Select(t => new ShellSettings(
-            new ShellId(t.Id.ToString()),
-            t.EnabledFeatures));
+        if (tenant is null)
+            return null;
+
+        return new ProvidedBlueprint(new DatabaseShellBlueprint(tenant));
     }
+
+    public Task<BlueprintPage> ListAsync(BlueprintListQuery query, CancellationToken cancellationToken = default) =>
+        // Return paged BlueprintSummary rows for your source.
+        throw new NotImplementedException();
 }
 ```
 
@@ -181,37 +186,41 @@ Register it:
 ```csharp
 builder.AddShells(cshells =>
 {
-    cshells.WithProvider<DatabaseShellSettingsProvider>();
+    cshells.AddBlueprintProvider(sp => sp.GetRequiredService<DatabaseShellBlueprintProvider>());
 });
 ```
 
+`DatabaseShellBlueprint` is your `IShellBlueprint` implementation that composes fresh `ShellSettings` for a tenant.
+
 ---
 
-## Multiple Providers
+## Provider Selection
 
-You can register multiple providers. They are queried in registration order; if two providers return a shell with the same name, **the last one wins**.
+CShells uses exactly one blueprint provider per host. Code-first `AddShell(...)` registrations use the built-in in-memory provider; external sources register a single provider through `AddBlueprintProvider(...)` or a provider-specific extension.
 
 ```csharp
 builder.AddShells(cshells =>
 {
-    // 1. Code-first defaults
+    // Code-first provider:
     cshells.AddShell("Default", shell => shell.WithFeatures("Core"));
+});
 
-    // 2. Configuration from appsettings.json (may override code-first)
+builder.AddShells(cshells =>
+{
+    // External configuration provider:
     cshells.WithConfigurationProvider(builder.Configuration);
+});
 
-    // 3. Database overrides (overrides anything above for matching shell names)
-    cshells.WithProvider<DatabaseShellSettingsProvider>();
+builder.AddShells(cshells =>
+{
+    // Custom external provider:
+    cshells.AddBlueprintProvider(sp => sp.GetRequiredService<DatabaseShellBlueprintProvider>());
 });
 ```
 
-This pattern is useful for:
+Do not mix `AddShell(...)` and `AddBlueprintProvider(...)` on the same host. If you need several backing stores, implement one custom `IShellBlueprintProvider` that combines them internally.
 
-- **Multi-environment**: Base config in `appsettings.json`, environment overrides from a database or environment variables.
-- **Progressive migration**: Legacy shells from one provider, migrated shells from another.
-- **Development overrides**: Production config with debug shells layered on top in development.
-
-See [Multiple Providers](Multiple-Shell-Providers) for detailed patterns and examples.
+See [Shell Blueprint Providers](Multiple-Shell-Providers) for provider patterns and examples.
 
 ---
 
@@ -233,8 +242,6 @@ Example: with `Path = "acme"` and `RoutePrefix = "api/v1"`, an endpoint mapped a
 
 | Provider | Class | Use Case |
 |---|---|---|
-| Configuration | `ConfigurationShellSettingsProvider` | `appsettings.json` and any `IConfiguration` source |
-| In-memory (immutable) | `InMemoryShellSettingsProvider` | Code-first, testing |
-| In-memory (mutable) | `MutableInMemoryShellSettingsProvider` | Dynamic runtime scenarios |
-| Composite | `CompositeShellSettingsProvider` | Aggregates multiple providers (used automatically) |
-| FluentStorage | `FluentStorageShellSettingsProvider` | Files on disk or cloud storage |
+| Configuration | `ConfigurationShellBlueprintProvider` | `appsettings.json` and any `IConfiguration` source |
+| In-memory | `InMemoryShellBlueprintProvider` | Code-first, testing |
+| FluentStorage | `FluentStorageShellBlueprintProvider` | Files on disk or cloud storage |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -10,7 +10,7 @@ CShells gives your application a structured way to define isolated **shells**, e
 
 - Each shell has its **own `IServiceProvider`** — services are fully isolated between shells.
 - Features are **discovered automatically** by scanning assemblies for types that implement `IShellFeature`.
-- Shell configuration comes from **`appsettings.json`**, external JSON files, code, a database, or any custom `IShellSettingsProvider`.
+- Shell configuration comes from **`appsettings.json`**, external JSON files, code, a database, or any custom `IShellBlueprintProvider`.
 
 ---
 
@@ -51,7 +51,7 @@ CShells gives your application a structured way to define isolated **shells**, e
 | [Configuring Shells](Configuring-Shells) | `appsettings.json`, code-first, FluentStorage, custom providers, multiple providers |
 | [Shell Resolution](Shell-Resolution) | Path, host, header, claim-based, and custom resolvers |
 | [Runtime Shell Management](Runtime-Shell-Management) | Add, remove, and update shells at runtime |
-| [Background Workers](Background-Workers) | Using `IShellContextScopeFactory` in background services |
+| [Background Workers](Background-Workers) | Using `IShellRegistry` and `IShell.BeginScope()` in background services |
 | [Integration Patterns](Integration-Patterns) | Safely integrating CShells into existing ASP.NET Core apps |
 | [FastEndpoints Integration](FastEndpoints-Integration) | Per-shell FastEndpoints support |
 | [Architecture](Architecture) | Internal design: shell host, feature discovery, DI, middleware |

--- a/wiki/Multiple-Shell-Providers.md
+++ b/wiki/Multiple-Shell-Providers.md
@@ -1,48 +1,14 @@
-# Multiple Shell Providers
+# Shell Blueprint Providers
 
-CShells supports registering multiple shell settings providers that are combined automatically. This allows you to load shells from different sources and compose them flexibly.
+CShells uses exactly one `IShellBlueprintProvider` per host. Code-first `AddShell(...)` registrations use the built-in in-memory provider. External sources register their provider through `AddBlueprintProvider(...)` or a provider-specific extension such as `WithConfigurationProvider(...)` or `WithFluentStorageBlueprints(...)`.
 
----
-
-## How It Works
-
-Providers are queried in the order they are registered. Each provider returns a list of `ShellSettings`. The results are merged by shell name: **the last provider to return a shell with a given name wins**.
-
-```
-Provider 1 (code-first)     Provider 2 (appsettings.json)     Provider 3 (database)
-      │                              │                               │
-      └──────────────────────────────┴───────────────────────────────┘
-                                     │
-                              Composite merge
-                          (last provider wins by ID)
-                                     │
-                              ShellSettingsCache
-```
-
----
-
-## Registering Multiple Providers
-
-```csharp
-builder.AddShells(cshells =>
-{
-    // 1. Code-first defaults
-    cshells.AddShell("Default", shell => shell
-        .WithFeatures("Core", "Starter"));
-
-    // 2. appsettings.json (overrides code-first for matching names)
-    cshells.WithConfigurationProvider(builder.Configuration);
-
-    // 3. Database (overrides anything above for matching names)
-    cshells.WithProvider<DatabaseShellSettingsProvider>();
-});
-```
+If you need to combine several sources, implement one custom provider that performs the fan-out internally and register only that provider. The runtime intentionally avoids implicit multi-provider merging so lookup, paging, and ownership are deterministic.
 
 ---
 
 ## Provider Registration Methods
 
-### `AddShell` — Code-First
+### `AddShell` - Code-First
 
 ```csharp
 cshells.AddShell("Tenant1", shell => shell
@@ -50,9 +16,9 @@ cshells.AddShell("Tenant1", shell => shell
     .WithConfiguration("WebRouting:Path", "tenant1"));
 ```
 
-Code-first shells are collected first and form the base layer.
+Code-first shells are read-only blueprints backed by the built-in in-memory provider.
 
-### `WithConfigurationProvider` — `appsettings.json`
+### `WithConfigurationProvider` - `appsettings.json`
 
 ```csharp
 cshells.WithConfigurationProvider(builder.Configuration);
@@ -60,73 +26,19 @@ cshells.WithConfigurationProvider(builder.Configuration);
 cshells.WithConfigurationProvider(builder.Configuration, "TenantConfig");
 ```
 
-### `WithProvider<T>` — Type-Registered Provider
+Configuration-backed blueprints re-read their configuration when composed for activation or reload.
 
-The provider type is resolved from DI at startup, so it can receive constructor dependencies:
-
-```csharp
-cshells.WithProvider<DatabaseShellSettingsProvider>();
-```
-
-### `WithProvider(instance)` — Instance
-
-```csharp
-var provider = new InMemoryShellSettingsProvider(myShells);
-cshells.WithProvider(provider);
-```
-
-### `WithProvider(factory)` — Factory Function
-
-```csharp
-cshells.WithProvider(sp =>
-    new DatabaseShellSettingsProvider(sp.GetRequiredService<AppDbContext>()));
-```
-
----
-
-## Common Patterns
-
-### Multi-Tenant SaaS
+### `AddBlueprintProvider` - Custom Provider
 
 ```csharp
 builder.AddShells(cshells =>
 {
-    // Fallback defaults for new/unknown tenants
-    cshells.AddShell("Default", shell => shell.WithFeatures("Core", "Starter"));
-
-    // Active tenants from database
-    cshells.WithProvider<ActiveTenantsProvider>();
+    cshells.AddBlueprintProvider(sp =>
+        sp.GetRequiredService<DatabaseShellBlueprintProvider>());
 });
 ```
 
-### Environment-Based Overrides
-
-```csharp
-builder.AddShells(cshells =>
-{
-    // Base config from appsettings.json
-    cshells.WithConfigurationProvider(builder.Configuration);
-
-    if (builder.Environment.IsDevelopment())
-    {
-        // Add debug shells on top, or override existing ones
-        cshells.AddShell("Debug", shell => shell.WithFeatures("Core", "Debug", "Swagger"));
-    }
-});
-```
-
-### Progressive Migration
-
-```csharp
-builder.AddShells(cshells =>
-{
-    // Legacy shells from old system
-    cshells.WithProvider<LegacyShellProvider>();
-
-    // Migrated shells from new system (override legacy ones by same ID)
-    cshells.WithProvider<NewDatabaseShellProvider>();
-});
-```
+The provider type is resolved from DI, so it can receive constructor dependencies.
 
 ---
 
@@ -134,47 +46,33 @@ builder.AddShells(cshells =>
 
 | Type | Description |
 |---|---|
-| `InMemoryShellSettingsProvider` | Immutable in-memory list (used internally for code-first shells) |
-| `MutableInMemoryShellSettingsProvider` | Thread-safe, mutable in-memory list for dynamic scenarios |
-| `ConfigurationShellSettingsProvider` | Reads from `IConfiguration` (typically `appsettings.json`) |
-| `CompositeShellSettingsProvider` | Aggregates multiple providers (created automatically when >1 provider is registered) |
-| `FluentStorageShellSettingsProvider` | Reads JSON files from disk or cloud storage |
+| `InMemoryShellBlueprintProvider` | Read-only in-memory blueprints used by code-first `AddShell(...)` registrations |
+| `ConfigurationShellBlueprintProvider` | Reads blueprints from `IConfiguration` |
+| `FluentStorageShellBlueprintProvider` | Reads JSON blueprints from disk or cloud storage and supports mutation |
 
-### `MutableInMemoryShellSettingsProvider`
+---
 
-Use this when you need to programmatically add/remove shells outside of `IShellManager`:
+## Mutable Sources
+
+Providers wrapping mutable stores can attach an `IShellBlueprintManager` to each returned `ProvidedBlueprint`. The manager persists create/update/delete operations. Runtime activation and reload remain explicit registry operations:
 
 ```csharp
-var mutableProvider = new MutableInMemoryShellSettingsProvider();
+var manager = await registry.GetManagerAsync("Tenant1");
+if (manager is null)
+    throw new InvalidOperationException("The shell source is read-only or unknown.");
 
-// Add or replace a shell
-mutableProvider.AddOrUpdate(myShellSettings);
-
-// Remove a shell
-mutableProvider.Remove(new ShellId("Tenant1"));
-
-// Register it as a provider
-cshells.WithProvider(mutableProvider);
+await manager.UpdateAsync(updatedSettings);
+await registry.ReloadAsync("Tenant1");
 ```
+
+Use `IShellRegistry.UnregisterBlueprintAsync(name)` for removal so CShells can delete the blueprint through its manager and then drain the active shell generation.
 
 ---
 
 ## Best Practices
 
-- Register providers from **most general** (defaults) to **most specific** (overrides).
-- Use `IShellManager.ReloadAllShellsAsync()` to refresh shells after external changes.
-- Use `IShellManager.ReloadShellAsync(shellId)` to reload a single shell efficiently.
-- Ensure custom providers are **thread-safe** — they may be called concurrently.
-- Code-first shells and provider-based shells coexist naturally; no special opt-in is required.
-
----
-
-## Targeted Provider Lookup
-
-Providers implement `GetShellSettingsAsync(ShellId)` for efficient single-shell lookup during `ReloadShellAsync`. Built-in providers optimize this (e.g., `MutableInMemoryShellSettingsProvider` uses O(1) dictionary lookup). Custom providers must implement both overloads of `GetShellSettingsAsync`; a simple approach is to enumerate all shells and filter by ID.
-
-With a `CompositeShellSettingsProvider`, all providers are queried for the targeted shell ID, and the last non-null result wins — matching the same last-wins semantics used during full enumeration.
-
-### Reload Notifications
-
-During reload operations, `ShellReloading` and `ShellReloaded` notifications are emitted. Providers do not need to handle these notifications, but downstream consumers can observe them to react to configuration changes. See [Runtime Shell Management](Runtime-Shell-Management.md#reload-notification-ordering) for ordering details.
+- Register exactly one blueprint source per host.
+- Use a custom `IShellBlueprintProvider` when several backing stores need to appear as one catalogue.
+- Use `IShellRegistry.GetOrActivateAsync(name)` to activate a shell on demand.
+- Use `IShellRegistry.ReloadAsync(name)` or `ReloadActiveAsync()` after external source changes.
+- Ensure custom providers are thread-safe; they may be called concurrently.

--- a/wiki/Runtime-Shell-Management.md
+++ b/wiki/Runtime-Shell-Management.md
@@ -1,28 +1,30 @@
 # Runtime Shell Management
 
-CShells supports adding, updating, removing, and reloading shells at runtime without restarting the application. Under the deferred-activation model, runtime management now records **desired** shell definitions immediately and reconciles them into **applied** runtimes only when a candidate runtime is fully ready.
+CShells supports activating, reloading, draining, unregistering, and inspecting shells at runtime without restarting the application. The runtime is centered on shell blueprints and active shell generations: blueprints describe how to compose `ShellSettings`, while `IShellRegistry` owns the currently active generations.
 
 ---
 
-## `IShellManager`
+## `IShellRegistry`
 
-`IShellManager` is registered automatically by `AddShells()`. Inject it into any service that needs to manage shells at runtime.
+`IShellRegistry` is registered automatically by `AddCShells()`. Inject it into services that need to activate, reload, drain, unregister, or inspect shells at runtime.
 
 ```csharp
-public class TenantProvisioningService
-{
-    private readonly IShellManager shellManager;
+using CShells.Lifecycle;
 
-    public TenantProvisioningService(IShellManager shellManager)
+public class TenantRuntimeService
+{
+    private readonly IShellRegistry registry;
+
+    public TenantRuntimeService(IShellRegistry registry)
     {
-        this.shellManager = shellManager;
+        this.registry = registry;
     }
 }
 ```
 
 ---
 
-## Adding a Shell
+## Creating or Updating a Blueprint
 
 ```csharp
 public async Task CreateTenantAsync(string tenantId, string tier)
@@ -37,15 +39,15 @@ public async Task CreateTenantAsync(string tenantId, string tier)
     var settings = new ShellSettings(new ShellId(tenantId), features);
     settings.ConfigurationData["WebRouting:Path"] = tenantId;
 
-    await shellManager.AddShellAsync(settings);
+    var manager = await registry.GetManagerAsync(tenantId)
+        ?? throw new InvalidOperationException("The shell source is read-only or unknown.");
+
+    await manager.CreateAsync(settings);
+    await registry.GetOrActivateAsync(tenantId);
 }
 ```
 
-When a shell is added:
-1. Its settings are recorded as the new **desired** definition.
-2. CShells refreshes the runtime feature catalog.
-3. If the candidate runtime builds successfully, it is committed and becomes active.
-4. If the shell cannot be applied yet, the desired state remains recorded and visible through runtime status until a later reconciliation succeeds.
+Mutable blueprint sources expose an `IShellBlueprintManager` for persisted create/update/delete operations. Read-only sources such as code-defined shells do not.
 
 ---
 
@@ -54,11 +56,11 @@ When a shell is added:
 ```csharp
 public async Task DeleteTenantAsync(string tenantId)
 {
-    await shellManager.RemoveShellAsync(new ShellId(tenantId));
+    await registry.UnregisterBlueprintAsync(tenantId);
 }
 ```
 
-Removal is the explicit operation that deletes a shell from desired state and tears down its applied runtime.
+Unregistering deletes the persisted blueprint through its owning manager, then drains and disposes any active generation.
 
 ---
 
@@ -74,11 +76,15 @@ public async Task UpgradeTenantAsync(string tenantId, string newTier)
     var settings = new ShellSettings(new ShellId(tenantId), features);
     settings.ConfigurationData["WebRouting:Path"] = tenantId;
 
-    await shellManager.UpdateShellAsync(settings);
+    var manager = await registry.GetManagerAsync(tenantId)
+        ?? throw new InvalidOperationException("The shell source is read-only or unknown.");
+
+    await manager.UpdateAsync(settings);
+    await registry.ReloadAsync(tenantId);
 }
 ```
 
-`UpdateShellAsync` no longer tears down the current runtime first. It records a newer desired generation and attempts to reconcile it into a successor runtime. If the new desired generation is deferred or fails, the last-known-good applied runtime stays routable.
+`UpdateAsync` only persists the blueprint. Call `ReloadAsync` when you want the running shell generation replaced.
 
 ---
 
@@ -87,15 +93,11 @@ public async Task UpgradeTenantAsync(string tenantId, string newTier)
 ```csharp
 public async Task RefreshAllTenantsAsync()
 {
-    await shellManager.ReloadAllShellsAsync();
+    await registry.ReloadActiveAsync();
 }
 ```
 
-Every full reload:
-- refreshes the runtime feature catalog first
-- reloads the latest desired shell set from providers
-- commits only shells whose successor runtimes are fully ready
-- preserves already applied shells when newer desired generations defer or fail
+Full reloads only reload currently active shells. Inactive blueprints remain inactive until they are explicitly activated or requested.
 
 ---
 
@@ -104,36 +106,33 @@ Every full reload:
 ```csharp
 public async Task RefreshTenantAsync(string tenantId)
 {
-    await shellManager.ReloadShellAsync(new ShellId(tenantId));
+    await registry.ReloadAsync(tenantId);
 }
 ```
 
-- The shell records the latest desired definition from the provider before reconciliation.
-- The previous applied runtime remains available until a successor commits.
-- Unrelated applied shells are not affected.
+- The registry composes fresh settings from the shell's blueprint.
+- A successor generation is activated and promoted.
+- The previous generation is cooperatively drained.
+- Unrelated active shells are not affected.
 - If the shell is unknown to the provider, the call throws without mutating runtime state.
 
 ---
 
-## Inspecting Desired vs. Applied State
+## Inspecting Blueprints and Active Generations
 
-Inject `IShellRuntimeStateAccessor` when you need to distinguish configured intent from currently serving runtimes.
+Use the registry to inspect the blueprint catalogue and active generations.
 
 ```csharp
-public class ShellStatusService(IShellRuntimeStateAccessor runtimeState)
+public class ShellStatusService(IShellRegistry registry)
 {
-    public IReadOnlyCollection<ShellRuntimeStatus> GetShells() => runtimeState.GetAllShells();
+    public IReadOnlyCollection<IShell> GetActiveShells() => registry.GetActiveShells();
+
+    public Task<ShellPage> ListAsync(ShellListQuery query, CancellationToken ct) =>
+        registry.ListAsync(query, ct);
 }
 ```
 
-Each `ShellRuntimeStatus` reports:
-- the latest `DesiredGeneration`
-- the committed `AppliedGeneration` (if any)
-- whether the shell is currently `IsInSync`
-- whether it is currently `IsRoutable`
-- any `BlockingReason` / `MissingFeatures`
-
-This means operators can see configured-but-unapplied shells without those shells becoming routable or endpoint-visible.
+`GetActive(name)` and `GetActiveShells()` read the in-memory active-generation index. `ListAsync()` returns a paginated catalogue view joined with current lifecycle state.
 
 ---
 
@@ -145,58 +144,44 @@ CShells publishes notifications during shell lifecycle events.
 
 | Notification | When |
 |---|---|
-| `ShellActivated` | A candidate runtime has been committed and is now applied |
-| `ShellDeactivating` | An applied runtime is about to be replaced or removed |
-| `ShellAdded` | A shell was added via `IShellManager.AddShellAsync` |
-| `ShellRemoved` | A shell was removed via `IShellManager.RemoveShellAsync` |
-| `ShellUpdated` | A shell was updated via `IShellManager.UpdateShellAsync` |
-| `ShellReloading` | A reload operation is starting |
-| `ShellReloaded` | A reload operation completed successfully |
-| `ShellsReloaded` | A reconciliation pass produced a fresh runtime status snapshot |
+| Lifecycle transition | Observe via `IShellLifecycleSubscriber` |
+| Activation | New generation becomes active |
+| Deactivation / drain | Old generation is being replaced, removed, or force-drained |
+| Reload | `ReloadAsync` or `ReloadActiveAsync` builds successor generations |
+| Unregister | Blueprint is deleted, then active runtime is drained and disposed |
 
 ### Reload Notification Ordering
 
-During a **single-shell reload** (`ReloadShellAsync`):
-1. `ShellReloading(shellId)`
-2. Desired state is refreshed from the provider
-3. The runtime feature catalog is refreshed
-4. If a successor commits, `ShellDeactivating` / `ShellActivated` are emitted around the applied runtime swap
-5. `ShellReloaded(shellId, [shellId], statuses)`
+During a **single-shell reload** (`ReloadAsync`):
+1. The registry composes fresh settings from the shell's blueprint.
+2. A new generation is built and initialized.
+3. The new generation is promoted to active.
+4. The previous generation enters cooperative drain.
 
-During a **full reload** (`ReloadAllShellsAsync`):
-1. `ShellReloading(null)`
-2. Desired state is refreshed from providers
-3. The runtime feature catalog is refreshed
-4. Ready candidates commit individually; deferred/failed generations remain unapplied
-5. `ShellsReloaded(statuses)`
-6. `ShellReloaded(null, changedShells, statuses)`
+During a **full active reload** (`ReloadActiveAsync`), the same sequence runs for each active shell. Inactive blueprints are not activated by this operation.
 
 ---
 
-## `IShellHost` — Accessing Applied Shells
+## `IShellRegistry` — Accessing Active Shells
 
-Inject `IShellHost` to enumerate or look up applied shell contexts.
+Inject `IShellRegistry` to enumerate or look up active shell generations.
 
 ```csharp
-public class ShellDashboardService
+using CShells.Lifecycle;
+
+public class ShellDashboardService(IShellRegistry registry)
 {
-    private readonly IShellHost shellHost;
-
-    public ShellDashboardService(IShellHost shellHost)
-    {
-        this.shellHost = shellHost;
-    }
-
     public IEnumerable<string> GetActiveShellNames() =>
-        shellHost.AllShells.Select(shell => shell.Settings.Id.Value);
+        registry.GetActiveShells().Select(shell => shell.Descriptor.Name);
 
-    public ShellContext GetShell(string name) =>
-        shellHost.GetShell(new ShellId(name));
+    public IShell? GetShell(string name) =>
+        registry.GetActive(name);
 }
 ```
 
 | Member | Description |
 |---|---|
-| `IShellHost.AllShells` | All currently applied shell contexts |
-| `IShellHost.DefaultShell` | The explicit `"Default"` shell only when it is applied; otherwise the first applied shell is used only when no explicit default exists |
-| `IShellHost.GetShell(ShellId)` | Looks up an applied shell by ID; throws `KeyNotFoundException` if no committed runtime exists |
+| `IShellRegistry.GetActiveShells()` | All currently active shell generations |
+| `IShellRegistry.GetActive(name)` | The active generation for a shell name, or `null` |
+| `IShellRegistry.GetOrActivateAsync(name)` | Returns the active generation or lazily activates it from its blueprint |
+| `IShell.BeginScope()` | Opens a tracked DI scope for work inside that shell |


### PR DESCRIPTION
## Summary

- Replace stale `IShellContextScopeFactory` / `IShellHost` background-worker guidance with `IShellRegistry` and `IShell.BeginScope()`.
- Update architecture and runtime-management docs to describe blueprint providers, active shell generations, and lifecycle subscribers.
- Refresh provider docs to explain the single `IShellBlueprintProvider` model and mutable blueprint managers.

## Validation

- `dotnet build`
- `git diff --check`
- stale-contract scan across `README.md`, `wiki`, and `AGENTS.md`
