### PR TITLE
Expose IRuntimeFeatureCatalog for reading discovered features

### DIFF
--- a/src/CShells.Abstractions/Features/IRuntimeFeatureCatalog.cs
+++ b/src/CShells.Abstractions/Features/IRuntimeFeatureCatalog.cs
@@ -1,0 +1,24 @@
+namespace CShells.Features;
+
+/// <summary>
+/// Provides read access to the set of shell features discovered across every configured feature assembly
+/// provider (explicit assemblies, host assemblies, and custom <see cref="IFeatureAssemblyProvider"/>s).
+/// </summary>
+/// <remarks>
+/// This is the authoritative catalog of features the host <em>can</em> activate. Whether any given feature is
+/// actually enabled is decided per shell by its configuration, independently of this catalog — so a host can use
+/// this to present "available" features (enabled or not) without re-implementing feature discovery.
+/// </remarks>
+public interface IRuntimeFeatureCatalog
+{
+    /// <summary>
+    /// Returns the current catalog snapshot, performing a first discovery pass if the catalog has not been
+    /// initialized yet.
+    /// </summary>
+    Task<RuntimeFeatureCatalogSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-discovers features from all configured providers and commits (and returns) a new snapshot.
+    /// </summary>
+    Task<RuntimeFeatureCatalogSnapshot> RefreshAsync(CancellationToken cancellationToken = default);
+}

--- a/src/CShells.Abstractions/Features/RuntimeFeatureCatalogSnapshot.cs
+++ b/src/CShells.Abstractions/Features/RuntimeFeatureCatalogSnapshot.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+namespace CShells.Features;
+
+/// <summary>
+/// An immutable snapshot of the shell features discovered across every configured feature assembly provider
+/// (explicit assemblies, host assemblies, and custom <see cref="IFeatureAssemblyProvider"/>s) at a point in time.
+/// </summary>
+/// <param name="Generation">A monotonically increasing number identifying this snapshot; a later snapshot always has a greater generation.</param>
+/// <param name="Assemblies">The assemblies that were scanned to produce this snapshot.</param>
+/// <param name="FeatureDescriptors">All discovered feature descriptors.</param>
+/// <param name="FeatureMap">The discovered features keyed by <see cref="ShellFeatureDescriptor.Id"/> (case-insensitive).</param>
+/// <param name="RefreshedAt">The UTC time the snapshot was committed.</param>
+public sealed record RuntimeFeatureCatalogSnapshot(
+    long Generation,
+    IReadOnlyCollection<Assembly> Assemblies,
+    IReadOnlyCollection<ShellFeatureDescriptor> FeatureDescriptors,
+    IReadOnlyDictionary<string, ShellFeatureDescriptor> FeatureMap,
+    DateTimeOffset RefreshedAt);

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -53,6 +53,11 @@ public static class ServiceCollectionExtensions
             return new RuntimeFeatureCatalog(ct => builder.BuildFeatureAssembliesAsync(sp, ct), logger);
         });
 
+        // Public, read-only view over the discovered feature catalog so hosts can present "available"
+        // features (enabled or not) without re-implementing feature discovery. Excluded from per-shell
+        // containers and root-delegated by ShellProviderBuilder so shell-scoped resolves alias the root.
+        services.TryAddSingleton<IRuntimeFeatureCatalog>(sp => sp.GetRequiredService<RuntimeFeatureCatalog>());
+
         // Lifecycle surface: provider builder + registry + auto-logger + drain defaults + startup service.
         services.TryAddSingleton<ShellProviderBuilder>(sp => new ShellProviderBuilder(
             sp.GetRequiredService<IRootServiceCollectionAccessor>(),

--- a/src/CShells/Features/RuntimeFeatureCatalog.cs
+++ b/src/CShells/Features/RuntimeFeatureCatalog.cs
@@ -6,7 +6,7 @@ namespace CShells.Features;
 
 internal sealed class RuntimeFeatureCatalog(
     Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver,
-    ILogger<RuntimeFeatureCatalog>? logger = null)
+    ILogger<RuntimeFeatureCatalog>? logger = null) : IRuntimeFeatureCatalog
 {
     private readonly Func<CancellationToken, Task<IReadOnlyCollection<Assembly>>> assemblyResolver = Guard.Against.Null(assemblyResolver);
     private readonly ILogger<RuntimeFeatureCatalog> logger = logger ?? NullLogger<RuntimeFeatureCatalog>.Instance;
@@ -24,6 +24,12 @@ internal sealed class RuntimeFeatureCatalog(
             return;
 
         await RefreshAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RuntimeFeatureCatalogSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return CurrentSnapshot;
     }
 
     public async Task<RuntimeFeatureCatalogSnapshot> RefreshAsync(CancellationToken cancellationToken = default)
@@ -64,11 +70,4 @@ internal sealed class RuntimeFeatureCatalog(
         }
     }
 }
-
-internal sealed record RuntimeFeatureCatalogSnapshot(
-    long Generation,
-    IReadOnlyCollection<Assembly> Assemblies,
-    IReadOnlyCollection<ShellFeatureDescriptor> FeatureDescriptors,
-    IReadOnlyDictionary<string, ShellFeatureDescriptor> FeatureMap,
-    DateTimeOffset RefreshedAt);
 

