### PR TITLE
Middleware seam: ordering, IMiddlewareFactory guarantee, per-shell dynamic pipelines

### DIFF
--- a/samples/CShells.Workbench.Features/README.md
+++ b/samples/CShells.Workbench.Features/README.md
@@ -7,15 +7,17 @@ Feature library for the CShells Workbench sample application — a multi-tenant 
 | `Posts`      | Core       | Blog posts CRUD (`/posts`)                     |
 | `Comments`   | Posts      | Reader comments (`/posts/{id}/comments`)       |
 | `Analytics`  | Posts      | View-count analytics (`/analytics`)            |
+| `RequestStamp` | —        | Stamps responses with `X-Shell-Stamp` header   |
 ## Tenant Plans
 | Shell    | Path      | Features                              | Description              |
 |----------|-----------|---------------------------------------|--------------------------|
 | Default  | `/`       | Core, Posts                           | Free tier                |
-| Acme     | `/acme`   | Core, Posts, Comments                 | Pro tier                 |
+| Acme     | `/acme`   | Core, Posts, Comments, RequestStamp   | Pro tier                 |
 | Contoso  | `/contoso`| Core, Posts, Comments, Analytics      | Enterprise tier          |
 ## Key Concepts Demonstrated
 
 - **`IWebShellFeature`**: All features — service registration + endpoint mapping
+- **`IMiddlewareShellFeature`**: `RequestStampFeature` — shell-scoped `IMiddleware` in the request pipeline
 - **`[ShellFeature]`**: Feature metadata + `DependsOn` chains
 - **`IConfigurableFeature<T>`**: `AnalyticsFeature` — typed per-shell options
 - **`IShellInitializer`**: `SeedPostsHandler` — per-shell startup work

--- a/samples/CShells.Workbench.Features/RequestStamp/RequestStampFeature.cs
+++ b/samples/CShells.Workbench.Features/RequestStamp/RequestStampFeature.cs
@@ -1,0 +1,44 @@
+using CShells.AspNetCore.Features;
+using CShells.Features;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CShells.Workbench.Features.RequestStamp;
+
+/// <summary>
+/// Request-stamp feature — demonstrates the CShells middleware seam
+/// (<see cref="IMiddlewareShellFeature"/>). Mounts an <see cref="IMiddleware"/>-style middleware
+/// into the shell's pipeline that stamps every response with an <c>X-Shell-Stamp</c> header
+/// carrying the tenant name. The middleware is resolved per request from the shell scope
+/// (via the <see cref="IMiddlewareFactory"/> CShells guarantees in shell containers), so it can
+/// inject shell-scoped services — here, the shell's <see cref="ShellSettings"/>.
+/// </summary>
+[ShellFeature("RequestStamp", DisplayName = "Request Stamp", Description = "Stamps responses with an X-Shell-Stamp header carrying the tenant name.")]
+public class RequestStampFeature : IMiddlewareShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<RequestStampMiddleware>();
+    }
+
+    public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment)
+    {
+        app.UseMiddleware<RequestStampMiddleware>();
+    }
+}
+
+/// <summary>Stamps the response with the owning shell's name.</summary>
+public class RequestStampMiddleware(ShellSettings settings) : IMiddleware
+{
+    public Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers["X-Shell-Stamp"] = settings.Id.Name;
+            return Task.CompletedTask;
+        });
+        return next(context);
+    }
+}

--- a/samples/CShells.Workbench/appsettings.json
+++ b/samples/CShells.Workbench/appsettings.json
@@ -30,7 +30,8 @@
           "Core": true,
           "Posts": true,
           "Comments": true,
-          "Analytics": false
+          "Analytics": false,
+          "RequestStamp": true
         },
         "Configuration": {
           "WebRouting": {

--- a/src/CShells.AspNetCore.Abstractions/Features/IMiddlewareShellFeature.cs
+++ b/src/CShells.AspNetCore.Abstractions/Features/IMiddlewareShellFeature.cs
@@ -14,30 +14,47 @@ namespace CShells.AspNetCore.Features;
 /// registers endpoints, this interface registers middleware that runs before endpoint dispatch.
 /// </para>
 /// <para>
-/// Middleware registered through this interface is automatically scoped to the shell's
-/// path prefix (if configured). The shell's service provider is already set as
-/// <c>HttpContext.RequestServices</c> by the time the middleware executes.
+/// Middleware registered through this interface runs only for requests resolved to the
+/// feature's shell, composed into a per-shell pipeline that executes at the point where
+/// <c>MapShells()</c> was called — immediately after the shell resolution middleware has set
+/// <c>HttpContext.RequestServices</c> to a scope of the shell's service provider. If the shell
+/// has a path prefix configured (<c>WebRouting:Path</c>), the middleware additionally only runs
+/// for requests under that prefix and observes the prefix-stripped <c>PathBase</c>/<c>Path</c>;
+/// the prefix is re-applied before the rest of the host pipeline (including endpoint execution)
+/// continues, so path rewrites made by the middleware are preserved downstream.
 /// </para>
 /// </remarks>
 public interface IMiddlewareShellFeature : IShellFeature
 {
     /// <summary>
+    /// Relative order in which this feature's middleware is applied within the shell's pipeline.
+    /// Lower values run earlier (outermost). Features with equal order are applied in
+    /// feature-dependency (discovery) order. Defaults to 0.
+    /// </summary>
+    int Order => 0;
+
+    /// <summary>
     /// Registers middleware components for this feature within the shell's pipeline scope.
     /// </summary>
     /// <param name="app">
-    /// The application builder. Middleware registered here will be scoped to the shell's
-    /// path prefix (if configured) and will execute within the shell's service provider context.
+    /// The application builder for the shell's pipeline branch. Middleware registered here is
+    /// scoped to the shell's path prefix (if configured) and executes within the shell's
+    /// service provider context.
     /// </param>
     /// <param name="environment">The hosting environment, or null if not registered in the service provider.</param>
     /// <remarks>
     /// <para>
-    /// This method is called when shells are activated, either during application startup
-    /// or when shells are dynamically added at runtime.
+    /// This method is called when the shell is activated — during application startup, on lazy
+    /// (cold) activation by the first matching request, on dynamic activation at runtime, and
+    /// again for each new generation when the shell is reloaded. Shells activated before
+    /// <c>MapShells()</c> runs are registered retroactively when <c>MapShells()</c> is called.
     /// </para>
     /// <para>
     /// Middleware registered here runs after the shell resolution middleware has set
     /// <c>HttpContext.RequestServices</c> to the shell's service provider, so any
     /// services resolved from the request will come from the correct shell scope.
+    /// Middleware types implementing <c>IMiddleware</c> are supported: CShells guarantees an
+    /// <c>IMiddlewareFactory</c> is available in the shell container.
     /// </para>
     /// </remarks>
     void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment);

--- a/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
@@ -206,6 +206,10 @@ public static class CShellsBuilderExtensions
             // Register the application builder accessor to capture IApplicationBuilder during MapShells()
             builder.Services.TryAddSingleton<ApplicationBuilderAccessor>();
 
+            // Register the per-shell middleware pipeline registry, populated on shell activation
+            // and dispatched per request by ShellMiddleware
+            builder.Services.TryAddSingleton<Middleware.ShellMiddlewarePipelineRegistry>();
+
             // Register the endpoint registration handler as a lifecycle subscriber. It
             // self-subscribes to IShellRegistry in its constructor and rebuilds endpoints on
             // Initializing → Active / tears them down on Deactivating.

--- a/src/CShells.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using CShells.AspNetCore.Middleware;
+using CShells.AspNetCore.Notifications;
 using CShells.AspNetCore.Routing;
+using CShells.Lifecycle;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,6 +69,17 @@ public static class ApplicationBuilderExtensions
         // Step 6: Add the data source to the endpoint route builder
         // This makes all shell endpoints available to the routing system
         endpoints.DataSources.Add(endpointDataSource);
+
+        // Step 7: Replay registration for shells that activated before this call captured the
+        // accessors (e.g. explicit warm-up activation in Program.cs before MapShells). Without
+        // the replay those generations would permanently lack endpoints and middleware.
+        var registrationHandler = endpoints.ServiceProvider.GetService<ShellEndpointRegistrationHandler>();
+        var shellRegistry = endpoints.ServiceProvider.GetService<IShellRegistry>();
+        if (registrationHandler is not null && shellRegistry is not null)
+        {
+            foreach (var shell in shellRegistry.GetActiveShells())
+                registrationHandler.RegisterActiveShell(shell);
+        }
 
         logger.LogInformation("CShells middleware and endpoints configured successfully");
 

--- a/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using CShells.DependencyInjection;
 using CShells.Hosting;
 using CShells.Lifecycle;
 using CShells.Resolution;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -31,6 +32,13 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<ShellResolverOptions>();
         services.TryAddSingleton<IShellResolver, DefaultShellResolver>();
+
+        // Guarantees IMiddleware-style middleware activation inside shell containers even when the
+        // root host never registered a factory (plain ServiceCollection / generic host). Scoped to
+        // match the framework's own registration in GenericWebHostBuilder; TryAdd defers to any host
+        // registration, and the descriptor flows into shell containers via
+        // ShellProviderBuilder.CopyRootServices.
+        services.TryAddScoped<IMiddlewareFactory, MiddlewareFactory>();
         services.AddMemoryCache();
         services.AddOptions<ShellMiddlewareOptions>();
 

--- a/src/CShells.AspNetCore/Hosting/AspNetCoreShellServiceExclusionProvider.cs
+++ b/src/CShells.AspNetCore/Hosting/AspNetCoreShellServiceExclusionProvider.cs
@@ -37,5 +37,11 @@ public class AspNetCoreShellServiceExclusionProvider : IShellServiceExclusionPro
         // IAuthenticationSchemeProvider must not be copied so each shell can have its own
         // with its own set of schemes (e.g., JWT, API Key)
         yield return typeof(IAuthenticationSchemeProvider);
+
+        // Root-only dispatch infrastructure: ShellMiddleware reads pipelines from the ROOT
+        // registry. Copying the descriptor would hand each shell a fresh, permanently-empty
+        // instance — resolving it from a shell scope should fail loudly instead of silently
+        // diverging from the registry that actually dispatches requests.
+        yield return typeof(Middleware.ShellMiddlewarePipelineRegistry);
     }
 }

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -30,6 +30,7 @@ public class ShellMiddleware(
     IShellResolver resolver,
     IShellRegistry registry,
     DynamicShellEndpointDataSource endpointDataSource,
+    ShellMiddlewarePipelineRegistry pipelineRegistry,
     IMemoryCache cache,
     IOptions<ShellMiddlewareOptions> options,
     ILogger<ShellMiddleware>? logger = null)
