### PR TITLE
Add IShellTerminator shell shutdown lifecycle hook

### DIFF
--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -10,7 +10,7 @@ A shell generation moves through:
 Initializing -> Active -> Deactivating -> Draining -> Drained -> Disposed
 ```
 
-`IShellInitializer` instances run while the shell is `Initializing`, before the generation is published as `Active`. `IDrainHandler` instances run while the shell is `Draining`, after outstanding `IShellScope` handles finish or the drain deadline is reached.
+`IShellInitializer` instances run while the shell is `Initializing`, before the generation is published as `Active`. `IDrainHandler` instances run while the shell is `Draining`, after outstanding `IShellScope` handles finish or the drain deadline is reached. `IShellTerminator` instances run while the shell is `Drained`, after all drain handlers complete and before the shell's service provider is disposed.
 
 ## Initializer Ordering
 
@@ -123,11 +123,50 @@ public sealed class QuartzPostgreSqlFeature : IShellFeature
 
 Quartz configures first because `QuartzPostgreSqlFeature` depends on `QuartzFeature`. PostgreSQL migrations run first because they are in `Prepare`; the scheduler starts later in `Start`.
 
+## Terminator Ordering
+
+`IShellTerminator` is the teardown counterpart to `IShellInitializer`: ordered, sequential shutdown work that runs during graceful drain, after the shell reaches `Drained` and before its service provider is disposed. **The shell container is fully usable during termination** — terminators are resolved from a fresh scope of the shell's provider and may resolve any shell service. This is the home for teardown that must coordinate across services (flush A before B, stop a task that drains another singleton), which cannot be expressed in singleton `Dispose`/`DisposeAsync` because MS DI disposes singletons in reverse realization order.
+
+Register terminators with `AddShellTerminator<TTerminator>()`, typically paired with the matching initializer at the same phase and order:
+
+```csharp
+[ShellFeature("Runtime")]
+public sealed class RuntimeFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddShellInitializer<StartRuntime>(LifecyclePhase.Start, order: 100);
+        services.AddShellTerminator<StopRuntime>(LifecyclePhase.Start, order: 100);
+    }
+}
+```
+
+Terminators reuse `LifecyclePhase` but execute **mirror-reversed**:
+
+1. `LifecyclePhase.Start`
+2. `LifecyclePhase.Default`
+3. `LifecyclePhase.Prepare`
+
+Within a phase, higher numeric `order` runs first, and equal phase/order ties run in reverse DI registration order (reported as non-fatal diagnostics). A terminator registered with the same phase/order as an initializer therefore tears down at the mirrored point — whatever started last stops first:
+
+| Initializer (startup order)          | Terminator (teardown order)          |
+| ------------------------------------ | ------------------------------------ |
+| 1. `ApplyMigrations` (Prepare, 100)  | 1. `StopRuntime` (Start, 100)        |
+| 2. `WarmCache` (Default, 0)          | 2. `FlushCache` (Default, 0)         |
+| 3. `StartRuntime` (Start, 100)       | 3. `ReleaseStorage` (Prepare, 100)   |
+
+Semantics:
+
+- **Sequential, log-and-continue.** Terminators run one at a time (unlike parallel drain handlers). A terminator that throws is logged and recorded in `DrainResult.TerminatorResults`; the remaining terminators still run. Terminator failures never change the `DrainStatus`.
+- **Cancellation budget.** Terminators share one cancellation token: the remaining drain deadline, never less than the grace period (scope-wait and drain handlers may have consumed the deadline). After a force-drain, terminators get one fresh grace-period-bounded chance instead of an already-cancelled token. Under an unbounded policy termination is unbounded, interruptible by `ForceAsync`. A terminator that ignores its token is abandoned after cancellation plus the grace period; disposal proceeds.
+- **Graceful drain only.** Terminators run on every path that drains (host shutdown, `ReloadAsync`, `UnregisterBlueprintAsync`, force-drain). They do **not** run on the emergency-dispose path taken when the host's shutdown timeout is breached — terminators are a graceful-drain facility, not a guaranteed destructor. Singleton `Dispose`/`DisposeAsync` remains the last-resort cleanup.
+- **Compatibility.** Legacy `services.AddTransient<IShellTerminator, X>()` registrations run in `LifecyclePhase.Default`, in reverse DI registration order. `LifecycleOrderAttribute` applies to terminator types the same way it does to initializers.
+
 ## Drain
 
-Drain behavior is intentionally unchanged by initializer ordering. `IDrainHandler` implementations are resolved from the shell provider and invoked in parallel during `Draining`.
+Drain behavior is intentionally unchanged by initializer ordering. `IDrainHandler` implementations are resolved from the shell provider and invoked in parallel during `Draining` — they are the cooperative "let in-flight work finish" hook. Ordered teardown is provided by `IShellTerminator` (see [Terminator Ordering](#terminator-ordering)), which runs after all drain handlers complete. Per-terminator outcomes are reported in `DrainResult.TerminatorResults` alongside `HandlerResults`.
 
-Ordered or phased drain execution is deferred to a future design. Existing deadline, force-drain, grace-period, and result-reporting behavior remains the compatibility baseline.
+Existing deadline, force-drain, grace-period, and result-reporting behavior remains the compatibility baseline.
 
 ## Diagnostics
 

--- a/src/CShells.Abstractions/Lifecycle/DrainResult.cs
+++ b/src/CShells.Abstractions/Lifecycle/DrainResult.cs
@@ -24,9 +24,14 @@ public enum DrainStatus
 /// Scope handles still outstanding when phase 1 ended (non-zero only when the phase was bounded out by the deadline).
 /// </param>
 /// <param name="HandlerResults">One entry per registered <see cref="IDrainHandler"/>.</param>
+/// <param name="TerminatorResults">
+/// One entry per resolved <see cref="IShellTerminator"/>; empty when termination was skipped
+/// (no terminators, ordering-plan failure, or provider already disposed).
+/// </param>
 public sealed record DrainResult(
     ShellDescriptor Shell,
     DrainStatus Status,
     TimeSpan ScopeWaitElapsed,
     int AbandonedScopeCount,
-    IReadOnlyList<DrainHandlerResult> HandlerResults);
+    IReadOnlyList<DrainHandlerResult> HandlerResults,
+    IReadOnlyList<ShellTerminatorResult> TerminatorResults);

--- a/src/CShells.Abstractions/Lifecycle/DrainResult.cs
+++ b/src/CShells.Abstractions/Lifecycle/DrainResult.cs
@@ -24,14 +24,31 @@ public enum DrainStatus
 /// Scope handles still outstanding when phase 1 ended (non-zero only when the phase was bounded out by the deadline).
 /// </param>
 /// <param name="HandlerResults">One entry per registered <see cref="IDrainHandler"/>.</param>
-/// <param name="TerminatorResults">
-/// One entry per resolved <see cref="IShellTerminator"/>; empty when termination was skipped
-/// (no terminators, ordering-plan failure, or provider already disposed).
-/// </param>
 public sealed record DrainResult(
     ShellDescriptor Shell,
     DrainStatus Status,
     TimeSpan ScopeWaitElapsed,
     int AbandonedScopeCount,
-    IReadOnlyList<DrainHandlerResult> HandlerResults,
-    IReadOnlyList<ShellTerminatorResult> TerminatorResults);
+    IReadOnlyList<DrainHandlerResult> HandlerResults)
+{
+    /// <summary>
+    /// Creates a drain result with per-terminator details.
+    /// </summary>
+    public DrainResult(
+        ShellDescriptor shell,
+        DrainStatus status,
+        TimeSpan scopeWaitElapsed,
+        int abandonedScopeCount,
+        IReadOnlyList<DrainHandlerResult> handlerResults,
+        IReadOnlyList<ShellTerminatorResult> terminatorResults)
+        : this(shell, status, scopeWaitElapsed, abandonedScopeCount, handlerResults)
+    {
+        TerminatorResults = terminatorResults;
+    }
+
+    /// <summary>
+    /// One entry per resolved <see cref="IShellTerminator"/>; empty when termination was skipped
+    /// (no terminators, ordering-plan failure, or provider already disposed).
+    /// </summary>
+    public IReadOnlyList<ShellTerminatorResult> TerminatorResults { get; init; } = [];
+}

--- a/src/CShells.Abstractions/Lifecycle/IDrainHandler.cs
+++ b/src/CShells.Abstractions/Lifecycle/IDrainHandler.cs
@@ -8,9 +8,9 @@ namespace CShells.Lifecycle;
 /// <remarks>
 /// Register implementations as transient services via <c>IShellFeature.ConfigureServices</c>.
 /// All handlers on a draining shell are resolved from the shell's <see cref="IServiceProvider"/>
-/// and invoked in parallel. Lifecycle phase and order metadata currently applies to
-/// <see cref="IShellInitializer"/> only; ordered drain phases are intentionally deferred so
-/// existing drain handlers keep their parallel behavior.
+/// and invoked in parallel; lifecycle phase and order metadata does not apply to them. For
+/// ordered teardown that runs after all drain handlers complete — while the shell container is
+/// still fully usable — implement <see cref="IShellTerminator"/> instead.
 /// </remarks>
 public interface IDrainHandler
 {

--- a/src/CShells.Abstractions/Lifecycle/IShellTerminator.cs
+++ b/src/CShells.Abstractions/Lifecycle/IShellTerminator.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Performs ordered teardown work for a shell during graceful drain, after the shell has
+/// transitioned to <see cref="ShellLifecycleState.Drained"/> and before its service provider
+/// is disposed.
+/// </summary>
+/// <remarks>
+/// The shell container is fully usable during termination: terminators are resolved from a
+/// scope of the shell's provider and may resolve any shell service. Register implementations
+/// via <c>IShellFeature.ConfigureServices</c> using
+/// <see cref="ServiceCollectionLifecycleExtensions.AddShellTerminator{TTerminator}(IServiceCollection, LifecyclePhase, int)"/>
+/// or <see cref="LifecycleOrderAttribute"/>. Terminators run sequentially in mirror-reversed
+/// lifecycle order — <see cref="LifecyclePhase.Start"/> first, <see cref="LifecyclePhase.Prepare"/>
+/// last, descending order within a phase — so a terminator registered with the same phase and
+/// order as an initializer tears down at the mirrored point. A terminator that throws is logged
+/// and does not prevent the remaining terminators from running. Terminators do not run on the
+/// emergency-dispose path (host shutdown-timeout breach); singleton
+/// <see cref="IDisposable"/>/<see cref="IAsyncDisposable"/> remains the last-resort cleanup.
+/// </remarks>
+public interface IShellTerminator
+{
+    /// <summary>Performs termination work.</summary>
+    Task TerminateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/CShells.Abstractions/Lifecycle/LifecycleOrderAttribute.cs
+++ b/src/CShells.Abstractions/Lifecycle/LifecycleOrderAttribute.cs
@@ -1,12 +1,14 @@
 namespace CShells.Lifecycle;
 
 /// <summary>
-/// Declares default lifecycle ordering metadata for an initializer type.
+/// Declares default lifecycle ordering metadata for a lifecycle component (initializer or
+/// terminator) type.
 /// </summary>
 /// <remarks>
 /// Explicit metadata supplied by <see cref="ServiceCollectionLifecycleExtensions.AddShellInitializer{TInitializer}(Microsoft.Extensions.DependencyInjection.IServiceCollection, LifecyclePhase, int)"/>
-/// takes precedence over this attribute. The attribute is read from the initializer type and
-/// does not require constructing the initializer before the shell provider exists.
+/// or <see cref="ServiceCollectionLifecycleExtensions.AddShellTerminator{TTerminator}(Microsoft.Extensions.DependencyInjection.IServiceCollection, LifecyclePhase, int)"/>
+/// takes precedence over this attribute. The attribute is read from the component type and
+/// does not require constructing the component before the shell provider exists.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
 public sealed class LifecycleOrderAttribute : Attribute

--- a/src/CShells.Abstractions/Lifecycle/LifecyclePhase.cs
+++ b/src/CShells.Abstractions/Lifecycle/LifecyclePhase.cs
@@ -5,8 +5,10 @@ namespace CShells.Lifecycle;
 /// </summary>
 /// <remarks>
 /// Initializer execution is ordered by phase first, then by numeric order within the phase.
-/// Existing unordered <see cref="IShellInitializer"/> registrations run in
-/// <see cref="Default"/> to preserve compatibility.
+/// <see cref="IShellTerminator"/> instances execute phases mirror-reversed
+/// (<see cref="Start"/> first, <see cref="Prepare"/> last, descending order within a phase).
+/// Existing unordered <see cref="IShellInitializer"/> and <see cref="IShellTerminator"/>
+/// registrations run in <see cref="Default"/> to preserve compatibility.
 /// </remarks>
 public enum LifecyclePhase
 {

--- a/src/CShells.Abstractions/Lifecycle/ServiceCollectionLifecycleExtensions.cs
+++ b/src/CShells.Abstractions/Lifecycle/ServiceCollectionLifecycleExtensions.cs
@@ -109,4 +109,113 @@ public static class ServiceCollectionLifecycleExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Registers a transient shell terminator in <see cref="LifecyclePhase.Default"/> with order <c>0</c>.
+    /// </summary>
+    /// <typeparam name="TTerminator">The terminator implementation type.</typeparam>
+    /// <param name="services">The shell service collection to register into.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// This is the first-class equivalent of registering a transient
+    /// <see cref="IShellTerminator"/> directly, with default-phase lifecycle metadata attached.
+    /// Because terminators execute phases mirror-reversed, the terminator runs in
+    /// <see cref="LifecyclePhase.Default"/> after any <see cref="LifecyclePhase.Start"/>
+    /// terminators and before any <see cref="LifecyclePhase.Prepare"/> terminators.
+    /// <code>
+    /// services.AddShellTerminator&lt;FlushCacheTerminator&gt;();
+    /// </code>
+    /// </remarks>
+    public static IServiceCollection AddShellTerminator<TTerminator>(this IServiceCollection services)
+        where TTerminator : class, IShellTerminator
+        => AddShellTerminatorCore<TTerminator>(
+            services,
+            LifecyclePhase.Default,
+            order: 0,
+            isExplicit: false,
+            source: $"AddShellTerminator<{typeof(TTerminator).FullName}> (default)");
+
+    /// <summary>
+    /// Registers a transient shell terminator in <see cref="LifecyclePhase.Default"/>.
+    /// </summary>
+    /// <typeparam name="TTerminator">The terminator implementation type.</typeparam>
+    /// <param name="services">The shell service collection to register into.</param>
+    /// <param name="order">The numeric order within <see cref="LifecyclePhase.Default"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// Use this overload when a terminator should stay in the compatibility phase but run
+    /// before or after other default-phase terminators. Higher orders run first during
+    /// termination (mirror of initializer ordering).
+    /// <code>
+    /// services.AddShellTerminator&lt;FlushCacheTerminator&gt;(order: 100);
+    /// </code>
+    /// </remarks>
+    public static IServiceCollection AddShellTerminator<TTerminator>(
+        this IServiceCollection services,
+        int order)
+        where TTerminator : class, IShellTerminator =>
+        services.AddShellTerminator<TTerminator>(LifecyclePhase.Default, order);
+
+    /// <summary>
+    /// Registers a transient shell terminator in the specified lifecycle phase.
+    /// </summary>
+    /// <typeparam name="TTerminator">The terminator implementation type.</typeparam>
+    /// <param name="services">The shell service collection to register into.</param>
+    /// <param name="phase">The semantic lifecycle phase.</param>
+    /// <param name="order">The numeric order within <paramref name="phase"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// Terminators registered through this API are resolved from the shell's
+    /// <see cref="IServiceProvider"/> during graceful drain — after the shell reaches
+    /// <see cref="ShellLifecycleState.Drained"/> and before its provider is disposed — so they
+    /// may depend on any shell service. Terminators execute mirror-reversed relative to
+    /// initializers: a terminator registered at the same phase and order as an initializer
+    /// tears down at the mirrored point (<see cref="LifecyclePhase.Start"/> first,
+    /// <see cref="LifecyclePhase.Prepare"/> last, descending order within a phase). Explicit
+    /// metadata from this registration overrides any <see cref="LifecycleOrderAttribute"/> on
+    /// <typeparamref name="TTerminator"/>. <typeparamref name="TTerminator"/> is registered as
+    /// transient and exposed as <see cref="IShellTerminator"/> without replacing any existing
+    /// descriptors.
+    /// <code>
+    /// services.AddShellInitializer&lt;StartSchedulerInitializer&gt;(LifecyclePhase.Start, order: 100);
+    /// services.AddShellTerminator&lt;StopSchedulerTerminator&gt;(LifecyclePhase.Start, order: 100);
+    /// </code>
+    /// As an alternative for legacy registrations, apply
+    /// <see cref="LifecycleOrderAttribute"/> to the terminator implementation type.
+    /// </remarks>
+    public static IServiceCollection AddShellTerminator<TTerminator>(
+        this IServiceCollection services,
+        LifecyclePhase phase,
+        int order)
+        where TTerminator : class, IShellTerminator
+        => AddShellTerminatorCore<TTerminator>(
+            services,
+            phase,
+            order,
+            isExplicit: true,
+            source: $"AddShellTerminator<{typeof(TTerminator).FullName}>");
+
+    private static IServiceCollection AddShellTerminatorCore<TTerminator>(
+        IServiceCollection services,
+        LifecyclePhase phase,
+        int order,
+        bool isExplicit,
+        string source)
+        where TTerminator : class, IShellTerminator
+    {
+        Guard.Against.Null(services);
+
+        var registrationIndex = services.Count(d => d.ServiceType == typeof(IShellTerminator));
+        services.AddTransient<TTerminator>();
+        services.AddTransient<IShellTerminator>(sp => sp.GetRequiredService<TTerminator>());
+        services.AddSingleton(new ShellTerminatorRegistration(
+            typeof(TTerminator),
+            phase,
+            order,
+            registrationIndex,
+            isExplicit,
+            source));
+
+        return services;
+    }
 }

--- a/src/CShells.Abstractions/Lifecycle/ShellTerminatorOrderException.cs
+++ b/src/CShells.Abstractions/Lifecycle/ShellTerminatorOrderException.cs
@@ -1,0 +1,23 @@
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Thrown when shell terminator ordering metadata cannot produce a valid termination plan.
+/// </summary>
+public sealed class ShellTerminatorOrderException : InvalidOperationException
+{
+    /// <summary>
+    /// Creates a new <see cref="ShellTerminatorOrderException"/> for the specified shell.
+    /// </summary>
+    /// <param name="shell">The shell descriptor being terminated.</param>
+    /// <param name="message">The ordering validation failure.</param>
+    public ShellTerminatorOrderException(ShellDescriptor shell, string message)
+        : base($"Invalid shell terminator ordering for shell '{shell.Name}' generation {shell.Generation}: {message}")
+    {
+        Shell = shell;
+    }
+
+    /// <summary>
+    /// Gets the shell descriptor whose terminator ordering failed validation.
+    /// </summary>
+    public ShellDescriptor Shell { get; }
+}

--- a/src/CShells.Abstractions/Lifecycle/ShellTerminatorRegistration.cs
+++ b/src/CShells.Abstractions/Lifecycle/ShellTerminatorRegistration.cs
@@ -1,0 +1,27 @@
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Ordering metadata for an <see cref="IShellTerminator"/> registration.
+/// </summary>
+/// <param name="TerminatorType">Concrete terminator implementation type.</param>
+/// <param name="Phase">Semantic lifecycle phase.</param>
+/// <param name="Order">Numeric order within <paramref name="Phase"/>.</param>
+/// <param name="RegistrationIndex">
+/// Zero-based ordinal of the associated <see cref="IShellTerminator"/> service descriptor, or
+/// <c>-1</c> when the metadata should be matched by terminator type.
+/// </param>
+/// <param name="IsExplicit">Whether this metadata came from an explicitly ordered lifecycle API.</param>
+/// <param name="Source">Human-readable metadata source for diagnostics.</param>
+/// <remarks>
+/// <see cref="ServiceCollectionLifecycleExtensions.AddShellTerminator{TTerminator}(Microsoft.Extensions.DependencyInjection.IServiceCollection, LifecyclePhase, int)"/>
+/// registers terminator implementations with transient lifetime. Existing unordered
+/// <see cref="IShellTerminator"/> registrations do not need this metadata and are treated as
+/// <see cref="LifecyclePhase.Default"/> entries.
+/// </remarks>
+public sealed record ShellTerminatorRegistration(
+    Type TerminatorType,
+    LifecyclePhase Phase,
+    int Order,
+    int RegistrationIndex,
+    bool IsExplicit,
+    string Source);

--- a/src/CShells.Abstractions/Lifecycle/ShellTerminatorResult.cs
+++ b/src/CShells.Abstractions/Lifecycle/ShellTerminatorResult.cs
@@ -1,0 +1,12 @@
+namespace CShells.Lifecycle;
+
+/// <summary>Outcome for a single <see cref="IShellTerminator"/> invocation.</summary>
+/// <param name="TerminatorTypeName">The concrete terminator type's <c>.Name</c>.</param>
+/// <param name="Completed">True if the terminator returned within its cancellation budget.</param>
+/// <param name="Elapsed">Wall-clock time consumed by this terminator.</param>
+/// <param name="Error">Non-null if the terminator threw.</param>
+public sealed record ShellTerminatorResult(
+    string TerminatorTypeName,
+    bool Completed,
+    TimeSpan Elapsed,
+    Exception? Error);

--- a/src/CShells.Management.Api/Endpoints/DtoMappers.cs
+++ b/src/CShells.Management.Api/Endpoints/DtoMappers.cs
@@ -64,6 +64,6 @@ internal static class DtoMappers
             Outcome: tr.Completed ? "Completed" : (tr.Error is not null ? "Faulted" : "Cancelled"),
             Elapsed: tr.Elapsed,
             ErrorMessage: tr.Error?.Message);
-    
+
     private static DrainSnapshot? MapDrain(IDrainOperation? drain) => drain is null ? null : new DrainSnapshot(drain.Status.ToString(), drain.Deadline);
 }

--- a/src/CShells.Management.Api/Endpoints/DtoMappers.cs
+++ b/src/CShells.Management.Api/Endpoints/DtoMappers.cs
@@ -48,7 +48,8 @@ internal static class DtoMappers
             Status: result.Status.ToString(),
             ScopeWaitElapsed: result.ScopeWaitElapsed,
             AbandonedScopeCount: result.AbandonedScopeCount,
-            HandlerResults: result.HandlerResults.Select(MapHandlerResult).ToArray());
+            HandlerResults: result.HandlerResults.Select(MapHandlerResult).ToArray(),
+            TerminatorResults: result.TerminatorResults.Select(MapTerminatorResult).ToArray());
 
     private static DrainHandlerResultResponse MapHandlerResult(DrainHandlerResult hr) =>
         new(
@@ -56,6 +57,13 @@ internal static class DtoMappers
             Outcome: hr.Completed ? "Completed" : (hr.Error is not null ? "Faulted" : "Cancelled"),
             Elapsed: hr.Elapsed,
             ErrorMessage: hr.Error?.Message);
+
+    private static ShellTerminatorResultResponse MapTerminatorResult(ShellTerminatorResult tr) =>
+        new(
+            TerminatorType: tr.TerminatorTypeName,
+            Outcome: tr.Completed ? "Completed" : (tr.Error is not null ? "Faulted" : "Cancelled"),
+            Elapsed: tr.Elapsed,
+            ErrorMessage: tr.Error?.Message);
     
     private static DrainSnapshot? MapDrain(IDrainOperation? drain) => drain is null ? null : new DrainSnapshot(drain.Status.ToString(), drain.Deadline);
 }

--- a/src/CShells.Management.Api/Models/DrainResultResponse.cs
+++ b/src/CShells.Management.Api/Models/DrainResultResponse.cs
@@ -10,11 +10,19 @@ internal sealed record DrainResultResponse(
     string Status,
     TimeSpan ScopeWaitElapsed,
     int AbandonedScopeCount,
-    IReadOnlyList<DrainHandlerResultResponse> HandlerResults);
+    IReadOnlyList<DrainHandlerResultResponse> HandlerResults,
+    IReadOnlyList<ShellTerminatorResultResponse> TerminatorResults);
 
 /// <summary>One drain-handler outcome inside a <see cref="DrainResultResponse"/>.</summary>
 internal sealed record DrainHandlerResultResponse(
     string HandlerType,
+    string Outcome,
+    TimeSpan Elapsed,
+    string? ErrorMessage);
+
+/// <summary>One shell-terminator outcome inside a <see cref="DrainResultResponse"/>.</summary>
+internal sealed record ShellTerminatorResultResponse(
+    string TerminatorType,
     string Outcome,
     TimeSpan Elapsed,
     string? ErrorMessage);

--- a/src/CShells/Lifecycle/DrainOperation.cs
+++ b/src/CShells/Lifecycle/DrainOperation.cs
@@ -21,6 +21,7 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
     private readonly TimeSpan _gracePeriod;
     private readonly ILogger<DrainOperation> _logger;
     private readonly TaskCompletionSource<DrainResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _completionGate = new();
     private readonly CancellationTokenSource _cancelSource = new();
     private DateTimeOffset? _deadline;
     private int _status = (int)DrainStatus.Pending;
@@ -50,15 +51,16 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
     /// <inheritdoc />
     public Task ForceAsync(CancellationToken cancellationToken = default)
     {
-        if (Interlocked.Exchange(ref _force, 1) != 0)
-            return Task.CompletedTask;
+        lock (_completionGate)
+        {
+            // Serialize the completion boundary with ForceAsync so a force accepted while a
+            // terminator is running is reflected in the final result. Once completion wins the
+            // lock, a later force remains a no-op.
+            if (_completion.Task.IsCompleted || _force != 0)
+                return Task.CompletedTask;
 
-        // Drain may have already completed — the CTS is disposed in that case and calling
-        // Cancel() would throw ObjectDisposedException. Checking the completion task (rather
-        // than status, which flips before terminators run) makes ForceAsync a clean no-op
-        // after completion while still able to interrupt a hung terminator.
-        if (_completion.Task.IsCompleted)
-            return Task.CompletedTask;
+            _force = 1;
+        }
 
         try
         {
@@ -95,7 +97,12 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
             try
             {
                 var result = await ExecuteAsync().ConfigureAwait(false);
-                _completion.TrySetResult(result);
+                lock (_completionGate)
+                {
+                    var finalStatus = ResolveStatus(result.HandlerResults);
+                    Volatile.Write(ref _status, (int)finalStatus);
+                    _completion.TrySetResult(result with { Status = finalStatus });
+                }
             }
             catch (Exception ex)
             {
@@ -139,12 +146,19 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
             // middleware pipeline removal) depends on this transition always firing.
             await _shell.ForceAdvanceAsync(ShellLifecycleState.Drained).ConfigureAwait(false);
 
-            // Phase 4: terminators run while the shell is Drained and the provider is still
-            // alive, before disposal. Best-effort during teardown — they self-protect against an
-            // already-disposed provider, so a faulted drain still disposes cleanly.
-            terminatorResults = await InvokeTerminatorsAsync().ConfigureAwait(false);
-
-            await _shell.DisposeAsync().ConfigureAwait(false);
+            try
+            {
+                // Phase 4: terminators run while the shell is Drained and the provider is still
+                // alive, before disposal. Best-effort during teardown — they self-protect against
+                // an already-disposed provider, so a faulted drain still disposes cleanly.
+                terminatorResults = await InvokeTerminatorsAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                // An unexpected terminator infrastructure failure must not strand the shell in
+                // Drained with its provider still alive.
+                await _shell.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         return new DrainResult(_shell.Descriptor, status, scopeWaitElapsed, abandonedScopes, handlerResults, terminatorResults);
@@ -277,6 +291,12 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
 
     private async Task<IReadOnlyList<ShellTerminatorResult>> InvokeTerminatorsAsync()
     {
+        if (_shell.State == ShellLifecycleState.Disposed)
+        {
+            _logger.LogWarning("Shell {Shell} was disposed before termination; skipping terminators.", _shell.Descriptor);
+            return [];
+        }
+
         // Resolve terminators inside a scope so transient registrations get a fresh instance.
         // Lifetime is deferred (see continuation below) for the same reason as handler scopes:
         // an abandoned terminator may still be running after the grace period.
@@ -301,11 +321,19 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
 
             if (terminators.Count == 0 && registrations.Count == 0)
             {
-                await scope.DisposeAsync().ConfigureAwait(false);
+                await DisposeTerminatorScopeAsync(scope).ConfigureAwait(false);
                 return [];
             }
 
             plan = new ShellTerminatorOrderingPlanner().Plan(_shell.Descriptor, terminators, registrations);
+        }
+        catch (ObjectDisposedException) when (_shell.State == ShellLifecycleState.Disposed)
+        {
+            // Emergency disposal can race after the scope is created but before its services
+            // are resolved. This is an expected skip, not an ordering-plan failure.
+            _logger.LogWarning("Shell {Shell} was disposed before termination; skipping terminators.", _shell.Descriptor);
+            await DisposeTerminatorScopeAsync(scope).ConfigureAwait(false);
+            return [];
         }
         catch (Exception ex)
         {
@@ -313,7 +341,7 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
             // terminators in arbitrary order would violate the guarantee they exist for.
             // Drain must never fail, so skip them and proceed to disposal.
             _logger.LogError(ex, "Shell terminator planning failed for shell {Shell}; skipping terminators.", _shell.Descriptor);
-            await scope.DisposeAsync().ConfigureAwait(false);
+            await DisposeTerminatorScopeAsync(scope).ConfigureAwait(false);
             return [];
         }
 
@@ -390,14 +418,7 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
         _ = loop.ContinueWith(
             async _ =>
             {
-                try
-                {
-                    await scope.DisposeAsync().ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Terminator scope disposal failed for shell {Shell}", _shell.Descriptor);
-                }
+                await DisposeTerminatorScopeAsync(scope).ConfigureAwait(false);
                 combined?.Dispose();
                 budgetCts.Dispose();
             },
@@ -420,6 +441,18 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
         }
 
         return results.ToList();
+    }
+
+    private async Task DisposeTerminatorScopeAsync(AsyncServiceScope scope)
+    {
+        try
+        {
+            await scope.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Terminator scope disposal failed for shell {Shell}", _shell.Descriptor);
+        }
     }
 
     private async Task WaitForCancellationThenGrace(CancellationToken token)

--- a/src/CShells/Lifecycle/DrainOperation.cs
+++ b/src/CShells/Lifecycle/DrainOperation.cs
@@ -7,10 +7,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace CShells.Lifecycle;
 
 /// <summary>
-/// Default <see cref="IDrainOperation"/>. Coordinates three drain phases:
+/// Default <see cref="IDrainOperation"/>. Coordinates four drain phases:
 /// (1) scope wait bounded by the deadline; (2) parallel handler invocation; (3) grace after
-/// deadline or force. Exposes itself as <see cref="IDrainExtensionHandle"/> to handlers,
-/// delegating extension requests to the configured <see cref="IDrainPolicy"/>.
+/// deadline or force; (4) sequential <see cref="IShellTerminator"/> invocation while the shell
+/// is <see cref="ShellLifecycleState.Drained"/> and its provider is still alive. Exposes itself
+/// as <see cref="IDrainExtensionHandle"/> to handlers, delegating extension requests to the
+/// configured <see cref="IDrainPolicy"/>.
 /// </summary>
 internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
 {
@@ -51,10 +53,11 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
         if (Interlocked.Exchange(ref _force, 1) != 0)
             return Task.CompletedTask;
 
-        // Drain may have already completed (status is not Pending) — the CTS is disposed in
-        // that case and calling Cancel() would throw ObjectDisposedException. Checking status
-        // first makes ForceAsync a clean no-op after completion.
-        if (Volatile.Read(ref _status) != (int)DrainStatus.Pending)
+        // Drain may have already completed — the CTS is disposed in that case and calling
+        // Cancel() would throw ObjectDisposedException. Checking the completion task (rather
+        // than status, which flips before terminators run) makes ForceAsync a clean no-op
+        // after completion while still able to interrupt a hung terminator.
+        if (_completion.Task.IsCompleted)
             return Task.CompletedTask;
 
         try
@@ -115,15 +118,20 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
         // Phase 2: handler invocation. Linked CTS: deadline or force.
         var handlerResults = await InvokeHandlersAsync().ConfigureAwait(false);
 
-        // Determine overall status.
+        // Determine overall status. Resolved before terminators run, so terminator outcomes
+        // structurally cannot affect the drain status.
         var status = ResolveStatus(handlerResults);
         Volatile.Write(ref _status, (int)status);
 
-        // Transition to Drained, then to Disposed (disposes provider).
         await _shell.ForceAdvanceAsync(ShellLifecycleState.Drained).ConfigureAwait(false);
+
+        // Phase 4: terminator invocation. The shell is Drained; its provider is still alive.
+        var terminatorResults = await InvokeTerminatorsAsync().ConfigureAwait(false);
+
+        // Transition to Disposed (disposes provider).
         await _shell.DisposeAsync().ConfigureAwait(false);
 
-        return new DrainResult(_shell.Descriptor, status, scopeWaitElapsed, abandonedScopes, handlerResults);
+        return new DrainResult(_shell.Descriptor, status, scopeWaitElapsed, abandonedScopes, handlerResults, terminatorResults);
     }
 
     private async Task<int> AwaitScopeReleaseAsync()
@@ -246,6 +254,153 @@ internal sealed class DrainOperation : IDrainOperation, IDrainExtensionHandle
         if (!allHandlers.IsCompleted)
         {
             await Task.WhenAny(allHandlers, WaitForCancellationThenGrace(token)).ConfigureAwait(false);
+        }
+
+        return results.ToList();
+    }
+
+    private async Task<IReadOnlyList<ShellTerminatorResult>> InvokeTerminatorsAsync()
+    {
+        // Resolve terminators inside a scope so transient registrations get a fresh instance.
+        // Lifetime is deferred (see continuation below) for the same reason as handler scopes:
+        // an abandoned terminator may still be running after the grace period.
+        AsyncServiceScope scope;
+        try
+        {
+            scope = _shell.ServiceProvider.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Emergency dispose (host shutdown-timeout breach) raced ahead of this drain;
+            // terminators are deliberately skipped on that path.
+            _logger.LogWarning("Shell {Shell} was disposed before termination; skipping terminators.", _shell.Descriptor);
+            return [];
+        }
+
+        ShellTerminatorOrderingPlanner.TerminatorOrderingPlan plan;
+        try
+        {
+            var terminators = scope.ServiceProvider.GetServices<IShellTerminator>().ToList();
+            var registrations = scope.ServiceProvider.GetServices<ShellTerminatorRegistration>().ToList();
+
+            if (terminators.Count == 0 && registrations.Count == 0)
+            {
+                await scope.DisposeAsync().ConfigureAwait(false);
+                return [];
+            }
+
+            plan = new ShellTerminatorOrderingPlanner().Plan(_shell.Descriptor, terminators, registrations);
+        }
+        catch (Exception ex)
+        {
+            // A broken ordering plan means execution order cannot be trusted; running
+            // terminators in arbitrary order would violate the guarantee they exist for.
+            // Drain must never fail, so skip them and proceed to disposal.
+            _logger.LogError(ex, "Shell terminator planning failed for shell {Shell}; skipping terminators.", _shell.Descriptor);
+            await scope.DisposeAsync().ConfigureAwait(false);
+            return [];
+        }
+
+        foreach (var diagnostic in plan.Diagnostics)
+        {
+            _logger.LogDebug(
+                "{Message} Shell: {Shell}. Terminators: {Terminators}",
+                diagnostic.Message,
+                _shell.Descriptor,
+                string.Join(", ", diagnostic.TerminatorTypes.Select(t => t.FullName ?? t.Name)));
+        }
+
+        // Terminators share one cancellation budget: the remaining drain deadline with a
+        // grace-period floor (scope-wait and handlers may have consumed the deadline). After a
+        // force, a fresh grace-only budget deliberately NOT linked to the already-cancelled
+        // force token — force-drain still gives flush work one bounded chance. Under an
+        // unbounded policy the budget never fires and ForceAsync remains the escape hatch.
+        var budgetCts = new CancellationTokenSource();
+        CancellationTokenSource? combined = null;
+        if (_cancelSource.IsCancellationRequested)
+        {
+            budgetCts.CancelAfter(_gracePeriod);
+        }
+        else
+        {
+            if (_deadline is { } deadline)
+            {
+                var remaining = deadline - DateTimeOffset.UtcNow;
+                budgetCts.CancelAfter(remaining > _gracePeriod ? remaining : _gracePeriod);
+            }
+
+            combined = CancellationTokenSource.CreateLinkedTokenSource(budgetCts.Token, _cancelSource.Token);
+        }
+
+        var token = combined?.Token ?? budgetCts.Token;
+
+        var entries = plan.Entries;
+        var results = new ShellTerminatorResult[entries.Count];
+        // Pre-seed with "not completed" defaults so abandoned terminators leave a valid entry.
+        for (var i = 0; i < entries.Count; i++)
+            results[i] = new ShellTerminatorResult(entries[i].TerminatorType.Name, Completed: false, Elapsed: TimeSpan.Zero, Error: null);
+
+        // Sequential invocation in mirror-reversed lifecycle order; log-and-continue per
+        // terminator so one failure never blocks the rest of the teardown.
+        var loop = Task.Run(async () =>
+        {
+            for (var i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                var sw = Stopwatch.StartNew();
+                try
+                {
+                    await entry.Terminator.TerminateAsync(token).ConfigureAwait(false);
+                    sw.Stop();
+                    results[i] = new ShellTerminatorResult(entry.TerminatorType.Name, Completed: true, sw.Elapsed, Error: null);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    sw.Stop();
+                    results[i] = results[i] with { Elapsed = sw.Elapsed };
+                }
+                catch (Exception ex)
+                {
+                    sw.Stop();
+                    _logger.LogWarning(ex, "Shell terminator {Terminator} threw for shell {Shell}", entry.TerminatorType.FullName, _shell.Descriptor);
+                    results[i] = new ShellTerminatorResult(entry.TerminatorType.Name, Completed: false, sw.Elapsed, Error: ex);
+                }
+            }
+        });
+
+        // Defer disposal of the scope and cancellation sources until the loop actually
+        // finishes, even if it is abandoned below — disposing them while a terminator is
+        // mid-flight would yield use-after-dispose for services resolved into the scope.
+        _ = loop.ContinueWith(
+            async _ =>
+            {
+                try
+                {
+                    await scope.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Terminator scope disposal failed for shell {Shell}", _shell.Descriptor);
+                }
+                combined?.Dispose();
+                budgetCts.Dispose();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        // Wait for the loop to complete, or cancellation + grace to elapse. A terminator still
+        // running after grace is abandoned; disposal proceeds (same accepted residual hazard
+        // as abandoned drain handlers).
+        if (!loop.IsCompleted)
+            await Task.WhenAny(loop, WaitForCancellationThenGrace(token)).ConfigureAwait(false);
+
+        if (!loop.IsCompleted)
+        {
+            _logger.LogWarning(
+                "Shell termination for {Shell} abandoned after cancellation and grace; {Remaining} terminator(s) did not complete.",
+                _shell.Descriptor,
+                results.Count(r => !r.Completed));
         }
 
         return results.ToList();

--- a/src/CShells/Lifecycle/LifecycleOrderingPlanner.cs
+++ b/src/CShells/Lifecycle/LifecycleOrderingPlanner.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Shared ordering core for shell lifecycle components. Matches resolved component instances
+/// to registration metadata (explicit registration first, then <see cref="LifecycleOrderAttribute"/>,
+/// then legacy defaults), validates the result, and sorts by the requested direction:
+/// <see cref="Direction.Startup"/> ascends phase/order/registration-index;
+/// <see cref="Direction.Teardown"/> is the exact mirror (descending on all three keys).
+/// </summary>
+internal static class LifecycleOrderingPlanner
+{
+    internal enum Direction
+    {
+        Startup,
+        Teardown,
+    }
+
+    internal sealed record ComponentMetadata(
+        Type ComponentType,
+        LifecyclePhase Phase,
+        int Order,
+        int RegistrationIndex,
+        bool IsExplicit,
+        string Source);
+
+    internal sealed record Entry<TComponent>(
+        TComponent Component,
+        Type ComponentType,
+        LifecyclePhase Phase,
+        int Order,
+        int RegistrationIndex,
+        bool IsExplicit,
+        string Source);
+
+    internal sealed record Diagnostic(
+        string Message,
+        IReadOnlyList<Type> ComponentTypes);
+
+    internal sealed record OrderingPlan<TComponent>(
+        IReadOnlyList<Entry<TComponent>> Entries,
+        IReadOnlyList<Diagnostic> Diagnostics);
+
+    public static OrderingPlan<TComponent> Plan<TComponent>(
+        ShellDescriptor shell,
+        IReadOnlyList<TComponent> components,
+        IReadOnlyList<ComponentMetadata> registrations,
+        Direction direction,
+        string componentNoun,
+        Func<ShellDescriptor, string, Exception> errorFactory)
+        where TComponent : class
+    {
+        Guard.Against.Null(components);
+        Guard.Against.Null(registrations);
+
+        foreach (var registration in registrations)
+        {
+            if (!typeof(TComponent).IsAssignableFrom(registration.ComponentType))
+            {
+                throw errorFactory(
+                    shell,
+                    $"ordering metadata source '{registration.Source}' references type '{registration.ComponentType.FullName}' which does not implement {typeof(TComponent).Name}.");
+            }
+
+            ValidatePhase(shell, registration.Phase, registration.Source, errorFactory);
+        }
+
+        var pendingRegistrations = registrations.ToList();
+
+        var entries = new List<Entry<TComponent>>(components.Count);
+
+        for (var i = 0; i < components.Count; i++)
+        {
+            var component = components[i];
+            var type = component.GetType();
+            var metadata = ResolveMetadata(shell, registrationIndex: i, type, pendingRegistrations, errorFactory);
+            entries.Add(new Entry<TComponent>(
+                component,
+                type,
+                metadata.Phase,
+                metadata.Order,
+                RegistrationIndex: i,
+                metadata.IsExplicit,
+                metadata.Source));
+        }
+
+        var unmatched = pendingRegistrations
+            .Select(r => r.ComponentType.FullName ?? r.ComponentType.Name)
+            .ToList();
+
+        if (unmatched.Count > 0)
+            throw errorFactory(
+                shell,
+                $"ordering metadata was registered for {componentNoun} type(s) that were not resolved from DI: {string.Join(", ", unmatched)}.");
+
+        var tieBreak = direction == Direction.Startup
+            ? "DI registration index will be used as the deterministic tie-break."
+            : "reverse DI registration index will be used as the deterministic tie-break.";
+
+        var duplicateGroups = entries
+            .GroupBy(e => (e.Phase, e.Order))
+            .Where(g => g.Count() > 1 && g.Any(e => e.IsExplicit))
+            .Select(g => new Diagnostic(
+                $"Multiple {componentNoun}s share phase '{g.Key.Phase}' and order {g.Key.Order}; {tieBreak}",
+                [.. g.Select(e => e.ComponentType)]))
+            .ToList();
+
+        var ordered = direction == Direction.Startup
+            ? entries.OrderBy(e => e.Phase).ThenBy(e => e.Order).ThenBy(e => e.RegistrationIndex).ToList()
+            : entries.OrderByDescending(e => e.Phase).ThenByDescending(e => e.Order).ThenByDescending(e => e.RegistrationIndex).ToList();
+
+        return new OrderingPlan<TComponent>(ordered, duplicateGroups);
+    }
+
+    private static ComponentMetadata ResolveMetadata(
+        ShellDescriptor shell,
+        int registrationIndex,
+        Type componentType,
+        List<ComponentMetadata> pendingRegistrations,
+        Func<ShellDescriptor, string, Exception> errorFactory)
+    {
+        var registration = TakeFirst(pendingRegistrations, r => r.RegistrationIndex == registrationIndex)
+            ?? TakeFirst(pendingRegistrations, r => r.ComponentType == componentType);
+
+        if (registration is not null)
+            return ResolveRegistrationMetadata(shell, registration, errorFactory);
+
+        var attribute = componentType.GetCustomAttribute<LifecycleOrderAttribute>();
+        if (attribute is not null)
+            return ResolveAttributeMetadata(shell, componentType, attribute, errorFactory);
+
+        return new ComponentMetadata(
+            componentType,
+            LifecyclePhase.Default,
+            Order: 0,
+            RegistrationIndex: -1,
+            IsExplicit: false,
+            Source: "Legacy DI registration");
+    }
+
+    private static ComponentMetadata ResolveRegistrationMetadata(
+        ShellDescriptor shell,
+        ComponentMetadata registration,
+        Func<ShellDescriptor, string, Exception> errorFactory)
+    {
+        if (!registration.IsExplicit)
+        {
+            var attribute = registration.ComponentType.GetCustomAttribute<LifecycleOrderAttribute>();
+            if (attribute is not null)
+                return ResolveAttributeMetadata(shell, registration.ComponentType, attribute, errorFactory);
+        }
+
+        ValidatePhase(shell, registration.Phase, registration.Source, errorFactory);
+        return registration;
+    }
+
+    private static ComponentMetadata ResolveAttributeMetadata(
+        ShellDescriptor shell,
+        Type componentType,
+        LifecycleOrderAttribute attribute,
+        Func<ShellDescriptor, string, Exception> errorFactory)
+    {
+        var source = $"{nameof(LifecycleOrderAttribute)} on {componentType.FullName}";
+        ValidatePhase(shell, attribute.Phase, source, errorFactory);
+        return new ComponentMetadata(
+            componentType,
+            attribute.Phase,
+            attribute.Order,
+            RegistrationIndex: -1,
+            IsExplicit: false,
+            Source: source);
+    }
+
+    private static ComponentMetadata? TakeFirst(
+        List<ComponentMetadata> registrations,
+        Func<ComponentMetadata, bool> predicate)
+    {
+        var index = registrations.FindIndex(r => predicate(r));
+        if (index < 0)
+            return null;
+
+        var registration = registrations[index];
+        registrations.RemoveAt(index);
+        return registration;
+    }
+
+    private static void ValidatePhase(
+        ShellDescriptor shell,
+        LifecyclePhase phase,
+        string source,
+        Func<ShellDescriptor, string, Exception> errorFactory)
+    {
+        if (!Enum.IsDefined(typeof(LifecyclePhase), phase))
+            throw errorFactory(shell, $"ordering metadata source '{source}' uses undefined lifecycle phase value '{(int)phase}'.");
+    }
+}

--- a/src/CShells/Lifecycle/ShellInitializerOrderingPlanner.cs
+++ b/src/CShells/Lifecycle/ShellInitializerOrderingPlanner.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace CShells.Lifecycle;
 
 internal sealed class ShellInitializerOrderingPlanner
@@ -12,137 +10,23 @@ internal sealed class ShellInitializerOrderingPlanner
         Guard.Against.Null(initializers);
         Guard.Against.Null(initializerRegistrations);
 
-        foreach (var registration in initializerRegistrations)
-        {
-            if (!typeof(IShellInitializer).IsAssignableFrom(registration.InitializerType))
-            {
-                throw new ShellInitializerOrderException(
-                    shell,
-                    $"ordering metadata source '{registration.Source}' references type '{registration.InitializerType.FullName}' which does not implement {nameof(IShellInitializer)}.");
-            }
-
-            ValidatePhase(shell, registration.Phase, registration.Source);
-        }
-
-        var pendingRegistrations = initializerRegistrations.ToList();
-
-        var entries = new List<InitializerOrderingEntry>(initializers.Count);
-
-        for (var i = 0; i < initializers.Count; i++)
-        {
-            var initializer = initializers[i];
-            var type = initializer.GetType();
-            var metadata = ResolveMetadata(shell, registrationIndex: i, type, pendingRegistrations);
-            entries.Add(new InitializerOrderingEntry(
-                initializer,
-                type,
-                metadata.Phase,
-                metadata.Order,
-                RegistrationIndex: i,
-                metadata.IsExplicit,
-                metadata.Source));
-        }
-
-        var unmatched = pendingRegistrations
-            .Select(r => r.InitializerType.FullName ?? r.InitializerType.Name)
+        var metadata = initializerRegistrations
+            .Select(r => new LifecycleOrderingPlanner.ComponentMetadata(
+                r.InitializerType, r.Phase, r.Order, r.RegistrationIndex, r.IsExplicit, r.Source))
             .ToList();
 
-        if (unmatched.Count > 0)
-            throw new ShellInitializerOrderException(
-                shell,
-                $"ordering metadata was registered for initializer type(s) that were not resolved from DI: {string.Join(", ", unmatched)}.");
+        var plan = LifecycleOrderingPlanner.Plan(
+            shell,
+            initializers,
+            metadata,
+            LifecycleOrderingPlanner.Direction.Startup,
+            componentNoun: "initializer",
+            errorFactory: static (s, m) => new ShellInitializerOrderException(s, m));
 
-        var duplicateGroups = entries
-            .GroupBy(e => (e.Phase, e.Order))
-            .Where(g => g.Count() > 1 && g.Any(e => e.IsExplicit))
-            .Select(g => new InitializerOrderingDiagnostic(
-                $"Multiple initializers share phase '{g.Key.Phase}' and order {g.Key.Order}; DI registration index will be used as the deterministic tie-break.",
-                [.. g.Select(e => e.InitializerType)]))
-            .ToList();
-
-        var ordered = entries
-            .OrderBy(e => e.Phase)
-            .ThenBy(e => e.Order)
-            .ThenBy(e => e.RegistrationIndex)
-            .ToList();
-
-        return new InitializerOrderingPlan(ordered, duplicateGroups);
-    }
-
-    private static ShellInitializerRegistration ResolveMetadata(
-        ShellDescriptor shell,
-        int registrationIndex,
-        Type initializerType,
-        List<ShellInitializerRegistration> pendingRegistrations)
-    {
-        var registration = TakeFirst(pendingRegistrations, r => r.RegistrationIndex == registrationIndex)
-            ?? TakeFirst(pendingRegistrations, r => r.InitializerType == initializerType);
-
-        if (registration is not null)
-            return ResolveRegistrationMetadata(shell, registration);
-
-        var attribute = initializerType.GetCustomAttribute<LifecycleOrderAttribute>();
-        if (attribute is not null)
-            return ResolveAttributeMetadata(shell, initializerType, attribute);
-
-        if (!typeof(IShellInitializer).IsAssignableFrom(initializerType))
-            throw new ShellInitializerOrderException(shell, $"type '{initializerType.FullName}' does not implement {nameof(IShellInitializer)}.");
-
-        return new ShellInitializerRegistration(
-            initializerType,
-            LifecyclePhase.Default,
-            Order: 0,
-            RegistrationIndex: -1,
-            IsExplicit: false,
-            Source: "Legacy DI registration");
-    }
-
-    private static ShellInitializerRegistration ResolveRegistrationMetadata(ShellDescriptor shell, ShellInitializerRegistration registration)
-    {
-        if (!registration.IsExplicit)
-        {
-            var attribute = registration.InitializerType.GetCustomAttribute<LifecycleOrderAttribute>();
-            if (attribute is not null)
-                return ResolveAttributeMetadata(shell, registration.InitializerType, attribute);
-        }
-
-        ValidatePhase(shell, registration.Phase, registration.Source);
-        return registration;
-    }
-
-    private static ShellInitializerRegistration ResolveAttributeMetadata(
-        ShellDescriptor shell,
-        Type initializerType,
-        LifecycleOrderAttribute attribute)
-    {
-        var source = $"{nameof(LifecycleOrderAttribute)} on {initializerType.FullName}";
-        ValidatePhase(shell, attribute.Phase, source);
-        return new ShellInitializerRegistration(
-            initializerType,
-            attribute.Phase,
-            attribute.Order,
-            RegistrationIndex: -1,
-            IsExplicit: false,
-            Source: source);
-    }
-
-    private static ShellInitializerRegistration? TakeFirst(
-        List<ShellInitializerRegistration> registrations,
-        Func<ShellInitializerRegistration, bool> predicate)
-    {
-        var index = registrations.FindIndex(r => predicate(r));
-        if (index < 0)
-            return null;
-
-        var registration = registrations[index];
-        registrations.RemoveAt(index);
-        return registration;
-    }
-
-    private static void ValidatePhase(ShellDescriptor shell, LifecyclePhase phase, string source)
-    {
-        if (!Enum.IsDefined(typeof(LifecyclePhase), phase))
-            throw new ShellInitializerOrderException(shell, $"ordering metadata source '{source}' uses undefined lifecycle phase value '{(int)phase}'.");
+        return new InitializerOrderingPlan(
+            [.. plan.Entries.Select(e => new InitializerOrderingEntry(
+                e.Component, e.ComponentType, e.Phase, e.Order, e.RegistrationIndex, e.IsExplicit, e.Source))],
+            [.. plan.Diagnostics.Select(d => new InitializerOrderingDiagnostic(d.Message, d.ComponentTypes))]);
     }
 
     internal sealed record InitializerOrderingPlan(

--- a/src/CShells/Lifecycle/ShellTerminatorOrderingPlanner.cs
+++ b/src/CShells/Lifecycle/ShellTerminatorOrderingPlanner.cs
@@ -1,0 +1,48 @@
+namespace CShells.Lifecycle;
+
+internal sealed class ShellTerminatorOrderingPlanner
+{
+    public TerminatorOrderingPlan Plan(
+        ShellDescriptor shell,
+        IReadOnlyList<IShellTerminator> terminators,
+        IReadOnlyList<ShellTerminatorRegistration> terminatorRegistrations)
+    {
+        Guard.Against.Null(terminators);
+        Guard.Against.Null(terminatorRegistrations);
+
+        var metadata = terminatorRegistrations
+            .Select(r => new LifecycleOrderingPlanner.ComponentMetadata(
+                r.TerminatorType, r.Phase, r.Order, r.RegistrationIndex, r.IsExplicit, r.Source))
+            .ToList();
+
+        var plan = LifecycleOrderingPlanner.Plan(
+            shell,
+            terminators,
+            metadata,
+            LifecycleOrderingPlanner.Direction.Teardown,
+            componentNoun: "terminator",
+            errorFactory: static (s, m) => new ShellTerminatorOrderException(s, m));
+
+        return new TerminatorOrderingPlan(
+            [.. plan.Entries.Select(e => new TerminatorOrderingEntry(
+                e.Component, e.ComponentType, e.Phase, e.Order, e.RegistrationIndex, e.IsExplicit, e.Source))],
+            [.. plan.Diagnostics.Select(d => new TerminatorOrderingDiagnostic(d.Message, d.ComponentTypes))]);
+    }
+
+    internal sealed record TerminatorOrderingPlan(
+        IReadOnlyList<TerminatorOrderingEntry> Entries,
+        IReadOnlyList<TerminatorOrderingDiagnostic> Diagnostics);
+
+    internal sealed record TerminatorOrderingEntry(
+        IShellTerminator Terminator,
+        Type TerminatorType,
+        LifecyclePhase Phase,
+        int Order,
+        int RegistrationIndex,
+        bool IsExplicit,
+        string Source);
+
+    internal sealed record TerminatorOrderingDiagnostic(
+        string Message,
+        IReadOnlyList<Type> TerminatorTypes);
+}

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
@@ -93,6 +93,23 @@ public class ShellRegistryTerminatorTests
         Assert.Equal(ShellLifecycleState.Disposed, shell.State);
     }
 
+    [Fact(DisplayName = "Terminator planning and scope-disposal failures do not fault the drain")]
+    public async Task TerminatorPlanningAndScopeDisposalFailures_DoNotFaultDrain()
+    {
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("broken-plan", s => s.WithFeature<BrokenPlanWithThrowingScopeFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("broken-plan");
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(DrainStatus.Completed, result.Status);
+        Assert.Empty(result.TerminatorResults);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
     [Fact(DisplayName = "Terminators run sequentially, never concurrently")]
     public async Task Terminators_RunSequentially()
     {
@@ -196,6 +213,30 @@ public class ShellRegistryTerminatorTests
         Assert.Equal(DrainStatus.Forced, result.Status);
         Assert.Equal(1, SequenceRecorder.TerminatorHits);
         Assert.True(result.TerminatorResults.Single().Completed);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
+    [Fact(DisplayName = "ForceAsync during termination cancels the terminator and reports Forced status")]
+    public async Task ForceDuringTermination_ReportsForcedStatus()
+    {
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells =>
+        {
+            cshells.WithAssemblyContaining<ShellRegistryTerminatorTests>();
+            cshells.AddShell("force-terminator", s => s.WithFeature<CancellableTerminatorFeature>());
+            cshells.ConfigureGracePeriod(TimeSpan.FromMilliseconds(50));
+        });
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("force-terminator");
+        var gate = shell.ServiceProvider.GetRequiredService<TerminatorGate>();
+
+        var op = await registry.DrainAsync(shell);
+        await gate.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await op.ForceAsync();
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(DrainStatus.Forced, result.Status);
+        Assert.False(Assert.Single(result.TerminatorResults).Completed);
         Assert.Equal(ShellLifecycleState.Disposed, shell.State);
     }
 
@@ -372,6 +413,41 @@ public class ShellRegistryTerminatorTests
         }
     }
 
+    public sealed class BrokenPlanWithThrowingScopeFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<ThrowingDisposeDependency>();
+            services.AddTransient<IShellTerminator, DependencyTerminator>();
+            services.AddSingleton(new ShellTerminatorRegistration(
+                typeof(UnresolvedTerminator),
+                LifecyclePhase.Default,
+                Order: 0,
+                RegistrationIndex: -1,
+                IsExplicit: true,
+                Source: "test"));
+        }
+    }
+
+    private sealed class DependencyTerminator(ThrowingDisposeDependency dependency) : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            _ = dependency;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class UnresolvedTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingDisposeDependency : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.FromException(new ApplicationException("scope disposal failed"));
+    }
+
     public sealed class ConcurrencyProbeFeature : IShellFeature
     {
         public void ConfigureServices(IServiceCollection services)
@@ -423,6 +499,29 @@ public class ShellRegistryTerminatorTests
     private sealed class StuckHandler : IDrainHandler
     {
         public Task DrainAsync(IDrainExtensionHandle _, CancellationToken ct) => Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    public sealed class CancellableTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<TerminatorGate>();
+            services.AddShellTerminator<CancellableTerminator>();
+        }
+    }
+
+    private sealed class TerminatorGate
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class CancellableTerminator(TerminatorGate gate) : IShellTerminator
+    {
+        public async Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            gate.Started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
     }
 
     public sealed class HungTerminatorFeature : IShellFeature

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CShells.DependencyInjection;
 using CShells.Features;
 using CShells.Hosting;
@@ -6,6 +7,7 @@ using CShells.Lifecycle.Policies;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace CShells.Tests.Integration.Lifecycle;
 
@@ -195,6 +197,34 @@ public class ShellRegistryTerminatorTests
         Assert.Equal(0, SequenceRecorder.TerminatorHits);
     }
 
+    [Fact(DisplayName = "Emergency disposal during terminator resolution is logged as a warning, not a planning error")]
+    public async Task EmergencyDisposeDuringTerminatorResolution_DoesNotLogPlanningError()
+    {
+        var logs = new CollectingLoggerProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(logging => logging.AddProvider(logs).SetMinimumLevel(LogLevel.Trace));
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShells(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("resolution-race", s => s.WithFeature<DisposeDuringTerminatorResolutionFeature>()));
+
+        await using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("resolution-race");
+        SequenceRecorder.ObservedShell = shell;
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(DrainStatus.Completed, result.Status);
+        Assert.Empty(result.TerminatorResults);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+        Assert.Contains(logs.Entries, entry =>
+            entry.Level == LogLevel.Warning && entry.Message.Contains("disposed before termination", StringComparison.Ordinal));
+        Assert.DoesNotContain(logs.Entries, entry =>
+            entry.Level >= LogLevel.Error && entry.Message.Contains("terminator planning failed", StringComparison.Ordinal));
+    }
+
     [Fact(DisplayName = "Forced drain still runs terminators within the grace budget")]
     public async Task ForcedDrain_StillInvokesTerminatorsWithGraceBudget()
     {
@@ -297,6 +327,37 @@ public class ShellRegistryTerminatorTests
         {
             lock (Sequence)
                 Sequence.Add(entry);
+        }
+    }
+
+    private sealed class CollectingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CollectingLogger(Entries);
+
+        public void Dispose() { }
+
+        private sealed class CollectingLogger(ConcurrentQueue<(LogLevel Level, string Message)> entries) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                entries.Enqueue((logLevel, formatter(state, exception)));
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+
+                public void Dispose() { }
+            }
         }
     }
 
@@ -499,6 +560,18 @@ public class ShellRegistryTerminatorTests
     private sealed class StuckHandler : IDrainHandler
     {
         public Task DrainAsync(IDrainExtensionHandle _, CancellationToken ct) => Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    public sealed class DisposeDuringTerminatorResolutionFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) =>
+            services.AddTransient<IShellTerminator>(_ => DisposeShellAndThrow());
+
+        private static IShellTerminator DisposeShellAndThrow()
+        {
+            ((Shell)SequenceRecorder.ObservedShell!).DisposeAsync().AsTask().GetAwaiter().GetResult();
+            throw new ObjectDisposedException(nameof(Shell.ServiceProvider));
+        }
     }
 
     public sealed class CancellableTerminatorFeature : IShellFeature

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryTerminatorTests.cs
@@ -1,0 +1,439 @@
+using CShells.DependencyInjection;
+using CShells.Features;
+using CShells.Hosting;
+using CShells.Lifecycle;
+using CShells.Lifecycle.Policies;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace CShells.Tests.Integration.Lifecycle;
+
+public class ShellRegistryTerminatorTests
+{
+    [Fact(DisplayName = "Terminators run after drain handlers while the shell is Drained")]
+    public async Task Terminators_RunAfterDrainHandlers_WhileDrained()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("ordered", s => s.WithFeature<HandlerThenTerminatorFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("ordered");
+        SequenceRecorder.ObservedShell = shell;
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(DrainStatus.Completed, result.Status);
+        Assert.Equal(["handler", "terminator"], SequenceRecorder.Sequence);
+        Assert.Equal(ShellLifecycleState.Drained, SequenceRecorder.StateDuringTermination);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
+    [Fact(DisplayName = "Terminators can resolve and use shell services (container-alive guarantee)")]
+    public async Task Terminators_CanUseShellContainer()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("alive", s => s.WithFeature<ContainerProbeFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("alive");
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(result.TerminatorResults.Single().Completed);
+        Assert.Equal("injected:resolved", SequenceRecorder.ProbeOutcome);
+    }
+
+    [Fact(DisplayName = "Terminators execute mirror-reversed across phases: Start, Default, Prepare")]
+    public async Task Terminators_MirroredPhaseOrdering_AcrossPhases()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("phased", s => s.WithFeature<PhasedTerminatorFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("phased");
+
+        var op = await registry.DrainAsync(shell);
+        await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(["start", "default", "prepare"], SequenceRecorder.Sequence);
+    }
+
+    [Fact(DisplayName = "A throwing terminator is recorded and does not prevent the rest from running")]
+    public async Task Terminator_Throwing_LogsAndContinues()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("mixed", s => s.WithFeature<ThrowingThenGoodTerminatorFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("mixed");
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The throwing terminator runs first (Start phase); the good one still runs after it.
+        Assert.Equal(["good"], SequenceRecorder.Sequence);
+        var bad = result.TerminatorResults.Single(r => r.TerminatorTypeName == nameof(ThrowingTerminator));
+        var good = result.TerminatorResults.Single(r => r.TerminatorTypeName == nameof(GoodTerminator));
+        Assert.False(bad.Completed);
+        Assert.IsType<ApplicationException>(bad.Error);
+        Assert.True(good.Completed);
+        Assert.Null(good.Error);
+        Assert.Equal(DrainStatus.Completed, result.Status);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
+    [Fact(DisplayName = "Terminators run sequentially, never concurrently")]
+    public async Task Terminators_RunSequentially()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("sequential", s => s.WithFeature<ConcurrencyProbeFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("sequential");
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(2, result.TerminatorResults.Count);
+        Assert.All(result.TerminatorResults, r => Assert.True(r.Completed));
+        Assert.False(SequenceRecorder.ConcurrencyViolation);
+    }
+
+    [Fact(DisplayName = "ReloadAsync runs terminators on the old generation only")]
+    public async Task Reload_RunsTerminatorsOnOldGeneration()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("reloadable", s => s.WithFeature<RecordingTerminatorFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        await registry.ActivateAsync("reloadable");
+
+        var reload = await registry.ReloadAsync("reloadable");
+        Assert.NotNull(reload.Drain);
+        await reload.Drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, SequenceRecorder.TerminatorHits);
+        Assert.Equal(ShellLifecycleState.Active, reload.NewShell!.State);
+    }
+
+    [Fact(DisplayName = "UnregisterBlueprintAsync runs terminators before completing")]
+    public async Task Unregister_RunsTerminatorsBeforeCompletion()
+    {
+        SequenceRecorder.Reset();
+
+        // Unregister requires a mutable blueprint source, so use the stub provider + manager.
+        var stub = new TestHelpers.StubShellBlueprintProvider()
+            .Add("removable", s => s.WithFeature<RecordingTerminatorFeature>(), new TestHelpers.StubShellBlueprintManager());
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddBlueprintProvider(_ => stub));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        await registry.ActivateAsync("removable");
+
+        await registry.UnregisterBlueprintAsync("removable");
+
+        Assert.Equal(1, SequenceRecorder.TerminatorHits);
+    }
+
+    [Fact(DisplayName = "Emergency dispose (host shutdown-timeout breach) skips terminators")]
+    public async Task EmergencyDispose_SkipsTerminators()
+    {
+        SequenceRecorder.Reset();
+
+        // Unbounded policy + a handler that never completes: the graceful drain can never
+        // reach the terminator phase on its own, so StopAsync's breached shutdown token is
+        // the only way the shell gets disposed.
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShells(cshells =>
+        {
+            cshells.WithAssemblyContaining<ShellRegistryTerminatorTests>();
+            cshells.AddShell("stuck", s => s.WithFeature<StuckHandlerWithTerminatorFeature>());
+            cshells.Services.Replace(ServiceDescriptor.Singleton<IDrainPolicy>(_ => new UnboundedDrainPolicy()));
+        });
+
+        await using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("stuck");
+
+        var hostedService = new CShellsStartupHostedService(registry);
+        await hostedService.StopAsync(new CancellationToken(canceled: true));
+
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+        Assert.Equal(0, SequenceRecorder.TerminatorHits);
+    }
+
+    [Fact(DisplayName = "Forced drain still runs terminators within the grace budget")]
+    public async Task ForcedDrain_StillInvokesTerminatorsWithGraceBudget()
+    {
+        SequenceRecorder.Reset();
+
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryTerminatorTests>()
+            .AddShell("forced", s => s.WithFeature<StuckHandlerWithTerminatorFeature>()));
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("forced");
+
+        var op = await registry.DrainAsync(shell);
+        await op.ForceAsync();
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(DrainStatus.Forced, result.Status);
+        Assert.Equal(1, SequenceRecorder.TerminatorHits);
+        Assert.True(result.TerminatorResults.Single().Completed);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
+    [Fact(DisplayName = "A hung terminator is abandoned after cancellation + grace; the shell is still disposed")]
+    public async Task HungTerminator_AbandonedAfterGrace_ShellStillDisposed()
+    {
+        SequenceRecorder.Reset();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShells(cshells =>
+        {
+            cshells.WithAssemblyContaining<ShellRegistryTerminatorTests>();
+            cshells.AddShell("hung", s => s.WithFeature<HungTerminatorFeature>());
+            cshells.Services.Replace(ServiceDescriptor.Singleton<IDrainPolicy>(_ => new FixedTimeoutDrainPolicy(TimeSpan.FromMilliseconds(150))));
+            cshells.Services.Replace(ServiceDescriptor.Singleton(new DrainGracePeriod(TimeSpan.FromMilliseconds(100))));
+        });
+
+        await using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IShellRegistry>();
+        var shell = await registry.ActivateAsync("hung");
+
+        var op = await registry.DrainAsync(shell);
+        var result = await op.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(result.TerminatorResults.Single().Completed);
+        Assert.Null(result.TerminatorResults.Single().Error);
+        Assert.Equal(ShellLifecycleState.Disposed, shell.State);
+    }
+
+    // =================================================================
+    // Test doubles
+    // =================================================================
+
+    private static class SequenceRecorder
+    {
+        public static readonly List<string> Sequence = [];
+        public static IShell? ObservedShell;
+        public static ShellLifecycleState? StateDuringTermination;
+        public static string? ProbeOutcome;
+        public static int TerminatorHits;
+        public static int CurrentlyRunning;
+        public static bool ConcurrencyViolation;
+
+        public static void Reset()
+        {
+            lock (Sequence)
+                Sequence.Clear();
+            ObservedShell = null;
+            StateDuringTermination = null;
+            ProbeOutcome = null;
+            TerminatorHits = 0;
+            CurrentlyRunning = 0;
+            ConcurrencyViolation = false;
+        }
+
+        public static void Record(string entry)
+        {
+            lock (Sequence)
+                Sequence.Add(entry);
+        }
+    }
+
+    public sealed class HandlerThenTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IDrainHandler, RecordingHandler>();
+            services.AddShellTerminator<StateObservingTerminator>();
+        }
+    }
+
+    private sealed class RecordingHandler : IDrainHandler
+    {
+        public Task DrainAsync(IDrainExtensionHandle _, CancellationToken ct)
+        {
+            SequenceRecorder.Record("handler");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StateObservingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            SequenceRecorder.StateDuringTermination = SequenceRecorder.ObservedShell?.State;
+            SequenceRecorder.Record("terminator");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ContainerProbeFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton(new ProbeService("injected"));
+            services.AddSingleton(new OtherProbeService("resolved"));
+            services.AddShellTerminator<ContainerProbeTerminator>();
+        }
+    }
+
+    private sealed record ProbeService(string Value);
+
+    private sealed record OtherProbeService(string Value);
+
+    private sealed class ContainerProbeTerminator(ProbeService injected, IServiceProvider provider) : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            var resolved = provider.GetRequiredService<OtherProbeService>();
+            SequenceRecorder.ProbeOutcome = $"{injected.Value}:{resolved.Value}";
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class PhasedTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddShellTerminator<PrepareRecordingTerminator>(LifecyclePhase.Prepare, 100);
+            services.AddShellTerminator<DefaultRecordingTerminator>(LifecyclePhase.Default, 0);
+            services.AddShellTerminator<StartRecordingTerminator>(LifecyclePhase.Start, 100);
+        }
+    }
+
+    private sealed class PrepareRecordingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            SequenceRecorder.Record("prepare");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DefaultRecordingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            SequenceRecorder.Record("default");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StartRecordingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            SequenceRecorder.Record("start");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ThrowingThenGoodTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Start phase tears down first, so the throwing terminator runs before the good one.
+            services.AddShellTerminator<ThrowingTerminator>(LifecyclePhase.Start, 0);
+            services.AddShellTerminator<GoodTerminator>(LifecyclePhase.Default, 0);
+        }
+    }
+
+    private sealed class ThrowingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => throw new ApplicationException("teardown boom");
+    }
+
+    private sealed class GoodTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            SequenceRecorder.Record("good");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class ConcurrencyProbeFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddShellTerminator<FirstSlowTerminator>();
+            services.AddShellTerminator<SecondSlowTerminator>();
+        }
+    }
+
+    private abstract class SlowTerminatorBase : IShellTerminator
+    {
+        public async Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref SequenceRecorder.CurrentlyRunning) > 1)
+                SequenceRecorder.ConcurrencyViolation = true;
+            await Task.Delay(50, cancellationToken);
+            Interlocked.Decrement(ref SequenceRecorder.CurrentlyRunning);
+        }
+    }
+
+    private sealed class FirstSlowTerminator : SlowTerminatorBase;
+
+    private sealed class SecondSlowTerminator : SlowTerminatorBase;
+
+    public sealed class RecordingTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) =>
+            services.AddShellTerminator<HitCountingTerminator>();
+    }
+
+    private sealed class HitCountingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref SequenceRecorder.TerminatorHits);
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class StuckHandlerWithTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IDrainHandler, StuckHandler>();
+            services.AddShellTerminator<HitCountingTerminator>();
+        }
+    }
+
+    private sealed class StuckHandler : IDrainHandler
+    {
+        public Task DrainAsync(IDrainExtensionHandle _, CancellationToken ct) => Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    public sealed class HungTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) =>
+            services.AddShellTerminator<TokenIgnoringTerminator>();
+    }
+
+    private sealed class TokenIgnoringTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) =>
+            Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None);
+    }
+}

--- a/tests/CShells.Tests/Integration/Management/ForceDrainEndpointTests.cs
+++ b/tests/CShells.Tests/Integration/Management/ForceDrainEndpointTests.cs
@@ -128,6 +128,27 @@ public class ForceDrainEndpointTests
         _ = oldGen; // pin to keep variable from being optimized; unused otherwise
     }
 
+    [Fact(DisplayName = "Force-drain response includes terminator results")]
+    public async Task ForceDrain_WithTerminator_ResponseIncludesTerminatorResults()
+    {
+        await using var fixture = new ManagementApiFixture(c => c
+            .WithAssemblyContaining<ForceDrainEndpointTests>()
+            .AddShell("acme", s => s.WithFeature<MgmtStuckDrainWithTerminatorFeature>()));
+        await fixture.Registry.GetOrActivateAsync("acme");
+
+        await fixture.PostAsync("/admin/reload/acme");
+
+        var response = await fixture.PostAsync("/admin/acme/force-drain");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<DrainResultResponse[]>(WebJson);
+        Assert.NotNull(body);
+        var terminatorResult = Assert.Single(Assert.Single(body).TerminatorResults);
+        Assert.Equal(nameof(MgmtRecordingTerminator), terminatorResult.TerminatorType);
+        Assert.Equal("Completed", terminatorResult.Outcome);
+        Assert.Null(terminatorResult.ErrorMessage);
+    }
+
     private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
 
     /// <summary>
@@ -174,5 +195,19 @@ public class ForceDrainEndpointTests
                 throw;
             }
         }
+    }
+
+    public sealed class MgmtStuckDrainWithTerminatorFeature : IShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IDrainHandler, MgmtStuckDrainHandler>();
+            services.AddShellTerminator<MgmtRecordingTerminator>();
+        }
+    }
+
+    private sealed class MgmtRecordingTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/tests/CShells.Tests/Unit/Lifecycle/DrainOperationTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/DrainOperationTests.cs
@@ -62,6 +62,21 @@ public class DrainOperationTests
         Assert.Equal(DrainStatus.Completed, op.Status);
     }
 
+    [Fact(DisplayName = "DrainResult's pre-terminator constructor remains compatible")]
+    public void DrainResult_PreTerminatorConstructor_HasEmptyTerminatorResults()
+    {
+        var result = new DrainResult(
+            ShellDescriptor.Create("legacy", 1),
+            DrainStatus.Completed,
+            TimeSpan.Zero,
+            0,
+            []);
+        var (_, _, _, _, handlerResults) = result;
+
+        Assert.Empty(result.TerminatorResults);
+        Assert.Same(result.HandlerResults, handlerResults);
+    }
+
     [Fact(DisplayName = "DrainResult carries the shell's descriptor and the per-handler elapsed timings")]
     public async Task DrainResult_Carries_PerHandler_Details()
     {

--- a/tests/CShells.Tests/Unit/Lifecycle/ShellTerminatorOrderingPlannerTests.cs
+++ b/tests/CShells.Tests/Unit/Lifecycle/ShellTerminatorOrderingPlannerTests.cs
@@ -1,0 +1,271 @@
+using CShells.Lifecycle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CShells.Tests.Unit.Lifecycle;
+
+public class ShellTerminatorOrderingPlannerTests
+{
+    private static readonly ShellDescriptor Shell = ShellDescriptor.Create("test", 1);
+    private readonly ShellTerminatorOrderingPlanner planner = new();
+
+    [Fact(DisplayName = "Planner orders terminators mirror-reversed: Start phase first, Prepare last, descending order within a phase")]
+    public void Plan_PhaseOrderAndNumericOrder_ReturnsMirrorReversedSequence()
+    {
+        var prepareLate = new PrepareLateTerminator();
+        var start = new StartTerminator();
+        var prepareEarly = new PrepareEarlyTerminator();
+        var defaultTerminator = new DefaultTerminator();
+
+        var plan = planner.Plan(
+            Shell,
+            [start, defaultTerminator, prepareLate, prepareEarly],
+            [
+                Registration<PrepareLateTerminator>(LifecyclePhase.Prepare, 20),
+                Registration<StartTerminator>(LifecyclePhase.Start, 0),
+                Registration<PrepareEarlyTerminator>(LifecyclePhase.Prepare, 10),
+                Registration<DefaultTerminator>(LifecyclePhase.Default, 0)
+            ]);
+
+        Assert.Equal(
+            [
+                typeof(StartTerminator),
+                typeof(DefaultTerminator),
+                typeof(PrepareLateTerminator),
+                typeof(PrepareEarlyTerminator)
+            ],
+            plan.Entries.Select(e => e.TerminatorType));
+    }
+
+    [Fact(DisplayName = "Planner maps unordered terminators to Default phase and reverses registration order")]
+    public void Plan_UnorderedTerminators_UseDefaultPhaseAndReverseRegistrationOrder()
+    {
+        var first = new FirstTerminator();
+        var second = new SecondTerminator();
+
+        var plan = planner.Plan(Shell, [first, second], []);
+
+        Assert.Equal([typeof(SecondTerminator), typeof(FirstTerminator)], plan.Entries.Select(e => e.TerminatorType));
+        Assert.All(plan.Entries, e => Assert.Equal(LifecyclePhase.Default, e.Phase));
+        Assert.Empty(plan.Diagnostics);
+    }
+
+    [Fact(DisplayName = "Planner applies attribute metadata for legacy registrations, teardown-ordered")]
+    public void Plan_AttributeMetadata_OrdersLegacyRegistrationsMirrorReversed()
+    {
+        var attributedStart = new AttributedStartTerminator();
+        var attributedPrepare = new AttributedPrepareTerminator();
+        var legacy = new FirstTerminator();
+
+        var plan = planner.Plan(Shell, [attributedPrepare, legacy, attributedStart], []);
+
+        // Start tears down first, Prepare last; the legacy terminator sits in Default between them.
+        Assert.Equal(
+            [typeof(AttributedStartTerminator), typeof(FirstTerminator), typeof(AttributedPrepareTerminator)],
+            plan.Entries.Select(e => e.TerminatorType));
+        Assert.False(plan.Entries[0].IsExplicit);
+    }
+
+    [Fact(DisplayName = "Planner gives explicit registration metadata precedence over attributes")]
+    public void Plan_ExplicitMetadata_OverridesAttributeMetadata()
+    {
+        var attributed = new AttributedPrepareTerminator();
+
+        var plan = planner.Plan(
+            Shell,
+            [attributed],
+            [Registration<AttributedPrepareTerminator>(LifecyclePhase.Start, 5)]);
+
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal(LifecyclePhase.Start, entry.Phase);
+        Assert.Equal(5, entry.Order);
+        Assert.True(entry.IsExplicit);
+    }
+
+    [Fact(DisplayName = "Equal phase/order ties run in reverse DI registration order and emit a diagnostic")]
+    public void Plan_EqualPhaseAndOrder_ReverseRegistrationIndexTieBreak()
+    {
+        var first = new FirstTerminator();
+        var second = new SecondTerminator();
+
+        var plan = planner.Plan(
+            Shell,
+            [first, second],
+            [
+                Registration<FirstTerminator>(LifecyclePhase.Prepare, 0, registrationIndex: 0),
+                Registration<SecondTerminator>(LifecyclePhase.Prepare, 0, registrationIndex: 1)
+            ]);
+
+        Assert.Equal([typeof(SecondTerminator), typeof(FirstTerminator)], plan.Entries.Select(e => e.TerminatorType));
+        var diagnostic = Assert.Single(plan.Diagnostics);
+        Assert.Contains("reverse DI registration index", diagnostic.Message);
+    }
+
+    [Fact(DisplayName = "Planner only emits equal-order diagnostics for explicitly ordered ties")]
+    public void Plan_EqualOrderDiagnostics_RequireExplicitOrdering()
+    {
+        var defaultPlan = planner.Plan(
+            Shell,
+            [new FirstTerminator(), new SecondTerminator()],
+            [
+                new ShellTerminatorRegistration(typeof(FirstTerminator), LifecyclePhase.Default, 0, -1, IsExplicit: false, Source: "default"),
+                new ShellTerminatorRegistration(typeof(SecondTerminator), LifecyclePhase.Default, 0, -1, IsExplicit: false, Source: "default")
+            ]);
+
+        Assert.Empty(defaultPlan.Diagnostics);
+    }
+
+    [Fact(DisplayName = "Planner fails when explicit metadata does not match resolved terminators")]
+    public void Plan_UnmatchedExplicitMetadata_Throws()
+    {
+        var ex = Assert.Throws<ShellTerminatorOrderException>(() =>
+            planner.Plan(
+                Shell,
+                [new FirstTerminator()],
+                [Registration<SecondTerminator>(LifecyclePhase.Prepare, 0)]));
+
+        Assert.Contains(nameof(SecondTerminator), ex.Message);
+        Assert.Contains(Shell.Name, ex.Message);
+    }
+
+    [Fact(DisplayName = "Planner fails when explicit metadata type is not a terminator")]
+    public void Plan_NonTerminatorExplicitMetadata_Throws()
+    {
+        var ex = Assert.Throws<ShellTerminatorOrderException>(() =>
+            planner.Plan(
+                Shell,
+                [new FirstTerminator()],
+                [
+                    new ShellTerminatorRegistration(
+                        typeof(string),
+                        LifecyclePhase.Prepare,
+                        Order: 0,
+                        RegistrationIndex: -1,
+                        IsExplicit: true,
+                        Source: "invalid metadata")
+                ]));
+
+        Assert.Contains("System.String", ex.Message);
+        Assert.Contains(nameof(IShellTerminator), ex.Message);
+        Assert.Contains(Shell.Name, ex.Message);
+    }
+
+    [Fact(DisplayName = "Planner fails for undefined explicit lifecycle phase")]
+    public void Plan_UndefinedExplicitLifecyclePhase_Throws()
+    {
+        var ex = Assert.Throws<ShellTerminatorOrderException>(() =>
+            planner.Plan(
+                Shell,
+                [new FirstTerminator()],
+                [Registration<FirstTerminator>((LifecyclePhase)(-1), 0, registrationIndex: 0)]));
+
+        Assert.Contains("-1", ex.Message);
+        Assert.Contains(nameof(FirstTerminator), ex.Message);
+    }
+
+    [Fact(DisplayName = "AddShellTerminator registers transient terminator and metadata")]
+    public void AddShellTerminator_RegistersTransientTerminatorAndMetadata()
+    {
+        var services = new ServiceCollection();
+
+        services.AddShellTerminator<FirstTerminator>(LifecyclePhase.Start, 42);
+
+        var terminatorDescriptor = Assert.Single(services, d => d.ServiceType == typeof(IShellTerminator));
+        var concreteDescriptor = Assert.Single(services, d => d.ServiceType == typeof(FirstTerminator));
+        Assert.Equal(ServiceLifetime.Transient, terminatorDescriptor.Lifetime);
+        Assert.Equal(ServiceLifetime.Transient, concreteDescriptor.Lifetime);
+
+        using var provider = services.BuildServiceProvider();
+        var terminator = Assert.Single(provider.GetServices<IShellTerminator>());
+        var registration = Assert.Single(provider.GetServices<ShellTerminatorRegistration>());
+
+        Assert.IsType<FirstTerminator>(terminator);
+        Assert.Equal(typeof(FirstTerminator), registration.TerminatorType);
+        Assert.Equal(LifecyclePhase.Start, registration.Phase);
+        Assert.Equal(42, registration.Order);
+        Assert.Equal(0, registration.RegistrationIndex);
+        Assert.True(registration.IsExplicit);
+    }
+
+    [Fact(DisplayName = "AddShellTerminator without order registers default metadata without explicit ordering")]
+    public void AddShellTerminator_NoArgs_RegistersDefaultMetadataWithoutExplicitOrdering()
+    {
+        var services = new ServiceCollection();
+
+        services.AddShellTerminator<FirstTerminator>();
+
+        using var provider = services.BuildServiceProvider();
+        var registration = Assert.Single(provider.GetServices<ShellTerminatorRegistration>());
+
+        Assert.Equal(typeof(FirstTerminator), registration.TerminatorType);
+        Assert.Equal(LifecyclePhase.Default, registration.Phase);
+        Assert.Equal(0, registration.Order);
+        Assert.Equal(0, registration.RegistrationIndex);
+        Assert.False(registration.IsExplicit);
+    }
+
+    [Fact(DisplayName = "AddShellTerminator without order does not override attribute metadata")]
+    public void AddShellTerminator_NoArgs_DoesNotOverrideAttributeMetadata()
+    {
+        var services = new ServiceCollection();
+        services.AddShellTerminator<AttributedPrepareTerminator>();
+
+        using var provider = services.BuildServiceProvider();
+        var terminators = provider.GetServices<IShellTerminator>().ToList();
+        var registrations = provider.GetServices<ShellTerminatorRegistration>().ToList();
+
+        var plan = planner.Plan(Shell, terminators, registrations);
+
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal(LifecyclePhase.Prepare, entry.Phase);
+        Assert.False(entry.IsExplicit);
+    }
+
+    private static ShellTerminatorRegistration Registration<TTerminator>(
+        LifecyclePhase phase,
+        int order,
+        int registrationIndex = -1)
+        where TTerminator : IShellTerminator =>
+        new(typeof(TTerminator), phase, order, registrationIndex, IsExplicit: true, Source: typeof(TTerminator).Name);
+
+    private sealed class FirstTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class SecondTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class DefaultTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class PrepareEarlyTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class PrepareLateTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class StartTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    [LifecycleOrder(LifecyclePhase.Prepare, 0)]
+    private sealed class AttributedPrepareTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    [LifecycleOrder(LifecyclePhase.Start, 0)]
+    private sealed class AttributedStartTerminator : IShellTerminator
+    {
+        public Task TerminateAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## What

Adds `IShellTerminator`, the teardown counterpart to `IShellInitializer`. Terminators run per-shell during graceful drain — after drain handlers complete and the shell reaches `Drained`, but **before** its `ServiceProvider` is disposed — so the shell container is fully usable during termination.

## Why

Today graceful teardown can only live in each singleton's own `Dispose`/`DisposeAsync`, and MS DI disposes singletons in reverse *realization* order. So cross-service ordered teardown — "stop task A, which gracefully drains singleton B", or "flush A before B" — is impossible: the target may already be hard-disposed by the time the stopper runs. Motivated by [elsa-workflows/elsa-foundation#606](https://github.com/elsa-workflows/elsa-foundation/issues/606); per the repo's "no workarounds" rule this belongs in CShells itself, not in consumers.

## How

- **Abstractions**: `IShellTerminator.TerminateAsync`, `ShellTerminatorRegistration`, `ShellTerminatorResult`, `ShellTerminatorOrderException`, and three `AddShellTerminator<T>` overloads mirroring the initializer trio.
- **Ordering**: reuses `LifecyclePhase` / `LifecycleOrderAttribute` but executes **mirror-reversed** (Start first, Prepare last, descending order within a phase, reverse registration-index tie-break), so an initializer/terminator pair registered at the same phase+order tears down at the mirrored point. Shared ordering logic is extracted into a direction-aware `LifecycleOrderingPlanner`; `ShellInitializerOrderingPlanner` keeps its exact surface as a thin adapter (existing planner tests are the regression gate).
- **Execution** (`DrainOperation`): a sequential, log-and-continue terminator phase between the `Drained` transition and provider disposal. A throwing terminator is logged and recorded; the rest still run. Terminators run on every graceful-drain path (shutdown, `ReloadAsync`, `UnregisterBlueprintAsync`, force-drain) and are deliberately **skipped** on the emergency-dispose path (host shutdown-timeout breach). Cancellation budget is the remaining drain deadline with a grace-period floor; a force gives one fresh grace-bounded chance.
- **Management API**: `DrainResult.TerminatorResults` reports per-terminator outcomes; the force-drain endpoint surfaces them as an additive `terminatorResults` JSON array (safe for existing clients).
- **Docs**: new "Terminator Ordering" section in `docs/shell-lifecycle.md` with the mirror table, container-alive guarantee, cancellation semantics, and emergency-path exclusion.

## Testing

`dotnet build` clean (0 warnings, all of net8/9/10). All 558 unit+integration tests and 28 E2E tests pass, including the pre-existing initializer-planner and drain suites that gate the planner refactor. New coverage: 11 planner unit tests + `ShellRegistryTerminatorTests` (runs-after-handlers-while-Drained, container usability, mirrored ordering, throw-and-continue, sequential execution, reload/unregister paths, emergency-dispose skip, forced-drain grace budget, hung-terminator abandonment) + a force-drain endpoint JSON test.

## Self-review follow-up

A five-pass self-review fixed the force-during-termination status race, preserved the pre-terminator `DrainResult` constructor/deconstruction API, classified emergency-disposal races correctly, and made terminator-scope cleanup log-and-continue even when planning and disposal both fail.

Verification after the fixes: `dotnet test --no-restore --verbosity minimal` passes all 592 unit/integration tests and all 31 E2E tests; PR-scoped `dotnet format --verify-no-changes` passes.