--- a/src/CShells/Hosting/DefaultShellServiceExclusionProvider.cs
+++ b/src/CShells/Hosting/DefaultShellServiceExclusionProvider.cs
@@ -41,6 +41,9 @@ public class DefaultShellServiceExclusionProvider : IShellServiceExclusionProvid
         yield return typeof(IShellLifecycleSubscriber);
         yield return typeof(IShellBlueprint);
         yield return typeof(RuntimeFeatureCatalog);
+        // Excluded here AND re-registered as a root delegation in ShellProviderBuilder so shells can read the
+        // catalog without copying the root-only assembly-resolver factory.
+        yield return typeof(IRuntimeFeatureCatalog);
         yield return typeof(IShellFeatureFactory);
         yield return typeof(IShellServiceExclusionRegistry);
         yield return typeof(IShellServiceExclusionProvider);

--- a/src/CShells/Lifecycle/ShellProviderBuilder.cs
+++ b/src/CShells/Lifecycle/ShellProviderBuilder.cs
@@ -134,6 +134,11 @@ internal sealed class ShellProviderBuilder(
         // singleton so shell-scoped resolves alias cleanly.
         var rootProvider = _rootProvider;
         services.AddSingleton<IShellRegistry>(_ => rootProvider.GetRequiredService<IShellRegistry>());
+
+        // Root-delegation for IRuntimeFeatureCatalog: shell-scoped consumers (e.g. a feature-management UI
+        // feature) may read the discovered catalog, but the catalog is root-only infrastructure. Alias to the
+        // root singleton rather than copying the excluded root factory.
+        services.AddSingleton<IRuntimeFeatureCatalog>(_ => rootProvider.GetRequiredService<IRuntimeFeatureCatalog>());
     }
 
     private void ConfigureFeatures(

--- a/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs
+++ b/tests/CShells.Tests/Unit/Features/RuntimeFeatureCatalogTests.cs
@@ -60,6 +60,30 @@ public class RuntimeFeatureCatalogTests
         Assert.Contains(catalog.CurrentSnapshot.FeatureDescriptors, descriptor => descriptor.Id == "Unique");
     }
 
+    [Fact(DisplayName = "GetSnapshotAsync initializes on first access and returns the committed snapshot")]
+    public async Task GetSnapshotAsync_InitializesAndReturnsCommittedSnapshot()
+    {
+        // Arrange
+        var refreshCalls = 0;
+        var uniqueAssembly = CreateDynamicFeatureAssembly("RuntimeFeatureCatalogGetSnapshot", "GetSnapshotFeature", "GetSnapshot");
+        IRuntimeFeatureCatalog catalog = new RuntimeFeatureCatalog(
+            _ =>
+            {
+                refreshCalls++;
+                return Task.FromResult<IReadOnlyCollection<Assembly>>([uniqueAssembly]);
+            },
+            NullLogger<RuntimeFeatureCatalog>.Instance);
+
+        // Act
+        var first = await catalog.GetSnapshotAsync();
+        var second = await catalog.GetSnapshotAsync();
+
+        // Assert: first access discovers once; subsequent access reuses the committed snapshot.
+        Assert.Equal(1, refreshCalls);
+        Assert.Same(first, second);
+        Assert.Contains(first.FeatureDescriptors, descriptor => descriptor.Id == "GetSnapshot");
+    }
+
     private static Assembly CreateDynamicFeatureAssembly(string assemblyName, string typeName, string featureName)
     {
         var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(new(assemblyName), AssemblyBuilderAccess.Run);


### PR DESCRIPTION
## Why

The runtime feature catalog already discovers every feature across all configured assembly providers (explicit `.WithAssemblies(...)`, host, and custom `IFeatureAssemblyProvider`s), but both `RuntimeFeatureCatalog` and `RuntimeFeatureCatalogSnapshot` were `internal`. Hosts that want to present the full set of **available** features (enabled or not) — e.g. a feature-management UI — had no way to read what the shell already knows, and had to re-implement discovery against a partial assembly set.

## What

- Add a public, read-only `IRuntimeFeatureCatalog` (`GetSnapshotAsync` / `RefreshAsync`) and make `RuntimeFeatureCatalogSnapshot` public, both in **CShells.Abstractions** (the contract package feature libraries already reference).
- `RuntimeFeatureCatalog` now implements the interface; `GetSnapshotAsync` initializes on first access and returns the committed snapshot.
- Register `IRuntimeFeatureCatalog` at the root and **root-delegate** it into shell containers (excluded from per-shell copy, then aliased back to the root singleton) — exactly mirroring the existing `IShellRegistry` treatment — so shell-scoped consumers resolve the same catalog.

No behavioural change to discovery; this is purely additive surface area. Enabled-state remains a per-shell configuration concern, independent of this catalog.

## Tests

- New unit test covering `GetSnapshotAsync` (initialize-once + reuse).
- Full suite green: **563 passed** (`CShells.Tests` 535, `CShells.Tests.EndToEnd` 28), 0 warnings.