@@ -38,6 +39,7 @@ public class ShellMiddleware(
     private readonly IShellResolver _resolver = Guard.Against.Null(resolver);
     private readonly IShellRegistry _registry = Guard.Against.Null(registry);
     private readonly DynamicShellEndpointDataSource _endpointDataSource = Guard.Against.Null(endpointDataSource);
+    private readonly ShellMiddlewarePipelineRegistry _pipelineRegistry = Guard.Against.Null(pipelineRegistry);
     private readonly IMemoryCache _cache = Guard.Against.Null(cache);
     private readonly ShellMiddlewareOptions _options = Guard.Against.Null(options).Value;
     private readonly ILogger<ShellMiddleware> _logger = logger ?? NullLogger<ShellMiddleware>.Instance;
@@ -96,6 +98,15 @@ public class ShellMiddleware(
         if (wasCold && ShouldTryMatchEndpointAfterColdActivation(context.GetEndpoint()))
             TryMatchEndpointAfterColdActivation(context, shellId.Value);
 
+        // Resolve the shell's composed middleware pipeline BEFORE taking the scope. Ordering
+        // matters: pipeline entries are removed when a generation reaches Disposed (bounded or
+        // forced drains can dispose a generation while requests are still arriving), and
+        // BeginScope rejects a Disposed generation — so resolving first means this request
+        // either holds the pipeline delegate (which stays usable even if the entry is removed
+        // mid-request) or fails loudly at BeginScope. It can never silently run without the
+        // shell's middleware.
+        var pipeline = _pipelineRegistry.Get(shellId.Value, shell.Descriptor.Generation, _next);
+
         // BeginScope increments the shell's active-scope counter (so in-flight drains' phase-1
         // waits for this request to complete). The scope is released via OnCompleted (not
         // `await using`) so upstream middleware can still read RequestServices during its
@@ -105,7 +116,7 @@ public class ShellMiddleware(
         context.RequestServices = scope.ServiceProvider;
         context.Response.OnCompleted(() => scope.DisposeAsync().AsTask());
 
-        await _next(context);
+        await (pipeline ?? _next)(context);
     }
 
     private async ValueTask<ShellId?> ResolveShellWithCacheAsync(

--- a/src/CShells.AspNetCore/Middleware/ShellMiddlewarePipelineRegistry.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddlewarePipelineRegistry.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+
+namespace CShells.AspNetCore.Middleware;
+
+/// <summary>
+/// Root singleton mapping a shell generation to its composed middleware pipeline, built from the
+/// shell's <see cref="Features.IMiddlewareShellFeature"/>s when the generation activates and
+/// dispatched per request by <see cref="ShellMiddleware"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keys are generation-aware because a reload activates the new generation before the old one
+/// deactivates. Entries are removed when a generation reaches Disposed; dispatchers must resolve
+/// the pipeline delegate via <see cref="Get"/> <b>before</b> taking a scope on the shell so that
+/// a concurrent disposal can never silently skip the pipeline — a resolved delegate stays usable
+/// for the request that holds it even after the entry is removed.
+/// </para>
+/// <para>
+/// This registry is root-only infrastructure (excluded from shell containers); the pipeline's
+/// terminal rejoins the host pipeline through the <see cref="ShellPipelineContinuation"/> bound
+/// on first <see cref="Get"/>.
+/// </para>
+/// </remarks>
+public sealed class ShellMiddlewarePipelineRegistry
+{
+    private readonly ConcurrentDictionary<(ShellId ShellId, int Generation), Entry> _pipelines = new();
+
+    /// <summary>Registers (or replaces) the pipeline for a shell generation.</summary>
+    /// <param name="shellId">The shell identifier.</param>
+    /// <param name="generation">The shell generation the pipeline was built for.</param>
+    /// <param name="pipeline">The composed pipeline delegate.</param>
+    /// <param name="continuation">
+    /// The continuation holder the pipeline's terminal rejoins the host pipeline through;
+    /// bound to the dispatcher's next-delegate on first <see cref="Get"/>.
+    /// </param>
+    public void Set(ShellId shellId, int generation, RequestDelegate pipeline, ShellPipelineContinuation continuation)
+    {
+        Guard.Against.Null(pipeline);
+        Guard.Against.Null(continuation);
+        _pipelines[(shellId, generation)] = new Entry(pipeline, continuation);
+    }
+
+    /// <summary>
+    /// Returns the pipeline for a shell generation with its continuation bound to
+    /// <paramref name="next"/>, or null if none is registered.
+    /// </summary>
+    public RequestDelegate? Get(ShellId shellId, int generation, RequestDelegate next)
+    {
+        Guard.Against.Null(next);
+        if (!_pipelines.TryGetValue((shellId, generation), out var entry))
+            return null;
+
+        entry.Continuation.Bind(next);
+        return entry.Pipeline;
+    }
+
+    /// <summary>Removes the pipeline for a shell generation.</summary>
+    public void Remove(ShellId shellId, int generation) =>
+        _pipelines.TryRemove((shellId, generation), out _);
+
+    private sealed record Entry(RequestDelegate Pipeline, ShellPipelineContinuation Continuation);
+}

--- a/src/CShells.AspNetCore/Middleware/ShellPipelineContinuation.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellPipelineContinuation.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+
+namespace CShells.AspNetCore.Middleware;
+
+/// <summary>
+/// Holder for the host-pipeline continuation a shell's composed middleware pipeline rejoins
+/// through. Created per pipeline at composition time; the dispatcher's next-delegate is bound
+/// once on the first <see cref="ShellMiddlewarePipelineRegistry.Get"/> (it is constant for the
+/// dispatching middleware's lifetime), so dispatching adds no per-request allocation.
+/// </summary>
+public sealed class ShellPipelineContinuation
+{
+    private RequestDelegate? _next;
+
+    /// <summary>The bound continuation. Throws if the pipeline is invoked without being obtained through the registry.</summary>
+    public RequestDelegate Next => _next ?? throw new InvalidOperationException(
+        "Shell middleware pipeline invoked before its continuation was bound. " +
+        "Obtain shell pipelines via ShellMiddlewarePipelineRegistry.Get, which binds the continuation.");
+
+    /// <summary>Binds the continuation on first use; later calls are no-ops (first writer wins).</summary>
+    internal void Bind(RequestDelegate next) => Interlocked.CompareExchange(ref _next, next, null);
+}

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -1,5 +1,7 @@
 using CShells.AspNetCore.Features;
+using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http;
 using CShells.Features;
 using CShells.Lifecycle;
 using Microsoft.AspNetCore.Builder;
@@ -12,8 +14,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace CShells.AspNetCore.Notifications;
 
 /// <summary>
-/// Reacts to shell lifecycle transitions by (re-)registering or removing endpoints + middleware
-/// in the dynamic endpoint data source. Subscribed to the registry via
+/// Reacts to shell lifecycle transitions by (re-)registering or removing endpoints in the
+/// dynamic endpoint data source and per-shell middleware pipelines in the
+/// <see cref="ShellMiddlewarePipelineRegistry"/>. Subscribed to the registry via
 /// <see cref="IShellLifecycleSubscriber"/>.
 /// </summary>
 public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
@@ -21,6 +24,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
     private readonly DynamicShellEndpointDataSource _endpointDataSource;
     private readonly EndpointRouteBuilderAccessor _endpointRouteBuilderAccessor;
     private readonly ApplicationBuilderAccessor _applicationBuilderAccessor;
+    private readonly ShellMiddlewarePipelineRegistry _pipelineRegistry;
     private readonly IShellFeatureFactory _featureFactory;
     private readonly IHostEnvironment? _environment;
     private readonly ILogger<ShellEndpointRegistrationHandler> _logger;
@@ -30,12 +34,14 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         IShellFeatureFactory featureFactory,
         EndpointRouteBuilderAccessor endpointRouteBuilderAccessor,
         ApplicationBuilderAccessor applicationBuilderAccessor,
+        ShellMiddlewarePipelineRegistry pipelineRegistry,
         IHostEnvironment? environment = null,
         ILogger<ShellEndpointRegistrationHandler>? logger = null)
     {
         _endpointDataSource = Guard.Against.Null(endpointDataSource);
         _endpointRouteBuilderAccessor = Guard.Against.Null(endpointRouteBuilderAccessor);
         _applicationBuilderAccessor = Guard.Against.Null(applicationBuilderAccessor);
+        _pipelineRegistry = Guard.Against.Null(pipelineRegistry);
         _featureFactory = Guard.Against.Null(featureFactory);
         _environment = environment;
         _logger = logger ?? NullLogger<ShellEndpointRegistrationHandler>.Instance;
@@ -50,16 +56,13 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             if (_endpointRouteBuilderAccessor.EndpointRouteBuilder is null)
             {
                 _logger.LogWarning(
-                    "Cannot register endpoints for shell '{Shell}': IEndpointRouteBuilder not available. " +
-                    "Endpoints will be registered on next application start.",
+                    "Cannot register endpoints or middleware for shell '{Shell}': MapShells() has not run yet. " +
+                    "Registration is replayed when MapShells() captures the routing infrastructure.",
                     shell.Descriptor);
                 return Task.CompletedTask;
             }
 
-            _logger.LogInformation("Registering endpoints for active shell '{Shell}'", shell.Descriptor);
-            var shellId = new ShellId(shell.Descriptor.Name);
-            _endpointDataSource.RemoveEndpoints(shellId);
-            RegisterShellEndpoints(shell);
+            RegisterActiveShell(shell);
             return Task.CompletedTask;
         }
 
@@ -70,9 +73,29 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             _logger.LogInformation("Removing endpoints for shell '{Shell}' generation {Generation} ({State})",
                 shell.Descriptor, shell.Descriptor.Generation, current);
             _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+
+            // The middleware pipeline is removed only on disposal: unlike endpoints (which must
+            // stop matching as soon as the generation deactivates), the pipeline is only looked
+            // up by requests that already hold this generation's scope — and drain's scope-wait
+            // keeps the generation from reaching Disposed while any such request is in flight.
+            if (current == ShellLifecycleState.Disposed)
+                _pipelineRegistry.Remove(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Registers endpoints and the middleware pipeline for an active shell. Invoked on the
+    /// Initializing → Active transition, and replayed by <c>MapShells()</c> for shells that
+    /// activated before the routing infrastructure was captured.
+    /// </summary>
+    public void RegisterActiveShell(IShell shell)
+    {
+        Guard.Against.Null(shell);
+        _logger.LogInformation("Registering endpoints for active shell '{Shell}'", shell.Descriptor);
+        _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name));
+        RegisterShellEndpoints(shell);
     }
 
     private void RegisterShellEndpoints(IShell shell)
@@ -106,7 +129,31 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var allFeatureDescriptors = shell.ServiceProvider.GetRequiredService<IEnumerable<ShellFeatureDescriptor>>().ToList();
         var featureContext = new ShellFeatureContext(settings, allFeatureDescriptors.AsReadOnly());
 
-        RegisterShellMiddleware(settings, shell, allFeatureDescriptors, featureContext, shellPathPrefix);
+        try
+        {
+            RegisterShellMiddleware(settings, shell, allFeatureDescriptors, featureContext, shellPathPrefix);
+        }
+        catch (Exception ex)
+        {
+            // Fail closed. The lifecycle fan-out swallows subscriber exceptions, so rethrowing
+            // cannot fail the activation — the shell WILL go Active. A shell whose middleware
+            // could not be composed must not serve requests without it (the features may be
+            // auth- or dispatch-critical), so register a pipeline that rejects everything, and
+            // continue so endpoint registration still happens and requests get a diagnosable
+            // 503 instead of a silent 404.
+            _logger.LogError(ex,
+                "Failed to compose the middleware pipeline for shell '{Shell}' generation {Generation}. " +
+                "The shell will respond 503 to all requests until it is successfully reloaded.",
+                shell.Descriptor, shell.Descriptor.Generation);
+
+            _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation,
+                context =>
+                {
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    return Task.CompletedTask;
+                },
+                new ShellPipelineContinuation());
+        }
 
         var webFeatures = DiscoverWebFeatures(settings, allFeatureDescriptors);
         foreach (var (featureId, featureType) in webFeatures)
@@ -182,36 +229,89 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             return;
         }
 
-        var middlewareFeatures = DiscoverMiddlewareFeatures(settings, allFeatureDescriptors).ToList();
+        var middlewareFeatures = new List<(string FeatureId, IMiddlewareShellFeature Feature)>();
+        foreach (var (featureId, featureType) in DiscoverMiddlewareFeatures(settings, allFeatureDescriptors))
+        {
+            try
+            {
+                middlewareFeatures.Add((featureId, _featureFactory.CreateFeature<IMiddlewareShellFeature>(featureType, settings, featureContext)));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create middleware feature '{FeatureId}' for shell '{Shell}'", featureId, shell.Descriptor);
+                throw;
+            }
+        }
+
         if (middlewareFeatures.Count == 0)
             return;
 
         _logger.LogInformation("Registering middleware for {Count} feature(s) in shell '{Shell}'",
             middlewareFeatures.Count, shell.Descriptor);
 
-        foreach (var (featureId, featureType) in middlewareFeatures)
+        // Stable sort: equal Order preserves feature-dependency (discovery) order.
+        var orderedFeatures = middlewareFeatures.OrderBy(f => f.Feature.Order).ToList();
+
+        // Compose a per-shell pipeline on a clone of the builder captured at MapShells() time.
+        // Cloning keeps ServerFeatures available while leaving the built root pipeline untouched;
+        // the shell's own provider becomes ApplicationServices so build-time middleware
+        // construction resolves against the shell container.
+        var builder = appBuilder.New();
+        builder.ApplicationServices = shell.ServiceProvider;
+
+        // The terminal rejoins the host pipeline through the continuation bound by the registry
+        // on first Get. It must not blanket-reset the request path: deliberate Path rewrites made
+        // by feature middleware belong to the request and flow downstream, exactly as they would
+        // for middleware in the host pipeline.
+        var continuation = new ShellPipelineContinuation();
+
+        void ApplyFeatures(IApplicationBuilder target)
         {
-            try
+            foreach (var (featureId, feature) in orderedFeatures)
             {
-                var feature = _featureFactory.CreateFeature<IMiddlewareShellFeature>(featureType, settings, featureContext);
-
-                if (!string.IsNullOrEmpty(shellPathPrefix))
+                try
                 {
-                    appBuilder.Map(shellPathPrefix, branch => feature.UseMiddleware(branch, _environment));
+                    feature.UseMiddleware(target, _environment);
+                    _logger.LogDebug("Registered middleware for feature '{FeatureId}' in shell '{Shell}'", featureId, shell.Descriptor);
                 }
-                else
+                catch (Exception ex)
                 {
-                    feature.UseMiddleware(appBuilder, _environment);
+                    _logger.LogError(ex, "Failed to register middleware for feature '{FeatureId}' in shell '{Shell}'", featureId, shell.Descriptor);
+                    throw;
                 }
-
-                _logger.LogDebug("Registered middleware for feature '{FeatureId}' in shell '{Shell}'", featureId, shell.Descriptor);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to register middleware for feature '{FeatureId}' in shell '{Shell}'", featureId, shell.Descriptor);
-                throw;
             }
         }
+
+        if (!string.IsNullOrEmpty(shellPathPrefix))
+        {
+            builder.Map(shellPathPrefix, branch =>
+            {
+                ApplyFeatures(branch);
+
+                // Undo exactly what Map stripped — re-apply the matched prefix segment (in its
+                // original request casing) — while preserving any Path rewrite feature middleware
+                // made inside the branch. Downstream host middleware then sees the full path.
+                branch.Run(context =>
+                {
+                    var pathBase = context.Request.PathBase.Value ?? string.Empty;
+                    if (pathBase.EndsWith(shellPathPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var matchedSegment = pathBase[^shellPathPrefix.Length..];
+                        context.Request.PathBase = new PathString(pathBase[..^shellPathPrefix.Length]);
+                        context.Request.Path = new PathString(matchedSegment + context.Request.Path.Value);
+                    }
+                    return continuation.Next(context);
+                });
+            });
+            builder.Run(context => continuation.Next(context)); // requests outside the prefix skip the features and rejoin
+        }
+        else
+        {
+            ApplyFeatures(builder);
+            builder.Run(context => continuation.Next(context));
+        }
+
+        _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation, builder.Build(), continuation);
     }
 
     private static string? GetPathPrefix(ShellSettings settings)
@@ -225,7 +325,10 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var trimmedPath = path.Trim();
         if (!trimmedPath.StartsWith('/')) trimmedPath = "/" + trimmedPath;
         if (trimmedPath.EndsWith('/') && trimmedPath.Length > 1) trimmedPath = trimmedPath.TrimEnd('/');
-        return trimmedPath;
+
+        // "/" means root-mounted, i.e. no prefix scoping — and ASP.NET's Map rejects any
+        // pathMatch ending in '/', so passing it through would throw during activation.
+        return trimmedPath == "/" ? null : trimmedPath;
     }
 
     private static string? GetRoutePrefix(ShellSettings settings)

--- a/src/CShells/Lifecycle/DrainOperation.cs
+++ b/src/CShells/Lifecycle/DrainOperation.cs
@@ -107,23 +107,31 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
 
     private async Task<DrainResult> ExecuteAsync()
     {
-        // Phase 1: scope wait.
-        var scopeWaitStart = Stopwatch.GetTimestamp();
-        var abandonedScopes = await AwaitScopeReleaseAsync().ConfigureAwait(false);
-        var scopeWaitElapsed = Stopwatch.GetElapsedTime(scopeWaitStart);
+        try
+        {
+            // Phase 1: scope wait.
+            var scopeWaitStart = Stopwatch.GetTimestamp();
+            var abandonedScopes = await AwaitScopeReleaseAsync().ConfigureAwait(false);
+            var scopeWaitElapsed = Stopwatch.GetElapsedTime(scopeWaitStart);
 
-        // Phase 2: handler invocation. Linked CTS: deadline or force.
-        var handlerResults = await InvokeHandlersAsync().ConfigureAwait(false);
+            // Phase 2: handler invocation. Linked CTS: deadline or force.
+            var handlerResults = await InvokeHandlersAsync().ConfigureAwait(false);
 
-        // Determine overall status.
-        var status = ResolveStatus(handlerResults);
-        Volatile.Write(ref _status, (int)status);
+            // Determine overall status.
+            var status = ResolveStatus(handlerResults);
+            Volatile.Write(ref _status, (int)status);
 
-        // Transition to Drained, then to Disposed (disposes provider).
-        await _shell.ForceAdvanceAsync(ShellLifecycleState.Drained).ConfigureAwait(false);
-        await _shell.DisposeAsync().ConfigureAwait(false);
-
-        return new DrainResult(_shell.Descriptor, status, scopeWaitElapsed, abandonedScopes, handlerResults);
+            return new DrainResult(_shell.Descriptor, status, scopeWaitElapsed, abandonedScopes, handlerResults);
+        }
+        finally
+        {
+            // Transition to Drained, then to Disposed (disposes provider) — in a finally so a
+            // faulted drain phase (e.g. IDrainHandler resolution failure) cannot park the
+            // generation in Draining forever. Disposed-keyed cleanup (endpoint removal,
+            // middleware pipeline removal) depends on this transition always firing.
+            await _shell.ForceAdvanceAsync(ShellLifecycleState.Drained).ConfigureAwait(false);
+            await _shell.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private async Task<int> AwaitScopeReleaseAsync()

--- a/tests/CShells.Tests.EndToEnd/ShellMiddlewareFeatureTests.cs
+++ b/tests/CShells.Tests.EndToEnd/ShellMiddlewareFeatureTests.cs
@@ -1,0 +1,59 @@
+namespace CShells.Tests.EndToEnd;
+
+/// <summary>
+/// End-to-end tests for the <c>IMiddlewareShellFeature</c> seam via the Workbench sample's
+/// RequestStamp feature (enabled for Acme only). The feature mounts an <c>IMiddleware</c>-style
+/// middleware — resolved from the shell scope through <c>IMiddlewareFactory</c> — that stamps
+/// responses with an <c>X-Shell-Stamp</c> header. Workbench shells activate lazily, so the first
+/// request exercises the dynamic (post-startup) middleware registration path.
+/// </summary>
+[Collection("Workbench")]
+public class ShellMiddlewareFeatureTests(WorkbenchApplicationFactory factory)
+{
+    private const string StampHeader = "X-Shell-Stamp";
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact(DisplayName = "Middleware feature runs for a lazily (dynamically) activated shell")]
+    public async Task MiddlewareFeature_RunsOnLazilyActivatedShell()
+    {
+        var response = await _client.GetAsync("/acme/");
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("Acme", Assert.Single(response.Headers.GetValues(StampHeader)));
+    }
+
+    [Fact(DisplayName = "Middleware feature does not run for shells that do not enable it")]
+    public async Task MiddlewareFeature_DoesNotRunForOtherShells()
+    {
+        var response = await _client.GetAsync("/contoso/");
+
+        response.EnsureSuccessStatusCode();
+        Assert.False(response.Headers.Contains(StampHeader));
+    }
+
+}
+
+/// <summary>
+/// Reload coverage for the middleware seam. Uses its own application instance (not the shared
+/// "Workbench" collection fixture) because reloading Acme advances its generation, which would
+/// leak into tests that assert on generation numbers.
+/// </summary>
+public class ShellMiddlewareFeatureReloadTests
+{
+    [Fact(DisplayName = "Middleware feature still runs after a shell reload (new generation)")]
+    public async Task MiddlewareFeature_RunsAfterReload()
+    {
+        await using var factory = new WorkbenchApplicationFactory();
+        var client = factory.CreateClient();
+
+        (await client.GetAsync("/acme/")).EnsureSuccessStatusCode(); // activate generation 1
+
+        var reload = await client.PostAsync("/_admin/shells/reload/Acme", null);
+        reload.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/acme/");
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("Acme", Assert.Single(response.Headers.GetValues("X-Shell-Stamp")));
+    }
+}

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,3 +1,4 @@
+using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
 using CShells.AspNetCore.Notifications;
 using CShells.Features;
@@ -103,7 +104,8 @@ public class DynamicShellEndpointDataSourceTests
             dataSource,
             new NoopFeatureFactory(),
             new EndpointRouteBuilderAccessor(),
-            new ApplicationBuilderAccessor());
+            new ApplicationBuilderAccessor(),
+            new ShellMiddlewarePipelineRegistry());
 
         dataSource.AddEndpoints([CreateEndpoint("default/api/items", shellId, 1, settings)]);
 

--- a/tests/CShells.Tests/Integration/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,8 @@
 using CShells.DependencyInjection;
+using CShells.Lifecycle;
 using CShells.Resolution;
+using CShells.Tests.TestHelpers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -108,6 +111,80 @@ public class ServiceCollectionExtensionsTests
         Assert.Equal(1, counter);
     }
 
+    [Fact(DisplayName = "AddCShellsAspNetCore registers a scoped IMiddlewareFactory when the host has none")]
+    public void AddCShellsAspNetCore_RegistersScopedMiddlewareFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+
+        CShells.AspNetCore.Extensions.ServiceCollectionExtensions.AddCShellsAspNetCore(services);
+
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IMiddlewareFactory));
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+        Assert.Equal(typeof(MiddlewareFactory), descriptor.ImplementationType);
+    }
+
+    [Fact(DisplayName = "AddCShellsAspNetCore does not override a host-registered IMiddlewareFactory")]
+    public void AddCShellsAspNetCore_WithHostMiddlewareFactory_DoesNotOverride()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddScoped<IMiddlewareFactory, CustomMiddlewareFactory>();
+
+        CShells.AspNetCore.Extensions.ServiceCollectionExtensions.AddCShellsAspNetCore(services);
+
+        using var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        Assert.IsType<CustomMiddlewareFactory>(scope.ServiceProvider.GetRequiredService<IMiddlewareFactory>());
+    }
+
+    [Fact(DisplayName = "Shell scopes resolve IMiddlewareFactory even when the host never registered one")]
+    public async Task ShellScope_ResolvesMiddlewareFactory_FromRootCopy()
+    {
+        // A plain ServiceCollection root (no web host) has no IMiddlewareFactory of its own;
+        // the shell container must still carry the one AddCShellsAspNetCore registers,
+        // via ShellProviderBuilder.CopyRootServices.
+        var stub = new StubShellBlueprintProvider().Add("acme");
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        CShells.AspNetCore.Extensions.ServiceCollectionExtensions.AddCShellsAspNetCore(services, cshells =>
+        {
+            cshells.WithAssemblies(); // no feature discovery
+            cshells.AddBlueprintProvider(_ => stub);
+        });
+        await using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IShellRegistry>();
+
+        var shell = await registry.GetOrActivateAsync("acme");
+        await using var scope = shell.BeginScope();
+
+        Assert.IsType<MiddlewareFactory>(scope.ServiceProvider.GetRequiredService<IMiddlewareFactory>());
+    }
+
+    [Fact(DisplayName = "Shell containers do not get a duplicate ShellMiddlewarePipelineRegistry")]
+    public async Task ShellScope_DoesNotResolvePipelineRegistry()
+    {
+        // The registry is root-only dispatch infrastructure. Copying its descriptor into shell
+        // containers would hand shell-scoped consumers a fresh, permanently-empty instance —
+        // resolution from a shell scope must fail loudly (null) instead.
+        var stub = new StubShellBlueprintProvider().Add("acme");
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        CShells.AspNetCore.Extensions.ServiceCollectionExtensions.AddCShellsAspNetCore(services, cshells =>
+        {
+            cshells.WithAssemblies();
+            cshells.AddBlueprintProvider(_ => stub);
+        });
+        await using var sp = services.BuildServiceProvider();
+
+        Assert.NotNull(sp.GetService<CShells.AspNetCore.Middleware.ShellMiddlewarePipelineRegistry>());
+
+        var shell = await sp.GetRequiredService<IShellRegistry>().GetOrActivateAsync("acme");
+        await using var scope = shell.BeginScope();
+
+        Assert.Null(scope.ServiceProvider.GetService<CShells.AspNetCore.Middleware.ShellMiddlewarePipelineRegistry>());
+    }
+
     private static ServiceProvider BuildProvider(Action<CShellsBuilder>? configure = null)
     {
         var services = new ServiceCollection();
@@ -132,5 +209,11 @@ public class ServiceCollectionExtensionsTests
     {
         public Task<ShellId?> ResolveAsync(ShellResolutionContext context, CancellationToken cancellationToken = default) =>
             Task.FromResult<ShellId?>(null);
+    }
+
+    private sealed class CustomMiddlewareFactory : IMiddlewareFactory
+    {
+        public IMiddleware? Create(Type middlewareType) => null;
+        public void Release(IMiddleware middleware) { }
     }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
@@ -1,0 +1,366 @@
+using CShells.AspNetCore.Features;
+using CShells.AspNetCore.Middleware;
+using CShells.AspNetCore.Notifications;
+using CShells.AspNetCore.Routing;
+using CShells.Features;
+using CShells.Lifecycle;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CShells.Tests.Integration.AspNetCore;
+
+/// <summary>
+/// Tests for the middleware side of <see cref="ShellEndpointRegistrationHandler"/>: building
+/// per-shell pipelines from <see cref="IMiddlewareShellFeature"/>s on activation, ordering,
+/// path-prefix semantics, composition failure policy, and generation-aware teardown.
+/// </summary>
+public class ShellEndpointRegistrationHandlerMiddlewareTests
+{
+    private readonly ShellMiddlewarePipelineRegistry _pipelines = new();
+    private readonly ApplicationBuilderAccessor _appBuilderAccessor;
+    private readonly ShellEndpointRegistrationHandler _handler;
+
+    public ShellEndpointRegistrationHandlerMiddlewareTests()
+    {
+        var rootProvider = new ServiceCollection().BuildServiceProvider();
+        _appBuilderAccessor = new ApplicationBuilderAccessor { ApplicationBuilder = new ApplicationBuilder(rootProvider) };
+        _handler = new ShellEndpointRegistrationHandler(
+            new DynamicShellEndpointDataSource(),
+            new ActivatorFeatureFactory(),
+            new EndpointRouteBuilderAccessor { EndpointRouteBuilder = new FakeEndpointRouteBuilder(rootProvider) },
+            _appBuilderAccessor,
+            _pipelines);
+    }
+
+    [Fact(DisplayName = "Initializing → Active with middleware features registers a pipeline for the shell generation")]
+    public async Task ActiveTransition_WithMiddlewareFeatures_RegistersPipeline()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        Assert.NotNull(GetPipeline("acme", 1));
+    }
+
+    [Fact(DisplayName = "Initializing → Active without middleware features registers no pipeline")]
+    public async Task ActiveTransition_WithoutMiddlewareFeatures_RegistersNoPipeline()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null);
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        Assert.Null(GetPipeline("acme", 1));
+    }
+
+    [Fact(DisplayName = "Features apply in ascending Order; a feature without an override defaults to 0")]
+    public async Task Pipeline_AppliesFeatures_InAscendingOrder()
+    {
+        // Discovery order deliberately scrambled relative to Order values.
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null,
+            ("Late", typeof(LateFeature)),        // Order 10
+            ("Default", typeof(DefaultOrderFeature)), // no override → 0
+            ("Early", typeof(EarlyFeature)));     // Order -10
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1);
+
+        Assert.Equal(["early", "default", "late"], run.Markers);
+        Assert.True(run.ContinuationCalled);
+    }
+
+    [Fact(DisplayName = "Features with equal Order preserve feature-discovery order")]
+    public async Task Pipeline_EqualOrder_PreservesDiscoveryOrder()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null,
+            ("Alpha", typeof(AlphaFeature)),
+            ("Bravo", typeof(BravoFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1);
+
+        Assert.Equal(["alpha", "bravo"], run.Markers);
+    }
+
+    [Fact(DisplayName = "Pipeline is removed on Disposed, but kept through Deactivating and Draining")]
+    public async Task TeardownTransitions_RemovePipelineOnlyOnDisposed()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Active, ShellLifecycleState.Deactivating);
+        Assert.NotNull(GetPipeline("acme", 1));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Deactivating, ShellLifecycleState.Draining);
+        Assert.NotNull(GetPipeline("acme", 1));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Draining, ShellLifecycleState.Disposed);
+        Assert.Null(GetPipeline("acme", 1));
+    }
+
+    [Fact(DisplayName = "Reload: disposing the old generation leaves the new generation's pipeline intact")]
+    public async Task Reload_OldGenerationDisposed_NewGenerationKept()
+    {
+        var gen1 = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+        var gen2 = CreateShell("acme", generation: 2, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+
+        await _handler.OnStateChangedAsync(gen1, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        // ReloadAsync activates the new generation before deactivating the old one.
+        await _handler.OnStateChangedAsync(gen2, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await _handler.OnStateChangedAsync(gen1, ShellLifecycleState.Draining, ShellLifecycleState.Disposed);
+
+        Assert.Null(GetPipeline("acme", 1));
+        Assert.NotNull(GetPipeline("acme", 2));
+    }
+
+    [Fact(DisplayName = "Prefixed shell: features see the stripped PathBase; the continuation sees the full path again")]
+    public async Task PrefixedShell_MatchingRequest_StripsAndReappliesPrefix()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("PathCapture", typeof(PathCaptureFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1, path: "/acme/orders");
+
+        Assert.Equal("/orders", run.FeaturePath);
+        Assert.Equal("/acme", run.FeaturePathBase);
+        Assert.True(run.ContinuationCalled);
+        Assert.Equal("/acme/orders", run.ContinuationPath);
+        Assert.Equal("", run.ContinuationPathBase);
+    }
+
+    [Fact(DisplayName = "Prefixed shell: a Path rewrite made by feature middleware survives into the continuation")]
+    public async Task PrefixedShell_FeatureRewrite_IsPreservedDownstream()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("Rewrite", typeof(PathRewriteFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1, path: "/acme/orders");
+
+        // The feature rewrote "/orders" → "/rewritten/orders"; the terminal re-applies the
+        // stripped prefix around the rewrite instead of resetting to the original path.
+        Assert.True(run.ContinuationCalled);
+        Assert.Equal("/acme/rewritten/orders", run.ContinuationPath);
+    }
+
+    [Fact(DisplayName = "Non-prefixed shell: a Path rewrite made by feature middleware flows downstream untouched")]
+    public async Task NonPrefixedShell_FeatureRewrite_IsPreservedDownstream()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Rewrite", typeof(PathRewriteFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1, path: "/orders");
+
+        Assert.True(run.ContinuationCalled);
+        Assert.Equal("/rewritten/orders", run.ContinuationPath);
+    }
+
+    [Fact(DisplayName = "Prefixed shell: a request outside the prefix skips the features but still rejoins the pipeline")]
+    public async Task PrefixedShell_NonMatchingRequest_SkipsFeaturesAndContinues()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("PathCapture", typeof(PathCaptureFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1, path: "/other");
+
+        Assert.Null(run.FeaturePath);
+        Assert.True(run.ContinuationCalled);
+        Assert.Equal("/other", run.ContinuationPath);
+    }
+
+    [Fact(DisplayName = "A root path prefix (\"/\") means no prefix scoping and does not throw")]
+    public async Task RootPathPrefix_TreatedAsNoPrefix()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: "/", ("Alpha", typeof(AlphaFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var run = await InvokePipelineAsync("acme", 1, path: "/anything");
+
+        Assert.Equal(["alpha"], run.Markers);
+        Assert.True(run.ContinuationCalled);
+    }
+
+    [Fact(DisplayName = "A middleware feature that fails to compose registers a fail-closed 503 pipeline instead of going dark")]
+    public async Task CompositionFailure_RegistersFailClosed503Pipeline()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Broken", typeof(ThrowingFeature)));
+
+        // Must not throw: the lifecycle fan-out would swallow it and leave the shell dark.
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        // Bind the tracking continuation on the FIRST Get — binding is first-wins.
+        var continuationCalled = false;
+        var pipeline = _pipelines.Get(new ShellId("acme"), 1, _ => { continuationCalled = true; return Task.CompletedTask; });
+        Assert.NotNull(pipeline);
+
+        var ctx = new DefaultHttpContext();
+        await pipeline!(ctx);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, ctx.Response.StatusCode);
+        Assert.False(continuationCalled);
+    }
+
+    [Fact(DisplayName = "Without a captured IApplicationBuilder no pipeline is registered and no exception is thrown")]
+    public async Task NoApplicationBuilder_NoPipelineNoThrow()
+    {
+        _appBuilderAccessor.ApplicationBuilder = null;
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        Assert.Null(GetPipeline("acme", 1));
+    }
+
+    [Fact(DisplayName = "RegisterActiveShell replays registration for a shell that activated before MapShells")]
+    public async Task RegisterActiveShell_ReplaysRegistration_AfterBuilderCaptured()
+    {
+        var savedBuilder = _appBuilderAccessor.ApplicationBuilder;
+        _appBuilderAccessor.ApplicationBuilder = null;
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        Assert.Null(GetPipeline("acme", 1));
+
+        // MapShells captures the builder and replays registration for active shells.
+        _appBuilderAccessor.ApplicationBuilder = savedBuilder;
+        _handler.RegisterActiveShell(shell);
+
+        Assert.NotNull(GetPipeline("acme", 1));
+    }
+
+    // =================================================================
+    // Helpers + test doubles
+    // =================================================================
+
+    private RequestDelegate? GetPipeline(string name, int generation) =>
+        _pipelines.Get(new ShellId(name), generation, _ => Task.CompletedTask);
+
+    private static IShell CreateShell(string name, int generation, string? pathPrefix, params (string Id, Type Type)[] features)
+    {
+        var settings = new ShellSettings(new ShellId(name), features.Select(f => f.Id).ToList());
+        if (pathPrefix is not null)
+            settings.ConfigurationData["WebRouting:Path"] = pathPrefix;
+
+        var descriptors = features
+            .Select(f => new ShellFeatureDescriptor(f.Id) { StartupType = f.Type })
+            .ToList();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(settings);
+        services.AddSingleton<IEnumerable<ShellFeatureDescriptor>>(descriptors);
+        return new ShellMiddlewareTests.FakeShell(ShellDescriptor.Create(name, generation), services.BuildServiceProvider());
+    }
+
+    private sealed record PipelineRun(
+        List<string> Markers,
+        bool ContinuationCalled,
+        string? ContinuationPath,
+        string? ContinuationPathBase,
+        string? FeaturePath,
+        string? FeaturePathBase);
+
+    private async Task<PipelineRun> InvokePipelineAsync(string shellName, int generation, string path = "/")
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = path;
+        ctx.Items["markers"] = new List<string>();
+
+        RequestDelegate continuation = c =>
+        {
+            c.Items["continued"] = true;
+            c.Items["cont-path"] = c.Request.Path.Value;
+            c.Items["cont-pathbase"] = c.Request.PathBase.Value;
+            return Task.CompletedTask;
+        };
+        var pipeline = _pipelines.Get(new ShellId(shellName), generation, continuation)
+            ?? throw new InvalidOperationException($"No pipeline registered for '{shellName}' generation {generation}.");
+
+        await pipeline(ctx);
+
+        return new PipelineRun(
+            (List<string>)ctx.Items["markers"]!,
+            ctx.Items.ContainsKey("continued"),
+            ctx.Items.TryGetValue("cont-path", out var cp) ? (string?)cp : null,
+            ctx.Items.TryGetValue("cont-pathbase", out var cpb) ? (string?)cpb : null,
+            ctx.Items.TryGetValue("feature-path", out var fp) ? (string?)fp : null,
+            ctx.Items.TryGetValue("feature-pathbase", out var fpb) ? (string?)fpb : null);
+    }
+
+    private abstract class MarkerFeature(string marker, int order) : IMiddlewareShellFeature
+    {
+        public int Order => order;
+        public void ConfigureServices(IServiceCollection services) { }
+
+        public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) => AddMarker(app, marker);
+
+        public static void AddMarker(IApplicationBuilder app, string marker) =>
+            app.Use(next => ctx =>
+            {
+                ((List<string>)ctx.Items["markers"]!).Add(marker);
+                return next(ctx);
+            });
+    }
+
+    private sealed class EarlyFeature() : MarkerFeature("early", -10);
+
+    private sealed class LateFeature() : MarkerFeature("late", 10);
+
+    private sealed class AlphaFeature() : MarkerFeature("alpha", 0);
+
+    private sealed class BravoFeature() : MarkerFeature("bravo", 0);
+
+    /// <summary>Does not override <see cref="IMiddlewareShellFeature.Order"/> — exercises the interface default of 0.</summary>
+    private sealed class DefaultOrderFeature : IMiddlewareShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+        public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) => MarkerFeature.AddMarker(app, "default");
+    }
+
+    private sealed class PathCaptureFeature : IMiddlewareShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+
+        public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) =>
+            app.Use(next => ctx =>
+            {
+                ctx.Items["feature-path"] = ctx.Request.Path.Value;
+                ctx.Items["feature-pathbase"] = ctx.Request.PathBase.Value;
+                return next(ctx);
+            });
+    }
+
+    /// <summary>Rewrites the request path before calling next — the rewrite must survive into the continuation.</summary>
+    private sealed class PathRewriteFeature : IMiddlewareShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+
+        public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) =>
+            app.Use(next => ctx =>
+            {
+                ctx.Request.Path = new PathString("/rewritten" + ctx.Request.Path.Value);
+                return next(ctx);
+            });
+    }
+
+    private sealed class ThrowingFeature : IMiddlewareShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+        public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) =>
+            throw new InvalidOperationException("broken feature");
+    }
+
+    private sealed class ActivatorFeatureFactory : IShellFeatureFactory
+    {
+        public T CreateFeature<T>(Type featureType, ShellSettings? shellSettings = null, ShellFeatureContext? featureContext = null)
+            where T : class =>
+            (T)Activator.CreateInstance(featureType)!;
+    }
+
+    private sealed class FakeEndpointRouteBuilder(IServiceProvider serviceProvider) : IEndpointRouteBuilder
+    {
+        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
+    }
+}

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -22,13 +22,10 @@ public class ShellMiddlewareLazyActivationTests
     public async Task Request_UnknownShell_Returns404()
     {
         var nextCalled = false;
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => { nextCalled = true; return Task.CompletedTask; },
             new FixedShellResolver("unknown"),
-            new ThrowingRegistry(new ShellBlueprintNotFoundException("unknown")),
-            new DynamicShellEndpointDataSource(),
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            new ThrowingRegistry(new ShellBlueprintNotFoundException("unknown")));
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -44,13 +41,10 @@ public class ShellMiddlewareLazyActivationTests
     {
         var nextCalled = false;
         var inner = new InvalidOperationException("db down");
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => { nextCalled = true; return Task.CompletedTask; },
             new FixedShellResolver("flaky"),
-            new ThrowingRegistry(new ShellBlueprintUnavailableException("flaky", inner)),
-            new DynamicShellEndpointDataSource(),
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            new ThrowingRegistry(new ShellBlueprintUnavailableException("flaky", inner)));
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -68,13 +62,10 @@ public class ShellMiddlewareLazyActivationTests
         var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "acme");
         var registry = new ShellMiddlewareTests.FakeRegistry(shell);
 
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => { nextCalled = true; return Task.CompletedTask; },
             new FixedShellResolver("acme"),
-            registry,
-            new DynamicShellEndpointDataSource(),
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            registry);
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -121,13 +112,11 @@ public class ShellMiddlewareLazyActivationTests
 
         var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "acme");
 
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => ctx.GetEndpoint() is { } ep ? ((RouteEndpoint)ep).RequestDelegate!(ctx) : Task.CompletedTask,
             new FixedShellResolver("acme"),
             new ColdActivatingRegistry(shell),
-            dataSource,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            dataSource);
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -169,13 +158,11 @@ public class ShellMiddlewareLazyActivationTests
             displayName: "spa-fallback");
 
         var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
             new FixedShellResolver("Default"),
             new ColdActivatingRegistry(shell),
-            dataSource,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            dataSource);
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -217,13 +204,11 @@ public class ShellMiddlewareLazyActivationTests
             displayName: "spa-fallback");
 
         var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
             new FixedShellResolver("Default"),
             new ColdActivatingRegistry(shell),
-            dataSource,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            dataSource);
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -265,13 +250,11 @@ public class ShellMiddlewareLazyActivationTests
             displayName: "host-status");
 
         var shell = ShellMiddlewareTests.FakeShell.WithServices(_ => { }, name: "Default");
-        var middleware = new ShellMiddleware(
+        var middleware = CreateMiddleware(
             ctx => ctx.GetEndpoint() is { } endpoint ? ((RouteEndpoint)endpoint).RequestDelegate!(ctx) : Task.CompletedTask,
             new FixedShellResolver("Default"),
             new ColdActivatingRegistry(shell),
-            dataSource,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new ShellMiddlewareOptions()));
+            dataSource);
 
         var ctx = new DefaultHttpContext();
         ctx.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
@@ -291,6 +274,13 @@ public class ShellMiddlewareLazyActivationTests
     // Test doubles
     // =================================================================
 
+    private static ShellMiddleware CreateMiddleware(
+        RequestDelegate next,
+        IShellResolver resolver,
+        IShellRegistry registry,
+        DynamicShellEndpointDataSource? endpointDataSource = null) =>
+        ShellMiddlewareTests.CreateMiddleware(next, resolver, registry, endpointDataSource);
+
     private sealed class FixedShellResolver(string name) : IShellResolver
     {
         public Task<ShellId?> ResolveAsync(ShellResolutionContext context, CancellationToken cancellationToken = default) =>
@@ -300,11 +290,17 @@ public class ShellMiddlewareLazyActivationTests
     /// <summary>
     /// Registry whose <see cref="GetActive"/> always returns <c>null</c> so the middleware
     /// observes a cold activation, while <see cref="GetOrActivateAsync"/> returns a preset
-    /// shell. Used to exercise the cold-start re-match path.
+    /// shell. Used to exercise the cold-start re-match path. The optional
+    /// <paramref name="onActivate"/> callback simulates the inline lifecycle-subscriber work
+    /// (endpoint + middleware-pipeline registration) that happens during real activation.
     /// </summary>
-    private sealed class ColdActivatingRegistry(IShell shell) : IShellRegistry
+    internal sealed class ColdActivatingRegistry(IShell shell, Action? onActivate = null) : IShellRegistry
     {
-        public Task<IShell> GetOrActivateAsync(string name, CancellationToken ct = default) => Task.FromResult(shell);
+        public Task<IShell> GetOrActivateAsync(string name, CancellationToken ct = default)
+        {
+            onActivate?.Invoke();
+            return Task.FromResult(shell);
+        }
         public Task<IShell> ActivateAsync(string name, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<ReloadResult> ReloadAsync(string name, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<ReloadResult>> ReloadActiveAsync(ReloadOptions? options = null, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewarePipelineRegistryTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewarePipelineRegistryTests.cs
@@ -1,0 +1,100 @@
+using CShells.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace CShells.Tests.Integration.AspNetCore;
+
+/// <summary>
+/// Tests for <see cref="ShellMiddlewarePipelineRegistry"/> — the generation-aware map from shell
+/// to composed middleware pipeline that <see cref="ShellMiddleware"/> dispatches through, and the
+/// bind-once <see cref="ShellPipelineContinuation"/> the pipelines rejoin the host pipeline with.
+/// </summary>
+public class ShellMiddlewarePipelineRegistryTests
+{
+    private readonly ShellMiddlewarePipelineRegistry _registry = new();
+    private static readonly RequestDelegate Pipeline1 = _ => Task.CompletedTask;
+    private static readonly RequestDelegate Pipeline2 = _ => Task.CompletedTask;
+    private static readonly RequestDelegate Next = _ => Task.CompletedTask;
+
+    private void Set(string name, int generation, RequestDelegate pipeline) =>
+        _registry.Set(new ShellId(name), generation, pipeline, new ShellPipelineContinuation());
+
+    [Fact(DisplayName = "Get returns the pipeline registered by Set for the same shell and generation")]
+    public void Get_AfterSet_ReturnsPipeline()
+    {
+        Set("acme", 1, Pipeline1);
+
+        Assert.Same(Pipeline1, _registry.Get(new ShellId("acme"), 1, Next));
+    }
+
+    [Fact(DisplayName = "Get returns null for an unregistered shell or generation")]
+    public void Get_Unregistered_ReturnsNull()
+    {
+        Set("acme", 1, Pipeline1);
+
+        Assert.Null(_registry.Get(new ShellId("other"), 1, Next));
+        Assert.Null(_registry.Get(new ShellId("acme"), 2, Next));
+    }
+
+    [Fact(DisplayName = "Shell names are matched case-insensitively")]
+    public void Get_DifferentCasing_ReturnsPipeline()
+    {
+        Set("Acme", 1, Pipeline1);
+
+        Assert.Same(Pipeline1, _registry.Get(new ShellId("ACME"), 1, Next));
+    }
+
+    [Fact(DisplayName = "Set replaces an existing pipeline for the same shell and generation")]
+    public void Set_SameKey_ReplacesPipeline()
+    {
+        Set("acme", 1, Pipeline1);
+        Set("acme", 1, Pipeline2);
+
+        Assert.Same(Pipeline2, _registry.Get(new ShellId("acme"), 1, Next));
+    }
+
+    [Fact(DisplayName = "Removing one generation leaves other generations intact")]
+    public void Remove_OneGeneration_LeavesOthers()
+    {
+        Set("acme", 1, Pipeline1);
+        Set("acme", 2, Pipeline2);
+
+        _registry.Remove(new ShellId("acme"), 1);
+
+        Assert.Null(_registry.Get(new ShellId("acme"), 1, Next));
+        Assert.Same(Pipeline2, _registry.Get(new ShellId("acme"), 2, Next));
+    }
+
+    [Fact(DisplayName = "Remove of an unknown key is a no-op")]
+    public void Remove_UnknownKey_DoesNotThrow()
+    {
+        _registry.Remove(new ShellId("ghost"), 1);
+    }
+
+    [Fact(DisplayName = "Set with a null pipeline or continuation throws ArgumentNullException")]
+    public void Set_NullArguments_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _registry.Set(new ShellId("acme"), 1, null!, new ShellPipelineContinuation()));
+        Assert.Throws<ArgumentNullException>(() => _registry.Set(new ShellId("acme"), 1, Pipeline1, null!));
+    }
+
+    [Fact(DisplayName = "Get binds the continuation to the passed next-delegate; first binding wins")]
+    public void Get_BindsContinuation_FirstWins()
+    {
+        var continuation = new ShellPipelineContinuation();
+        _registry.Set(new ShellId("acme"), 1, Pipeline1, continuation);
+
+        _registry.Get(new ShellId("acme"), 1, Next);
+        Assert.Same(Next, continuation.Next);
+
+        _registry.Get(new ShellId("acme"), 1, Pipeline2); // different delegate: no rebind
+        Assert.Same(Next, continuation.Next);
+    }
+
+    [Fact(DisplayName = "An unbound continuation throws instead of silently dropping the request")]
+    public void Continuation_Unbound_Throws()
+    {
+        var continuation = new ShellPipelineContinuation();
+
+        Assert.Throws<InvalidOperationException>(() => continuation.Next);
+    }
+}

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -135,36 +135,125 @@ public class ShellMiddlewareTests
         Assert.Equal(0, shell.ActiveScopeCount);
     }
 
-    [Theory(DisplayName = "Constructor guard clauses throw ArgumentNullException")]
-    [InlineData(true, false, false, false, false, false, "next")]
-    [InlineData(false, true, false, false, false, false, "resolver")]
-    [InlineData(false, false, true, false, false, false, "registry")]
-    [InlineData(false, false, false, true, false, false, "endpointDataSource")]
-    [InlineData(false, false, false, false, true, false, "cache")]
-    [InlineData(false, false, false, false, false, true, "options")]
-    public void Constructor_GuardClauses_ThrowArgumentNullException(
-        bool nullNext, bool nullResolver, bool nullRegistry, bool nullDataSource, bool nullCache, bool nullOptions, string expectedParam)
+    [Fact(DisplayName = "InvokeAsync with a registered shell pipeline dispatches through it, then rejoins next")]
+    public async Task InvokeAsync_PipelineRegistered_DispatchesThroughShellPipeline()
     {
-        RequestDelegate? next = nullNext ? null : _ => Task.CompletedTask;
-        IShellResolver? resolver = nullResolver ? null : new NullShellResolver();
-        IShellRegistry? registry = nullRegistry ? null : new FakeRegistry();
-        DynamicShellEndpointDataSource? dataSource = nullDataSource ? null : new DynamicShellEndpointDataSource();
-        IMemoryCache? cache = nullCache ? null : new MemoryCache(new MemoryCacheOptions());
-        IOptions<ShellMiddlewareOptions>? options = nullOptions ? null : Options.Create(new ShellMiddlewareOptions());
+        var shell = FakeShell.WithServices(s => s.AddSingleton<ITestService, TestService>(), name: "TestShell");
+        var pipelineRegistry = new ShellMiddlewarePipelineRegistry();
+        var executionOrder = new List<string>();
+        IServiceProvider? servicesInsidePipeline = null;
 
-        var ex = Assert.Throws<ArgumentNullException>(() => new ShellMiddleware(next!, resolver!, registry!, dataSource!, cache!, options!));
-        Assert.Equal(expectedParam, ex.ParamName);
+        var continuation = new ShellPipelineContinuation();
+        pipelineRegistry.Set(new ShellId("TestShell"), shell.Descriptor.Generation, ctx =>
+        {
+            executionOrder.Add("pipeline");
+            servicesInsidePipeline = ctx.RequestServices;
+            return continuation.Next(ctx);
+        }, continuation);
+
+        var middleware = CreateMiddleware(
+            _ => { executionOrder.Add("next"); return Task.CompletedTask; },
+            resolver: new FixedShellResolver("TestShell"),
+            registry: new FakeRegistry(shell),
+            pipelineRegistry: pipelineRegistry);
+
+        var (httpContext, _) = CreateHttpContextWithFireableResponse();
+
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.Equal(["pipeline", "next"], executionOrder);
+        Assert.NotNull(servicesInsidePipeline?.GetService<ITestService>()); // shell scope was already set
+    }
+
+    [Fact(DisplayName = "Another shell's pipeline is not invoked for the resolved shell")]
+    public async Task InvokeAsync_PipelineForDifferentShell_FallsBackToNext()
+    {
+        var shell = FakeShell.WithServices(_ => { }, name: "ShellB");
+        var pipelineRegistry = new ShellMiddlewarePipelineRegistry();
+        var shellAPipelineInvoked = false;
+        var nextCalled = false;
+
+        pipelineRegistry.Set(new ShellId("ShellA"), 1,
+            _ => { shellAPipelineInvoked = true; return Task.CompletedTask; },
+            new ShellPipelineContinuation());
+
+        var middleware = CreateMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            resolver: new FixedShellResolver("ShellB"),
+            registry: new FakeRegistry(shell),
+            pipelineRegistry: pipelineRegistry);
+
+        var (httpContext, _) = CreateHttpContextWithFireableResponse();
+
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.True(nextCalled);
+        Assert.False(shellAPipelineInvoked);
+    }
+
+    [Fact(DisplayName = "Pipeline registered during cold activation runs on the activating request")]
+    public async Task InvokeAsync_ColdActivation_RegistersAndRunsPipelineOnFirstRequest()
+    {
+        // Mirrors the production guarantee: the registry awaits lifecycle subscribers inline
+        // during activation, so the pipeline entry exists before GetOrActivateAsync returns.
+        var shell = FakeShell.WithServices(_ => { }, name: "ColdShell");
+        var pipelineRegistry = new ShellMiddlewarePipelineRegistry();
+        var pipelineInvoked = false;
+
+        var continuation = new ShellPipelineContinuation();
+        var registry = new ShellMiddlewareLazyActivationTests.ColdActivatingRegistry(shell, onActivate: () =>
+            pipelineRegistry.Set(new ShellId("ColdShell"), shell.Descriptor.Generation, ctx =>
+            {
+                pipelineInvoked = true;
+                return continuation.Next(ctx);
+            }, continuation));
+
+        var middleware = CreateMiddleware(
+            _ => Task.CompletedTask,
+            resolver: new FixedShellResolver("ColdShell"),
+            registry: registry,
+            pipelineRegistry: pipelineRegistry);
+
+        var (httpContext, _) = CreateHttpContextWithFireableResponse();
+        httpContext.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.True(pipelineInvoked);
+    }
+
+    [Theory(DisplayName = "Constructor guard clauses throw ArgumentNullException")]
+    [InlineData("next")]
+    [InlineData("resolver")]
+    [InlineData("registry")]
+    [InlineData("endpointDataSource")]
+    [InlineData("pipelineRegistry")]
+    [InlineData("cache")]
+    [InlineData("options")]
+    public void Constructor_GuardClauses_ThrowArgumentNullException(string nullParam)
+    {
+        RequestDelegate? next = nullParam == "next" ? null : _ => Task.CompletedTask;
+        IShellResolver? resolver = nullParam == "resolver" ? null : new NullShellResolver();
+        IShellRegistry? registry = nullParam == "registry" ? null : new FakeRegistry();
+        DynamicShellEndpointDataSource? dataSource = nullParam == "endpointDataSource" ? null : new DynamicShellEndpointDataSource();
+        ShellMiddlewarePipelineRegistry? pipelineRegistry = nullParam == "pipelineRegistry" ? null : new ShellMiddlewarePipelineRegistry();
+        IMemoryCache? cache = nullParam == "cache" ? null : new MemoryCache(new MemoryCacheOptions());
+        IOptions<ShellMiddlewareOptions>? options = nullParam == "options" ? null : Options.Create(new ShellMiddlewareOptions());
+
+        var ex = Assert.Throws<ArgumentNullException>(() => new ShellMiddleware(next!, resolver!, registry!, dataSource!, pipelineRegistry!, cache!, options!));
+        Assert.Equal(nullParam, ex.ParamName);
     }
 
     // =================================================================
     // Test doubles
     // =================================================================
 
-    private static ShellMiddleware CreateMiddleware(
+    internal static ShellMiddleware CreateMiddleware(
         RequestDelegate next,
         IShellResolver? resolver = null,
         IShellRegistry? registry = null,
         DynamicShellEndpointDataSource? endpointDataSource = null,
+        ShellMiddlewarePipelineRegistry? pipelineRegistry = null,
         IMemoryCache? cache = null,
         IOptions<ShellMiddlewareOptions>? options = null) =>
         new(
@@ -172,6 +261,7 @@ public class ShellMiddlewareTests
             resolver ?? new NullShellResolver(),
             registry ?? new FakeRegistry(),
             endpointDataSource ?? new DynamicShellEndpointDataSource(),
+            pipelineRegistry ?? new ShellMiddlewarePipelineRegistry(),
             cache ?? new MemoryCache(new MemoryCacheOptions()),
             options ?? Options.Create(new ShellMiddlewareOptions()));
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -189,7 +189,13 @@ Services registered in the root application (e.g., `ILogger<T>`, `IHttpClientFac
 2. Gets or activates the matching `IShell` from `IShellRegistry`.
 3. Creates a tracked scope from the shell with `IShell.BeginScope()`.
 4. Sets `HttpContext.RequestServices` to the shell-scoped provider.
-5. Passes control to the next middleware (endpoint routing).
+5. Dispatches through the shell's composed feature middleware pipeline (if any), then passes control to the next middleware (endpoint routing).
+
+### Per-Shell Middleware Pipelines
+
+When a shell activates (at startup, lazily on first request, dynamically at runtime, or on reload), its `IMiddlewareShellFeature`s are composed — in ascending `Order`, ties preserving feature-dependency order — into a per-shell pipeline stored in `ShellMiddlewarePipelineRegistry`, keyed by shell name and generation. `ShellMiddleware` dispatches matching requests through this pipeline before rejoining the host pipeline, so shell feature middleware runs only for that shell's requests and works for shells activated after the host pipeline was built. Shells that activated before `MapShells()` ran are registered retroactively when `MapShells()` is called.
+
+Entries are removed when a generation is disposed. `ShellMiddleware` resolves the pipeline delegate before taking the request's shell scope, so a concurrent disposal (bounded or forced drain) can never silently skip a shell's middleware: a request either holds the delegate — usable for the rest of that request — or fails loudly when the scope is taken. If a shell's middleware cannot be composed (a feature throws during activation), the shell fails closed: a pipeline that answers 503 is registered in its place until the shell is successfully reloaded.
 
 ### Shell Resolver
 

--- a/wiki/Creating-Features.md
+++ b/wiki/Creating-Features.md
@@ -117,6 +117,16 @@ public class RequestLoggingFeature : IMiddlewareShellFeature
 
 Middleware registered here runs inside the shell's service provider scope, so services resolved from `HttpContext.RequestServices` come from the correct shell.
 
+How the pipeline behaves:
+
+- **Per-shell scoping** — each shell's middleware is composed into its own pipeline and runs **only** for requests resolved to that shell (never for other shells' requests or unresolved requests).
+- **Position** — the shell pipeline executes at the point where `MapShells()` was called, immediately after shell resolution sets `HttpContext.RequestServices`. Middleware the host registers before `MapShells()` (e.g. authentication) runs before shell feature middleware.
+- **Dynamic activation** — the pipeline is built whenever the shell activates: at startup, lazily on first request, dynamically at runtime, and again for each new generation on reload. Shells activated before `MapShells()` are registered retroactively when `MapShells()` runs.
+- **Ordering** — override the interface's `Order` property (default `0`) to control the order in which features' middleware is applied within the shell's pipeline. Lower values run earlier (outermost); ties preserve feature-dependency order.
+- **Path prefix** — for shells with a `WebRouting:Path`, feature middleware only runs for requests under the prefix and sees the prefix-stripped `PathBase`/`Path`; the prefix is re-applied before the host pipeline continues, so path rewrites made by feature middleware are preserved downstream. A path of `/` means root-mounted (no prefix scoping).
+- **Failure policy** — if a shell's middleware cannot be composed at activation (a feature throws), the shell fails closed: it answers 503 to every request until it is successfully reloaded, rather than serving without its middleware.
+- **`IMiddleware` support** — middleware classes implementing `IMiddleware` are resolved per request from the shell scope; CShells guarantees an `IMiddlewareFactory` is registered in shell containers. See the Workbench sample's `RequestStampFeature` for a complete example.
+
 ---
 
 ## `[ShellFeature]` Attribute


### PR DESCRIPTION
Closes the three platform gaps in the ASP.NET middleware seam confirmed by the elsa-foundation spec-089 review (elsa-foundation PR #578), per the "enhance the platform, don't design around it" rule.

## The three gaps

1. **Ordering hook** — `IMiddlewareShellFeature` gains `int Order => 0` (default interface member; existing implementations compile unchanged). Features apply in ascending `Order`; ties preserve feature-dependency order. Consumers like Elsa's `ActivitiesHttpFeature` can now declare "after authentication".
2. **`IMiddlewareFactory` in shell containers** — `AddCShellsAspNetCore` registers `TryAddScoped<IMiddlewareFactory, MiddlewareFactory>()`, flowing into every shell container via root-copy. `IMiddleware`-style shell middleware works without per-feature workarounds; host registrations win.
3. **Dynamic shell middleware** — feature middleware now composes into per-shell pipelines (`ShellMiddlewarePipelineRegistry`, keyed by shell name + generation), built on every activation — startup, lazy, dynamic, reload — and dispatched by `ShellMiddleware`. The old append-to-root-builder approach was a silent no-op for shells activated after the pipeline was built, and its prefixed `Map(...)` branch never rejoined the root pipeline.

## Hardening (from self-review)

- **Fail-closed activation**: a middleware feature that fails to compose registers a 503 pipeline instead of silently darkening the tenant (the lifecycle fan-out swallows subscriber exceptions, so the shell goes Active regardless).
- **Race-free dispatch**: pipeline delegates resolve before `BeginScope`, so bounded/forced drains can never silently skip a shell's middleware.
- **No leaks**: `DrainOperation` disposes the generation in a `finally`; faulted drains can't park generations in `Draining` and retain pipeline entries.
- **Path semantics**: prefixed terminals re-apply the stripped prefix (preserving feature path rewrites downstream); `WebRouting:Path` of `/` now means root-mounted instead of throwing at activation.
- **Replay**: `MapShells()` retroactively registers shells that activated before it ran (also fixes the pre-existing endpoint gap).
- `ShellMiddlewarePipelineRegistry` excluded from shell containers; continuations bind once per pipeline (zero per-request allocation).

## Behavior changes (intentional)

No `IMiddlewareShellFeature` implementations existed in-repo, and the prefixed path was latently broken, so real-world impact is minimal — but on paper:
- Shell middleware runs **only** for requests resolved to that shell (a no-prefix shell's middleware no longer runs globally).
- It runs at the `MapShells()` position, not appended at the end of the root pipeline.
- `ShellMiddleware`'s constructor gains a required parameter.

## Tests

New Workbench `RequestStamp` sample feature (`IMiddleware`-based, so it exercises the factory path E2E) with E2E coverage for lazy (dynamic) activation, cross-shell isolation, and reload; handler/registry/middleware integration suites for ordering, teardown transitions, prefix strip/re-apply, rewrite preservation, fail-closed 503, and `MapShells` replay. 566 unit/integration + 31 E2E tests green across net8/9/10.

## Follow-up (elsa-foundation)

Once this ships, `ActivitiesHttpFeature` can drop its `TryAddTransient<IMiddlewareFactory>` workaround and its (inaccurate) comment about shell containers lacking ASP.NET default services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)